### PR TITLE
Revert "fix: root projectのdestination namespaceの制約を緩める"

### DIFF
--- a/proxy-kubernetes/argocd/argocd-helm-chart-values.yaml
+++ b/proxy-kubernetes/argocd/argocd-helm-chart-values.yaml
@@ -25,7 +25,7 @@ server:
         path: proxy-kubernetes/argocd/apps/root
       destination:
         server: https://kubernetes.default.svc
-        namespace: '*'
+        namespace: argocd
       syncPolicy:
         automated:
           prune: true


### PR DESCRIPTION
Reverts GiganticMinecraft/seichi_infra#155

AppProject リソースの destination はデプロイ先の制約だが、Application リソースの destination.namespace は [namespace-scoped なリソースで namespace が指定されていないもののデプロイに使われるのみ](https://github.com/argoproj/argo-cd/blob/8be24f577f127edd23119424f5125dcc73354f02/docs/operator-manual/application.yaml#L109)なので、具体的な namespace を指定するのが正しい。