### PR TITLE
Remove pdb from single components of ArgoCD

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/argocd-helm-chart-values.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/argocd-helm-chart-values.yaml
@@ -111,10 +111,6 @@ controller:
     requests:
       cpu: 250m
       memory: 768Mi
-  pdb:
-    enabled: true
-    minAvailable: 1
-    maxUnavailable: 0
   metrics:
     enabled: true
     serviceMonitor:
@@ -130,10 +126,6 @@ dex:
     requests:
       cpu: 50m
       memory: 64Mi
-  pdb:
-    enabled: true
-    minAvailable: 1
-    maxUnavailable: 0
   metrics:
     enabled: true
     serviceMonitor:


### PR DESCRIPTION
現状`app controller`と`dex`は単一のPodで動いており、pdbを不用意に仕掛けるとかえって副作用があるため削除する。具体的にはkubectl drainでノードをシャットダウンする場合などにこれらのPodを退役できずエラーになったりする。

一方で、pdbを使うにはPodを少なくとも2台以上で構成するべきであるが、dexはインメモリストアに認証情報を持たせるためあまり水平スケールのメリットがなく、app controllerについても複数台構成の場合シャードが必要なので、シングル構成のほうが考慮事項が少なくて楽である。加えて瞬間的な停止によるユーザーインパクトはまず無いことから、わざわざ台数を増やしてまでpdbを増やす意味がなさそうという結論に至った。

ref. https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/#scaling-up