### PR TITLE
feat: kubeadmの実行ファイルが存在するまでansibleを待たせる

### DIFF
--- a/seichi-onp-k8s/cluster-boot-up/ansible/roles/00-wait-to-host-reachable/tasks/main.yaml
+++ b/seichi-onp-k8s/cluster-boot-up/ansible/roles/00-wait-to-host-reachable/tasks/main.yaml
@@ -5,6 +5,7 @@
 - name: Wait until the file /usr/bin/kubeadm is present before continuing
   ansible.builtin.wait_for:
     path: /usr/bin/kubeadm
+    timeout: 1200
 
 - name: Gather facts for first time
   setup:

--- a/seichi-onp-k8s/cluster-boot-up/ansible/roles/00-wait-to-host-reachable/tasks/main.yaml
+++ b/seichi-onp-k8s/cluster-boot-up/ansible/roles/00-wait-to-host-reachable/tasks/main.yaml
@@ -2,5 +2,9 @@
   wait_for_connection:
     timeout: 1200
 
+- name: Wait until the file /usr/bin/kubeadm is present before continuing
+  ansible.builtin.wait_for:
+    path: /usr/bin/kubeadm
+
 - name: Gather facts for first time
   setup:


### PR DESCRIPTION
ちょっと雑だけどこれでフライングすることはほぼなくなるはず