### PR TITLE
feat: add newrelic agents

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/newrelic.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/newrelic.yaml
@@ -1,0 +1,52 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: newrelic
+  namespace: newrelic
+spec:
+  project: cluster-wide-apps
+  source:
+    chart: nri-bundle
+    repoURL: https://helm-charts.newrelic.com
+    targetRevision: 5.0.4
+    helm:
+      values: |
+        newrelic-infrastructure:
+          privileged: true
+        global:
+          lowDataMode: true
+          customSecretName: "newrelic-credentials"
+          customSecretLicenseKey: "LicenseKey"
+          cluster: seichi-onp-k8s
+        kube-state-metrics:
+          enabled: true
+          image:
+            tag: "v2.7.0"
+        kubeEvents
+          enabled: true
+        newrelic-prometheus-agent:
+          enabled: true
+          lowDataMode: true
+          config:
+            kubernetes:
+              integrations_filter:
+                enabled: false
+        newrelic-pixie:
+          enabled: true
+          # https://github.com/newrelic/helm-charts/blob/newrelic-pixie-2.0.2/charts/newrelic-pixie/values.yaml
+          customSecretApiKeyName: "newrelic-credentials"
+          customSecretApiKeyKey: "PixieApiKey"
+        pixie-chart:
+          enabled: true
+          # https://github.com/pixie-io/pixie/blob/release/operator/v0.0.35/k8s/operator/helm/values.yaml
+          # The deploy key may be read from a custom secret in the Pixie namespace.
+          # This secret should be formatted where the key of the deploy key is "deploy-key".
+          customDeployKeySecret: "newrelic-credentials"
+          clusterName: seichi-onp-k8s
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: newrelic
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/newrelic.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/newrelic.yaml
@@ -10,6 +10,7 @@ spec:
     repoURL: https://helm-charts.newrelic.com
     targetRevision: 5.0.4
     helm:
+      # https://github.com/newrelic/helm-charts/blob/nri-bundle-5.0.4/charts/nri-bundle/values.yaml
       values: |
         newrelic-infrastructure:
           privileged: true
@@ -31,14 +32,16 @@ spec:
             kubernetes:
               integrations_filter:
                 enabled: false
+        # nri-bundle の subchart である newrelic-pixie の設定
+        # https://github.com/newrelic/helm-charts/blob/newrelic-pixie-2.0.2/charts/newrelic-pixie/values.yaml
         newrelic-pixie:
           enabled: true
-          # https://github.com/newrelic/helm-charts/blob/newrelic-pixie-2.0.2/charts/newrelic-pixie/values.yaml
           customSecretApiKeyName: "newrelic-credentials"
           customSecretApiKeyKey: "PixieApiKey"
+        # nri-bundle の subchart である pixie-operator-chart の設定
+        # https://github.com/pixie-io/pixie/blob/release/operator/v0.0.35/k8s/operator/helm/values.yaml
         pixie-chart:
           enabled: true
-          # https://github.com/pixie-io/pixie/blob/release/operator/v0.0.35/k8s/operator/helm/values.yaml
           # The deploy key may be read from a custom secret in the Pixie namespace.
           # This secret should be formatted where the key of the deploy key is "deploy-key".
           customDeployKeySecret: "newrelic-credentials"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/projects.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/projects.yaml
@@ -22,6 +22,7 @@ spec:
     #  - minio
     #  - monitoring
     #  - synology-csi
+    #  - newrelic
     #
     # のリソースインストールを行うため、namespaceを明示的に許可する必要がある
     - namespace: "kube-system"
@@ -39,6 +40,8 @@ spec:
     - namespace: "moco-system"
       server: https://kubernetes.default.svc
     - namespace: "cert-manager"
