### PR TITLE
wip: Grafanaのaddon-dashboardたちの復活

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
@@ -130,6 +130,48 @@ spec:
               requests:
                 memory: 2Gi
             retention: 60d
+        dashboardProviders:
+          dashboardproviders.yaml:
+            apiVersion: 1
+            providers:
+            - name: 'addons-by-helm'
+              orgId: 2
+              folder: 'addons-by-helm'
+              type: file
+              allowUiUpdates: true
+              disableDeletion: true
+              editable: false
+              options:
+                path: /var/lib/grafana/dashboards/addons-by-helm
+        dashboards:
+          addons-by-helm:
+            cilium-agent:
+              gnetId: 16611
+              revision: 1
+              datasource: Prometheus
+            cilium-operator:
+              gnetId: 16612
+              revision: 1
+              datasource: Prometheus
+            cilium-hubble:
+              gnetId: 16613
+              revision: 1
+              datasource: Prometheus
+            argocd:
+              gnetId: 14584
+              revision: 1
+            synology-details:
+              gnetId: 14284
+              revision: 9
+              datasource: Prometheus
+            synology-overview:
+              gnetId: 14364
+              revision: 8
+              datasource: Prometheus
+            disconnected-log-metrics-bungee:
+              gnetId: 19689
+              revision: 2
+              datasource: Loki
         alertmanager:
           enabled: false
         kubeProxy:


### PR DESCRIPTION
一旦wip

## TODO

- [x] #1347 を実現するためのdashboardの追加(alrtingは含まず。これは別でやる)
- [ ] #1121 当時動いていない `.values.grafana.dashboardProviders` と `.values.grafana.dashboards` を動作するようにする
  - 過去に #1121 がmergeされた時点のmainブランチの状況
    -  `charts: kube-prometheus-stack` は `targetRevision: 47.0.0` が指定されていた
https://github.com/GiganticMinecraft/seichi_infra/blob/93772e4b9e03107a5803145c8e42ebe7ececfd31/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml#L11
  - 現在のmainブランチの状況
    - `charts: kube-prometheus-stack` は `targetRevision: 51.2.0` が指定されている
https://github.com/GiganticMinecraft/seichi_infra/blob/c34fc7f75e1c6041dc9d5125e8ea00a2369dfa98/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml#L38
  - 双方バージョンともに`.values.grafana.dashboardProviders` や `.values.grafana.dashboards` の指定には対応してる
    - https://github.com/prometheus-community/helm-charts/blob/kube-prometheus-stack-47.0.0/charts/kube-prometheus-stack/Chart.yaml#L51
https://github.com/grafana/helm-charts/blob/grafana-6.59.5/charts/grafana/values.yaml
    - https://github.com/prometheus-community/helm-charts/blob/kube-prometheus-stack-51.2.0/charts/kube-prometheus-stack/Chart.yaml#L54
https://github.com/grafana/helm-charts/blob/grafana-6.57.4/charts/grafana/values.yaml
