### PR TITLE
refactor: synology-csi-storageclass で namespace.yml を管理しないようにする

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/synology-csi-storageclass/kustomization.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/synology-csi-storageclass/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://raw.githubusercontent.com/SynologyOpenSource/synology-csi/v1.1.0/deploy/kubernetes/v1.20/namespace.yml
   - https://raw.githubusercontent.com/SynologyOpenSource/synology-csi/v1.1.0/deploy/kubernetes/v1.20/controller.yml
   - https://raw.githubusercontent.com/SynologyOpenSource/synology-csi/v1.1.0/deploy/kubernetes/v1.20/csi-driver.yml
   - https://raw.githubusercontent.com/SynologyOpenSource/synology-csi/v1.1.0/deploy/kubernetes/v1.20/node.yml


### PR DESCRIPTION
Terraform が作成しているため。