+      server: https://kubernetes.default.svc
+    - namespace: "newrelic"
       server: https://kubernetes.default.svc
   clusterResourceWhitelist:
     - group: "*"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -200,6 +200,28 @@ variable "minio_root_password" {
 
 #endregion
 
+#region credentials for newrelic agents
+
+variable "newrelic_licencekey" {
+  description = "newrelic licencekey"
+  type        = string
+  sensitive   = true
+}
+
+variable "newrelic_pixie_api_key" {
+  description = "newrelic pixie api key"
+  type        = string
+  sensitive   = true
+}
+
+variable "newrelic_pixie_chart_deploy_key" {
+  description = "newrelic pixie chart deploy key"
+  type        = string
+  sensitive   = true
+}
+
+#endregion
+
 #region on-premise minecraft config secrets
 
 variable "minecraft__discordsrv_bot_token" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -202,8 +202,8 @@ variable "minio_root_password" {
 
 #region credentials for newrelic agents
 
-variable "newrelic_licencekey" {
-  description = "newrelic licencekey"
+variable "newrelic_licensekey" {
+  description = "newrelic licensekey"
   type        = string
   sensitive   = true
 }

--- a/terraform/onp_cluster_namespaces.tf
+++ b/terraform/onp_cluster_namespaces.tf
@@ -51,3 +51,9 @@ resource "kubernetes_namespace" "minio" {
     name = "minio"
   }
 }
+
+resource "kubernetes_namespace" "newrelic" {
+  metadata {
+    name = "newrelic"
+  }
+}

--- a/terraform/onp_cluster_secrets.tf
+++ b/terraform/onp_cluster_secrets.tf
@@ -92,7 +92,7 @@ resource "kubernetes_secret" "newrelic_credentials" {
   }
 
   data = {
-    "LicenseKey"          = var.newrelic_licencekey
+    "LicenseKey"          = var.newrelic_licensekey
     "PixieApiKey"         = var.newrelic_pixie_api_key
     "deploy-key"          = var.newrelic_pixie_chart_deploy_key
   }

--- a/terraform/onp_cluster_secrets.tf
+++ b/terraform/onp_cluster_secrets.tf
@@ -92,9 +92,9 @@ resource "kubernetes_secret" "newrelic_credentials" {
   }
 
   data = {
-    "LicenseKey"          = var.newrelic_licensekey
-    "PixieApiKey"         = var.newrelic_pixie_api_key
-    "deploy-key"          = var.newrelic_pixie_chart_deploy_key
+    "LicenseKey"  = var.newrelic_licensekey
+    "PixieApiKey" = var.newrelic_pixie_api_key
+    "deploy-key"  = var.newrelic_pixie_chart_deploy_key
   }
 
   type = "Opaque"

--- a/terraform/onp_cluster_secrets.tf
+++ b/terraform/onp_cluster_secrets.tf
@@ -82,3 +82,20 @@ resource "kubernetes_secret" "minio_root_user" {
 
   type = "Opaque"
 }
+
+resource "kubernetes_secret" "newrelic_credentials" {
+  depends_on = [kubernetes_namespace.newrelic]
+
+  metadata {
+    name      = "newrelic-credentials"
+    namespace = "newrelic"
+  }
+
+  data = {
+    "LicenseKey"          = var.newrelic_licencekey
+    "PixieApiKey"         = var.newrelic_pixie_api_key
+    "deploy-key"          = var.newrelic_pixie_chart_deploy_key
+  }
+
+  type = "Opaque"
+}

--- a/terraform/onp_cluster_secrets.tf
+++ b/terraform/onp_cluster_secrets.tf
@@ -91,12 +91,12 @@ resource "kubernetes_secret" "newrelic_credentials" {
     namespace = "newrelic"
   }
 
+  # "deploy-key"は本来であれば他のkeyと命名規則を統一するべきだが
+  # 20230314現在、helm-chart(pixie-operator-chart:0.0.35)でハードコードされているため命名を変更できない。
+  # https://github.com/pixie-io/pixie/blob/release/operator/v0.0.35/k8s/operator/helm/values.yaml#L31-L33
   data = {
     "LicenseKey"  = var.newrelic_licensekey
     "PixieApiKey" = var.newrelic_pixie_api_key
-    # 以下の"deploy-key"は本来であれば他のkeyと命名規則を統一するべきだが
-    # 20230314現在、helm-chart(pixie-operator-chart:0.0.35)でハードコードされているため命名を変更できない。
-    # https://github.com/pixie-io/pixie/blob/release/operator/v0.0.35/k8s/operator/helm/values.yaml#L31-L33
     "deploy-key"  = var.newrelic_pixie_chart_deploy_key
   }
 

--- a/terraform/onp_cluster_secrets.tf
+++ b/terraform/onp_cluster_secrets.tf
@@ -94,6 +94,9 @@ resource "kubernetes_secret" "newrelic_credentials" {
   data = {
     "LicenseKey"  = var.newrelic_licensekey
     "PixieApiKey" = var.newrelic_pixie_api_key
+    # 以下の"deploy-key"は本来であれば他のkeyと命名規則を統一するべきだが
+    # 20230314現在、helm-chart(pixie-operator-chart:0.0.35)でハードコードされているため命名を変更できない。
+    # https://github.com/pixie-io/pixie/blob/release/operator/v0.0.35/k8s/operator/helm/values.yaml#L31-L33
     "deploy-key"  = var.newrelic_pixie_chart_deploy_key
   }
 


### PR DESCRIPTION
よくわからんのでとりあえずk8s integrationのinstall wizardをデフォルト値で進めたら出てきたhelm installコマンドをベースに錬成。

追加オプションは以下がデフォルト選択

- [x] Scrape Prometheus endpoints
  - [ ] Scrape all Prometheus endpoints
  - [x] Scrape all endpoints except Kubernetes infrastructure endpoints already collected by the Kubernetes integration (recommended)
  - [ ] Scrape only endpoints with curated experiences
- [ ] Gather Log data
- [x] Instant service-level insights, full-body requests, and application profiles through Pixie
Pixie uses eBPF to automatically detect any HTTP-based services in this cluster and gather data. For even deeper insights, you can add language agents to individual services.
- [ ] Pixie is already running in this cluster

install wizardで出たベースとなったコマンドはこんな感じ

```bash
function ver { printf "%03d%03d" $(echo "$1" | tr '.' ' '); } && \
K8S_VERSION=$(kubectl version --short 2>&1 | grep 'Server Version' | awk -F' v' '{ print $2; }' | awk -F. '{ print $1"."$2; }') && \
if [[ $(ver $K8S_VERSION) -lt $(ver "1.25") ]]; then KSM_IMAGE_VERSION="v2.6.0"; else KSM_IMAGE_VERSION="v2.7.0"; fi && \
helm repo add newrelic https://helm-charts.newrelic.com && helm repo update && \
kubectl create namespace newrelic ; helm upgrade --install newrelic-bundle newrelic/nri-bundle \
 --set global.licenseKey=***sensored*** \
 --set global.cluster=seichi-onp-k8s \
 --namespace=newrelic \
 --set newrelic-infrastructure.privileged=true \
 --set global.lowDataMode=true \
 --set kube-state-metrics.image.tag=${KSM_IMAGE_VERSION} \
 --set kube-state-metrics.enabled=true \
 --set kubeEvents.enabled=true \
 --set newrelic-prometheus-agent.enabled=true \
 --set newrelic-prometheus-agent.lowDataMode=true \
 --set newrelic-prometheus-agent.config.kubernetes.integrations_filter.enabled=false \
 --set newrelic-pixie.enabled=true \
 --set newrelic-pixie.apiKey=***sensored*** \
 --set pixie-chart.enabled=true \
 --set pixie-chart.deployKey=***sensored*** \
 --set pixie-chart.clusterName=seichi-onp-k8s  
```