### PR TITLE
Add KEDA for scale to zero requirement based on schedule

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/keda.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/keda.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: keda
+  namespace: argocd
+spec:
+  project: cluster-wide-apps
+  source:
+    chart: keda
+    repoURL: https://kedacore.github.io/charts
+    targetRevision: 2.7.2
+    helm:
+      releaseName: keda
+      values: |
+        prometheus:
+          metricServer:
+            enabled: true
+            podMonitor:
+              enabled: true
+              additionalLabels:
+                release: prometheus
+          operator:
+            enabled: true
+            port: 8080
+            path: /metrics
+            podMonitor:
+              enabled: true
+              additionalLabels:
+                release: prometheus
+            prometheusRules:
+              enabled: true
+              additionalLabels:
+                release: prometheus
+              alerts:
+                - alert: KedaScalerErrors
+                  annotations:
+                    description: Keda scaledObject {{ $labels.scaledObject }} is experiencing errors with {{ $labels.scaler }} scaler
+                    summary: Keda Scaler {{ $labels.scaler }} Errors
+                  expr: sum by ( scaledObject , scaler) (rate(keda_metrics_adapter_scaler_errors[2m]))  > 0
+                  for: 2m
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: keda
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+    - CreateNamespace=true

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/projects.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/projects.yaml
@@ -16,6 +16,7 @@ spec:
     - namespace: "argocd"
       server: https://kubernetes.default.svc
     # ./cluster-wide-app-resources でインストールされる
+    #  - keda(event driven autoscaler, 時間によってPodを0にスケールダウンさせるために使用)
     #  - metrics-server
     #  - metallb
     #  - monitoring
@@ -24,6 +25,8 @@ spec:
     #
     # のリソースインストールを行うため、namespaceを明示的に許可する必要がある
     - namespace: "kube-system"
+      server: https://kubernetes.default.svc
+    - namespace: "keda"
       server: https://kubernetes.default.svc
     - namespace: "metallb-system"
       server: https://kubernetes.default.svc


### PR DESCRIPTION
KEDAを入れるとこんな感じでcronベースのscale to zeroができるようになるのでよさそうという話. related to https://github.com/GiganticMinecraft/seichi_infra/issues/417

ref. https://keda.sh/docs/2.7/concepts/scaling-deployments/
https://keda.sh/docs/2.7/scalers/cron/

```yaml
apiVersion: keda.sh/v1alpha1
kind: ScaledObject
metadata:
  name: mc-server
  namespace: mc-server
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: StatefulSets
    name: mc-server # Mandatory. Must be in the same namespace as the ScaledObject
  minReplicaCount:  0
  maxReplicaCount:  1
  triggers:
- type: cron
  metadata:
    timezone: Asia/Tokyo
    start: 30 * * * *       # Every hour on the 30th minute
    end: 45 * * * *         # Every hour on the 45th minute
    desiredReplicas: "0"
```