### PR TITLE
CommandReferenceのカスタムドメインへのDNSを設定

### DIFF
--- a/terraform/cloudflare_dns_records.tf
+++ b/terraform/cloudflare_dns_records.tf
@@ -24,6 +24,14 @@ resource "cloudflare_record" "github_pages" {
   ttl     = 1 # automatic
 }
 
+resource "cloudflare_record" "github_pages" {
+  zone_id = local.cloudflare_zone_id
+  name    = "cmd"
+  value = "giganticminecraft.github.io"
+  type = "CNAME"
+  ttl = 1 # automatic
+}
+
 resource "cloudflare_record" "portal" {
   zone_id = local.cloudflare_zone_id
   name    = "portal"

--- a/terraform/cloudflare_dns_records.tf
+++ b/terraform/cloudflare_dns_records.tf
@@ -27,9 +27,9 @@ resource "cloudflare_record" "github_pages" {
 resource "cloudflare_record" "github_pages" {
   zone_id = local.cloudflare_zone_id
   name    = "cmd"
-  value = "giganticminecraft.github.io"
-  type = "CNAME"
-  ttl = 1 # automatic
+  value   = "giganticminecraft.github.io"
+  type    = "CNAME"
+  ttl     = 1 # automatic
 }
 
 resource "cloudflare_record" "portal" {

--- a/terraform/cloudflare_dns_records.tf
+++ b/terraform/cloudflare_dns_records.tf
@@ -24,7 +24,7 @@ resource "cloudflare_record" "github_pages" {
   ttl     = 1 # automatic
 }
 
-resource "cloudflare_record" "github_pages" {
+resource "cloudflare_record" "github_pages_command_reference" {
   zone_id = local.cloudflare_zone_id
   name    = "cmd"
   value   = "giganticminecraft.github.io"


### PR DESCRIPTION
https://github.com/GiganticMinecraft/CommandReference/issues/5 にて、 CommandReference に対し `cmd.seichi.click` というカスタムドメインを割り当てました。

https://docs.github.com/ja/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site