### PR TITLE
Modify Argo CD resource request and autoscale

### DIFF
--- a/proxy-kubernetes/argocd-helm-chart-values.yaml
+++ b/proxy-kubernetes/argocd-helm-chart-values.yaml
@@ -112,11 +112,11 @@ controller:
 dex:
   resources:
    limits:
+     cpu: 100m
+     memory: 128Mi
+   requests:
      cpu: 50m
      memory: 64Mi
-   requests:
-     cpu: 10m
-     memory: 32Mi
   pdb:
     enabled: true
     minAvailable: 1

--- a/proxy-kubernetes/argocd-helm-chart-values.yaml
+++ b/proxy-kubernetes/argocd-helm-chart-values.yaml
@@ -7,16 +7,16 @@ server:
     minReplicas: 2
     maxReplicas: 5
     # -- Average CPU utilization percentage for the Argo CD server [HPA]
-    targetCPUUtilizationPercentage: 50
+    targetCPUUtilizationPercentage: 70
     # -- Average memory utilization percentage for the Argo CD server [HPA]
-    targetMemoryUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 70
   resources:
    limits:
+     cpu: 200m
+     memory: 256Mi
+   requests:
      cpu: 100m
      memory: 128Mi
-   requests:
-     cpu: 50m
-     memory: 64Mi
   pdb:
     enabled: true
     minAvailable: 1
@@ -126,7 +126,7 @@ redis:
   resources:
    limits:
      cpu: 200m
-     memory: 128Mi
+     memory: 256Mi
    requests:
      cpu: 100m
      memory: 64Mi
@@ -141,16 +141,16 @@ repoServer:
     minReplicas: 2
     maxReplicas: 5
     # -- Average CPU utilization percentage for the repo server [HPA]
-    targetCPUUtilizationPercentage: 50
+    targetCPUUtilizationPercentage: 70
     # -- Average memory utilization percentage for the repo server [HPA]
-    targetMemoryUtilizationPercentage: 50
+    targetMemoryUtilizationPercentage: 70
   resources:
+   limits:
+     cpu: 100m
+     memory: 256Mi
    limits:
      cpu: 50m
      memory: 128Mi
-   requests:
-     cpu: 10m
-     memory: 64Mi
   pdb:
     enabled: true
     minAvailable: 1


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20236173/160395874-7660180c-fccc-426a-81bc-f0054a7585ea.png)

はやくもArgoCD Repo serverとserverのオートスケールが発火しているので、リソース許容値とオートスケールハッカのタイミングを変える