### PR TITLE
feat: add raritan(PDU)-web-panel

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cloudflared-tunnel-exits/http-exits.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cloudflared-tunnel-exits/http-exits.yaml
@@ -26,6 +26,11 @@ spec:
             external-hostname: grafana.onp.admin.seichi.click
             internal-authority: "192.168.3.20:3000"
 
+          # raritan(PDU)
+          - name: raritan
+            external-hostname: raritan.onp.admin.seichi.click
+            internal-authority: "192.168.19.200:80"
+
           # プライベートなminecraft pluginをアップロードするためのMinIO。
           # 肝心のオブジェクトストレージは seichi-private-plugin-blackhole-minio.minio:9000 にClusterIPでアクセスすればよい。
           - name: minio-console

--- a/terraform/cloudflare_network_admin_services.tf
+++ b/terraform/cloudflare_network_admin_services.tf
@@ -66,6 +66,32 @@ resource "cloudflare_access_policy" "onp_admin_proxmox" {
   }
 }
 
+resource "cloudflare_access_application" "onp_admin_raritan" {
+  zone_id          = local.cloudflare_zone_id
+  name             = "raritan(PDU) administration"
+  domain           = "raritan.onp.admin.${local.root_domain}"
+  type             = "self_hosted"
+  session_duration = "24h"
+
+  http_only_cookie_attribute = true
+}
+
+resource "cloudflare_access_policy" "onp_admin_raritan" {
+  application_id = cloudflare_access_application.onp_admin_raritan.id
+  zone_id        = local.cloudflare_zone_id
+  name           = "Require to be in a GitHub team to access"
+  precedence     = "1"
+  decision       = "allow"
+
+  include {
+    github {
+      name                 = local.github_org_name
+      teams                = [github_team.onp_admin_raritan.slug]
+      identity_provider_id = cloudflare_access_identity_provider.github_oauth.id
+    }
+  }
+}
+
 resource "cloudflare_access_application" "onp_admin_minio" {
   zone_id          = local.cloudflare_zone_id
   name             = "minio-console administration"

--- a/terraform/github_teams.tf
+++ b/terraform/github_teams.tf
@@ -35,6 +35,12 @@ resource "github_team" "onp_admin_proxmox" {
   privacy     = "closed"
 }
 
+resource "github_team" "onp_admin_raritan" {
+  name        = "onp-admin-raritan"
+  description = "オンプレミス環境のraritan(PDU)に接続できるTeam"
+  privacy     = "closed"
+}
+
 resource "github_team" "onp_admin_minio" {
   name        = "onp-admin-minio"
   description = "オンプレミス環境のminioに接続できるTeam"


### PR DESCRIPTION
PDUの管理パネルをCloudflare-ZeroTrust経由で公開する(許可メンバーはリモートでproxmoxホストの電源制御が可能になる)

関連:
https://github.com/GiganticMinecraft/teams/pull/19