### PR TITLE
fix: Cloudflareによって自動的にPagesにデプロイするのを止める

### DIFF
--- a/terraform/cloudflare_page_projects.tf
+++ b/terraform/cloudflare_page_projects.tf
@@ -4,32 +4,6 @@ resource "cloudflare_pages_project" "seichi_portal" {
   account_id        = local.cloudflare_account_id
   name              = "seichi-portal"
   production_branch = "main"
-  build_config {
-    build_command   = "yarn build"
-    destination_dir = "out"
-    root_dir        = "/"
-  }
-  deployment_configs {
-    preview {
-      # No config
-    }
-    production {
-      environment_variables = {
-        NODE_ENV                        = "production"
-        NEXT_PUBLIC_BACKEND_API_URL     = var.cloudflare_pages__seichi_portal__next_public_backend_api_url
-        NEXT_PUBLIC_MS_APP_CLIENT_ID    = var.cloudflare_pages__seichi_portal__next_public_ms_app_client_id
-        NEXT_PUBLIC_MS_APP_REDIRECT_URL = "https://portal.${local.root_domain}"
-      }
-    }
-  }
-  source {
-    type = "github"
-    config {
-      owner             = local.github_org_name
-      repo_name         = "seichi-portal-frontend"
-      production_branch = "main"
-    }
-  }
 }
 
 resource "cloudflare_pages_domain" "seichi_portal_domain" {


### PR DESCRIPTION
https://discord.com/channels/237758724121427969/959300385883967498/1087151721345724466
https://discord.com/channels/237758724121427969/959300385883967498/1087288362458685450
上記のDiscordリンクのように、Cloudflare側でビルドをしてデプロイをする形だと、Cloudflareを直接開くことができる人でないとログを確認することができない。いちいち、ビルドが失敗するたびにログをスクショしてもらうのは大変。
よって、Cloudflare側でビルドをするのではなく、GitHub Actions側でビルドをして、Cloudflare側にその生成物をアップロードする形にすることで、これを回避することができる。