### PR TITLE
fix: mysql_userをmcserverにする

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/gachadata-server/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/gachadata-server/deployment.yaml
@@ -27,7 +27,7 @@ spec:
               memory: 256Mi
           env:
             - name: MYSQL_USER
-              value: mc-server
+              value: mcserver
             - name: MYSQL_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
MySQLユーザーが`mc-server`だと思っていたら`mcserver`っぽいので直しました。
(そもそもあってますか...?)

下の2つを参考にしました
https://github.com/GiganticMinecraft/seichi_infra/blob/8d1d53d69989cf71a70a6ac2570ba06f53cc20a3/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-game-data-server/deployment.yaml

https://github.com/GiganticMinecraft/seichi_infra/blob/8d1d53d69989cf71a70a6ac2570ba06f53cc20a3/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-game-data-server/configmap.yaml