### PR TITLE
fix: cert-managerの定義からprometheusの設定を削除する

### DIFF
--- a/proxy-kubernetes/argocd/apps/root/crd-apps.yaml
+++ b/proxy-kubernetes/argocd/apps/root/crd-apps.yaml
@@ -43,17 +43,6 @@ spec:
       releaseName: cert-manager
       values: |
         installCRDs: true
-        prometheus:
-          enabled: true
-          servicemonitor:
-            enabled: true
-            prometheusInstance: default
-            targetPort: 9402
-            path: /metrics
-            interval: 60s
-            scrapeTimeout: 30s
-            labels: {}
-            honorLabels: false
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd


### PR DESCRIPTION
prometheus operatorが入っていないため monitoring.coreos.com/v1/ServiceMonitor が無いと起こられてしまう