### PR TITLE
gachadata-serverを追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cloudflared-tunnel-exits/http-exits.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cloudflared-tunnel-exits/http-exits.yaml
@@ -85,6 +85,11 @@ spec:
             external-hostname: portal.public-gigantic-api.seichi.click
             internal-authority: "seichi-portal-backend.seichi-minecraft:80"
 
+          # gachadata.sqlを公開するためのエンドポイント。
+          - name: gachadata-server
+            external-hostname: gachadata.public-gigantic-api.seichi.click
+            internal-authority: "gachadata-server.seichi-minecraft:80"
+
           # phpMyAdmin
           - name: phpmyadmin
             external-hostname: phpmyadmin.onp-k8s.admin.seichi.click

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/gachadata-server/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/gachadata-server/deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gachadata-server
+  namespace: seichi-minecraft
+  labels:
+    app: gachadata-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gachadata-server
+  template:
+    metadata:
+      labels:
+        app: gachadata-server
+    spec:  
+      containers:
+        - name: gachadata-server
+          image: ghcr.io/giganticminecraft/gachadata-server:sha-beab594
+          resources:
+            requests:
+              cpu: 250m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          env:
+            - name: MYSQL_USER
+              value: mc-server
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mcserver--common--config-secrets
+                  key: GAME_DB_PASSWORD
+            - name: MYSQL_HOST
+              value: "192.168.2.186"
+            - name: MYSQL_PORT
+              value: "3306"
+            - name: HTTP_PORT
+              value: "80"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/gachadata-server/service.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/gachadata-server/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: seichi-minecraft
+  name: gachadata-server
+spec:
+  type: ClusterIP
+  ports:
+    - name: gachadata-server-web
+      port: 80
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: gachadata-server


### PR DESCRIPTION
[gachadata-server](https://github.com/GiganticMinecraft/gachadata-server) を追加しました。

gachadata-serverは[SeichiAssistのissue#2178](https://github.com/GiganticMinecraft/SeichiAssist/issues/2178) を解決するために作られたサーバーで、`seichiassist`データベースから、`gachadata.sql`のダンプファイルをダウンロードすることができます