### PR TITLE
1.18.2のベースイメージをビルドするときにmod-downloaderを利用してプラグインをダウンロードするように

### DIFF
--- a/.github/workflows/build_mcserver_base_images.yaml
+++ b/.github/workflows/build_mcserver_base_images.yaml
@@ -1,5 +1,5 @@
 name: Build Minecraft Server Base Images
-on: 
+on:
   push:
     paths:
       - ".github/workflows/build_mcserver_base_images.yaml"
@@ -78,3 +78,9 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             MCSERVER_BASE_IMAGE=itzg/minecraft-server:${{ matrix.mcserver_base_image_tag }}@${{ matrix.mcserver_base_image_digest }}
+            MINIO_ENDPOINT=seichi-private-plugin-blackhole-minio-console.minio:9001
+            MINIO_ACCESS_KEY= ${{ secrets.TF_VAR_MINIO_PROD_ACCESS_KEY }}
+            MINIO_ACCESS_SECRET=${{ secrets.TF_VAR_MINIO_PROD_ACCESS_SECRET }}
+            BUCKET_NAME=seichi-plugins 
+            BUCKET_PREFIX_NAME=deb-1-18-2 
+            DOWNLOAD_TARGET_DIR_PATH=/plugins

--- a/.github/workflows/build_mcserver_images.yaml
+++ b/.github/workflows/build_mcserver_images.yaml
@@ -1,5 +1,5 @@
 name: Build Minecraft Server Images
-on: 
+on:
   push:
     paths:
       - ".github/workflows/build_mcserver_images.yaml"
@@ -93,3 +93,10 @@ jobs:
           cache-from: type=gha
           # すべてのビルドステージのすべてのレイヤーをキャッシュして欲しいのでmode=max
           cache-to: type=gha,mode=max
+          build-args: |
+            MINIO_ENDPOINT=seichi-private-plugin-blackhole-minio-console.minio:9001
+            MINIO_ACCESS_KEY= ${{ secrets.TF_VAR_MINIO_PROD_ACCESS_KEY }}
+            MINIO_ACCESS_SECRET=${{ secrets.TF_VAR_MINIO_PROD_ACCESS_SECRET }}
+            BUCKET_NAME=seichi-plugins 
+            BUCKET_PREFIX_NAME=deb-1-18-2 
+            DOWNLOAD_TARGET_DIR_PATH=/plugins

--- a/docker-images/mcservers/debug/seichi-servers/base-images/1_18_2/Dockerfile
+++ b/docker-images/mcservers/debug/seichi-servers/base-images/1_18_2/Dockerfile
@@ -1,3 +1,5 @@
+FROM ghcr.io/giganticminecraft/mod-downloader:sha-39a89de as mod-downloader
+
 FROM ghcr.io/giganticminecraft/seichi_minecraft_server_base:1.0.0-java17-jdk@sha256:57accce4686dfe6bf6cb5107a664b169f130e97ef697ea7b37778a14e7f942e6
 
 ENV VERSION="1.18.2"
@@ -6,6 +8,9 @@ ENV VERSION="1.18.2"
 #   このイメージでは基底のリスト (/extras/plugin-list.ini) に追記する
 COPY --link ./additional-plugin-list.ini /extras/additional-plugin-list.ini
 RUN /bin/bash -c "cat /extras/additional-plugin-list.ini >> /extras/plugin-list.ini"
+
+COPY --from=mod-downloader ./bin/ /
+RUN /mod-downloader
 
 # プラグインの設定ファイル
 COPY --link ./additional-plugin-configs /plugins

--- a/docker-images/mcservers/debug/seichi-servers/base-images/1_18_2/Dockerfile
+++ b/docker-images/mcservers/debug/seichi-servers/base-images/1_18_2/Dockerfile
@@ -2,13 +2,6 @@ FROM ghcr.io/giganticminecraft/mod-downloader:sha-39a89de as mod-downloader
 
 FROM ghcr.io/giganticminecraft/seichi_minecraft_server_base:1.0.0-java17-jdk@sha256:57accce4686dfe6bf6cb5107a664b169f130e97ef697ea7b37778a14e7f942e6
 
-ARG MINIO_ENDPOINT
-ARG MINIO_ACCESS_KEY
-ARG MINIO_ACCESS_SECRET
-ARG BUCKET_NAME
-ARG BUCKET_PREFIX_NAME
-ARG DOWNLOAD_TARGET_DIR_PATH
-
 ENV VERSION="1.18.2"
 
 # プラグインリスト

--- a/docker-images/mcservers/debug/seichi-servers/base-images/1_18_2/Dockerfile
+++ b/docker-images/mcservers/debug/seichi-servers/base-images/1_18_2/Dockerfile
@@ -2,6 +2,13 @@ FROM ghcr.io/giganticminecraft/mod-downloader:sha-39a89de as mod-downloader
 
 FROM ghcr.io/giganticminecraft/seichi_minecraft_server_base:1.0.0-java17-jdk@sha256:57accce4686dfe6bf6cb5107a664b169f130e97ef697ea7b37778a14e7f942e6
 
+ARG MINIO_ENDPOINT
+ARG MINIO_ACCESS_KEY
+ARG MINIO_ACCESS_SECRET
+ARG BUCKET_NAME
+ARG BUCKET_PREFIX_NAME
+ARG DOWNLOAD_TARGET_DIR_PATH
+
 ENV VERSION="1.18.2"
 
 # プラグインリスト


### PR DESCRIPTION
そもそも方向性が合っているかはわかりませんが、デバッグサーバー起動時にプラグインがダウンロードされていないようなので、MinIOのdeb-1-18-2バケッドからプラグインをダウンロードするようにしました。