### PR TITLE
refactor: kubernetes/helmのresourceのproviderを明示的に指定する

### DIFF
--- a/terraform/lke_cluster_argocd.tf
+++ b/terraform/lke_cluster_argocd.tf
@@ -1,4 +1,6 @@
 resource "helm_release" "lke_cluster_argocd" {
+  provider = helm.lke_cluster
+
   depends_on = [kubernetes_namespace.argocd]
 
   # https://github.com/argoproj/argo-helm/releases/tag/argo-cd-4.2.2

--- a/terraform/lke_cluster_namespaces.tf
+++ b/terraform/lke_cluster_namespaces.tf
@@ -1,22 +1,30 @@
 resource "kubernetes_namespace" "seichi_debug_gateway" {
+  provider = kubernetes.lke_cluster
+
   metadata {
     name = "seichi-debug-gateway"
   }
 }
 
 resource "kubernetes_namespace" "seichi_gateway" {
+  provider = kubernetes.lke_cluster
+
   metadata {
     name = "seichi-gateway"
   }
 }
 
 resource "kubernetes_namespace" "argocd" {
+  provider = kubernetes.lke_cluster
+
   metadata {
     name = "argocd"
   }
 }
 
 resource "kubernetes_namespace" "cluster_wide_apps" {
+  provider = kubernetes.lke_cluster
+
   metadata {
     name = "cluster-wide-apps"
   }

--- a/terraform/lke_cluster_secrets.tf
+++ b/terraform/lke_cluster_secrets.tf
@@ -1,4 +1,6 @@
 resource "kubernetes_secret" "cloudflared_tunnel_credential" {
+  provider = kubernetes.lke_cluster
+
   depends_on = [kubernetes_namespace.cluster_wide_apps]
 
   metadata {
@@ -14,6 +16,8 @@ resource "kubernetes_secret" "cloudflared_tunnel_credential" {
 }
 
 resource "kubernetes_secret" "logdna_agent_ingestion_key" {
+  provider = kubernetes.lke_cluster
+
   depends_on = [kubernetes_namespace.cluster_wide_apps]
 
   # name と data の指定は LOGDNA_INGESTION_KEY の参照指定による
@@ -32,6 +36,8 @@ resource "kubernetes_secret" "logdna_agent_ingestion_key" {
 }
 
 resource "kubernetes_secret" "argocd_github_oauth_app_secret" {
+  provider = kubernetes.lke_cluster
+
   depends_on = [kubernetes_namespace.argocd]
 
   metadata {
@@ -52,6 +58,8 @@ resource "kubernetes_secret" "argocd_github_oauth_app_secret" {
 }
 
 resource "kubernetes_secret" "debug_cloudflared_access_service_token" {
+  provider = kubernetes.lke_cluster
+
   depends_on = [kubernetes_namespace.seichi_debug_gateway]
 
   metadata {
@@ -68,6 +76,8 @@ resource "kubernetes_secret" "debug_cloudflared_access_service_token" {
 }
 
 resource "kubernetes_secret" "prod_cloudflared_access_service_token" {
+  provider = kubernetes.lke_cluster
+
   depends_on = [kubernetes_namespace.seichi_gateway]
 
   metadata {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -117,12 +117,16 @@ locals {
 }
 
 provider "kubernetes" {
+  alias = "lke_cluster"
+
   host                   = local.lke_kubenetes_cluster_host
   token                  = local.lke_kubenetes_cluster_token
   cluster_ca_certificate = local.lke_kubenetes_cluster_ca_certificate
 }
 
 provider "helm" {
+  alias = "lke_cluster"
+
   kubernetes {
     host                   = local.lke_kubenetes_cluster_host
     token                  = local.lke_kubenetes_cluster_token


### PR DESCRIPTION
オンプレk8sクラスタに徐々に設定を移行したいため。