### PR TITLE
fix: seichi-gatewayのApplicationSetの名前がseichi-debug-gatewayのそれのものになっているのを修正する

### DIFF
--- a/proxy-kubernetes/argocd/apps/seichi-gateway/cloudflared-mcserver-appset/application-set.yaml
+++ b/proxy-kubernetes/argocd/apps/seichi-gateway/cloudflared-mcserver-appset/application-set.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   # 各ApplicationSet は argocd namespace に配置されるため prefix する
-  name: seichi-debug-gateway--cloudflared-mcserver-appset
+  name: seichi-gateway--cloudflared-mcserver-appset
   namespace: argocd
 spec:
   generators:


### PR DESCRIPTION
This closes #168