### PR TITLE
remove tcpshield plugin

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-gateway/bungeecord/bungeecord-plugin-configs-patch.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-gateway/bungeecord/bungeecord-plugin-configs-patch.yaml
@@ -42,9 +42,3 @@ data:
         - 'seichi.click network for debug 3TBUkfU6'
       dynamic:
         - 'seichi.click network for debug 3TBUkfU6'
-
-  TCPShield-config.yml: |
-    only-allow-proxy-connections: true
-    timestamp-validation: 'htpdate'
-    debug-mode: false
-    enable-geyser-support: false

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-gateway/bungeecord/bungeecord-plugin-configs-patch.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-gateway/bungeecord/bungeecord-plugin-configs-patch.yaml
@@ -56,9 +56,3 @@ data:
         - '&b&lseichi.click network &6&l| &7&lver &a&l1.12.2 , 1.14.4%newline&f整地にする？整地にする？それとも…セ・イ・チ？'
         - '&b&lseichi.click network &6&l| &7&lver &a&l1.12.2 , 1.14.4%newline&f用法用量を守って正しく整地しましょう'
         - '&b&lseichi.click network &6&l| &7&lver &a&l1.12.2 , 1.14.4%newline&fYou have a pickaxe. You have a time. Oh! Seichi Love.'
-
-  TCPShield-config.yml: |
-    only-allow-proxy-connections: true
-    timestamp-validation: 'htpdate'
-    debug-mode: false
-    enable-geyser-support: false

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/kustomize-bases/minecraft-gateway-bungeecord/configs/plugin-configs.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/kustomize-bases/minecraft-gateway-bungeecord/configs/plugin-configs.yaml
@@ -92,16 +92,3 @@ data:
     motds:
       generic: []
       dynamic: []
-
-  TCPShield-config.yml: |
-    # Please keep this as true in while using TCPShield!
-    only-allow-proxy-connections: true
-
-    # available modes: system (uses the system time), htpdate (uses a synchronized date) & off (deactivates timestamp validation)
-    timestamp-validation: 'htpdate'
-
-    # Turn on to diagnose connection issues
-    debug-mode: false
-
-    # Toggle to enable support for Geyser/Floodgate v2
-    enable-geyser-support: false

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/kustomize-bases/minecraft-gateway-bungeecord/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/kustomize-bases/minecraft-gateway-bungeecord/deployment.yaml
@@ -65,14 +65,11 @@ spec:
               #   https://github.com/GiganticMinecraft/BungeeSemaphore/releases/download/release-at-bcd5886827c813c75eb31d6f6fa926e0e8e0fd4f/BungeeSemaphore.jar
               # RedisBungee:
               #   https://github.com/ProxioDev/RedisBungee/releases/download/0.6.5/RedisBungee-0.6.5.jar
-              # TCPShield (RealIP):
-              #   https://github.com/TCPShield/RealIP/releases/download/2.5.6/TCPShield-2.5.6.jar
               value: >-
                 https://github.com/GiganticMinecraft/BungeeKick/releases/download/release-at-bdbef2f162815b6805aaf7379c213136a077cf04/bungeekick-1.3.jar,
                 https://github.com/GiganticMinecraft/BungeeHubCommand/releases/download/release-at-4c5449d8aecf6bf5a6b810fb85a1bfa75c0fd03f/bungeehubcommand-1.jar,
                 https://github.com/GiganticMinecraft/BungeeSemaphore/releases/download/release-at-bcd5886827c813c75eb31d6f6fa926e0e8e0fd4f/BungeeSemaphore.jar,
-                https://github.com/ProxioDev/RedisBungee/releases/download/0.6.5/RedisBungee-0.6.5.jar,
-                https://github.com/TCPShield/RealIP/releases/download/2.5.6/TCPShield-2.5.6.jar
+                https://github.com/ProxioDev/RedisBungee/releases/download/0.6.5/RedisBungee-0.6.5.jar
 
             # BungeeYAML (depended by SwiftMOTD):
             #   https://www.spigotmc.org/resources/bungeeyaml-original.13068/
@@ -131,9 +128,6 @@ spec:
             - name: bungeecord-plugin-configs
               mountPath: /config/plugins/SwiftMOTD/config.yml
               subPath: SwiftMOTD-config.yml
-            - name: bungeecord-plugin-configs
-              mountPath: /config/plugins/TCPShield/config.yml
-              subPath: TCPShield-config.yml
 
             # JMX exporter 周りのファイルが入ったボリューム達のマウント設定
             - name: jmx-exporter-download-volume


### PR DESCRIPTION
> I've just rolled out an update to our proxies. With Proxy Protocol, before now we were also sending the hostname payload the RealIP plugin required to function, this means that player hostnames where server.com///<bunch of data> which caused forced hosts to not function correctly, therefore this has been fixed while using proxy protocol. However, this means if you for some reason still have the RealIP plugin installed, you will be getting a "Disconnected" error message. The fix is simply to remove the plugin, providing you have proxy protocol enabled.
Edit: RealIP is also known as TCPShield.jar

2022/03/30 TCPShield Official Discordより引用
https://discord.com/channels/820701684203257857/820705337958465546/958508761222352926