### PR TITLE
fix name

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
@@ -95,7 +95,7 @@ spec:
                   type: loki
                   url: http://loki:3100
           dashboards:
-            General:
+            default:
               cilium-agent:
                 gnetId: 16611
                 revision: 1


### PR DESCRIPTION
大文字入れるなって怒られたのでデフォルト指定にする



one or more synchronization tasks completed unsuccessfully, reason: ConfigMap "prometheus-grafana-dashboards-General" is invalid: metadata.name: Invalid value: "prometheus-grafana-dashboards-General": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'),Deployment.apps "prometheus-grafana" is invalid: spec.template.spec.volumes[1].name: Invalid value: "dashboards-General": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name', or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?') (retried 5 times).