### PR TITLE
fix: grafanaのdefaultではないdatasourceを明示する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
@@ -89,6 +89,7 @@ spec:
                 - name: Loki
                   type: loki
                   url: http://loki:3100
+                  isDefault: false
           dashboards:
             default:
               cilium-agent:


### PR DESCRIPTION
いつぞやからgrafanaが以下のエラーで起動しなくなってたので修正
`Datasource provisioning error: datasource.yaml config is invalid. Only one datasource per organization can be marked as default`