### PR TITLE
disable connection_throttle param on seichi-debug-gateway

### DIFF
--- a/proxy-kubernetes/apps/seichi-debug-gateway/bungeecord/bungeecord-config-patch.yaml
+++ b/proxy-kubernetes/apps/seichi-debug-gateway/bungeecord/bungeecord-config-patch.yaml
@@ -71,8 +71,8 @@ data:
     # The timeout value must be set shorter than the upper network
     timeout: 20000
     server_connect_timeout: 5000
-    connection_throttle: 2000
-    connection_throttle_limit: 16
+    connection_throttle: -1
+    connection_throttle_limit: -1
     network_compression_threshold: 256
     log_pings: false
 


### PR DESCRIPTION
#262 の原因切り分けとして。
体感、プレイヤー数が多ければ多いほど新規接続がしにくくなる傾向があるので、怪しいパラメータを無効化してみるの巻。
本来`connection_throttle`のパラメータは同一IPからの接続リクエスト数を制限するものだが、上流にTCPShieldがいるのでワンチャン副作用を起こしている可能性がある。
問題なければ本番もやる。