### PR TITLE
PRごとにをデバッグサーバーを立ち上げるときのinitContainersにmod-downloaderを追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/stateful-set.yaml
@@ -33,6 +33,27 @@ spec:
             - "sh"
             - "-c"
             - 'wget -O /root/jmx-exporter-download/jmx-exporter-javaagent.jar "${JMX_EXPORTER_URL}"'
+        - name: mod-downloader
+          image: ghcr.io/giganticminecraft/mod-downloader:sha-8326d06
+          env:
+            - name: MINIO_ENDPOINT
+              value: seichi-private-plugin-blackhole-minio-console.minio:9001
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mcserver--common--config-secrets
+                  key: MINIO_DEBUG_ACCESS_KEY
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mcserver--common--config-secrets
+                  key: MINIO_DEBUG_ACCESS_SECRET
+            - name: BUCKET_NAME
+              value: seichi-plugins
+            - name: BUCKET_PREFIX_NAME
+              value: deb-1-18-2
+            - name: DOWNLOAD_TARGET_DIR_PATH
+              value: /plugins
 
       containers:
         - resources:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/stateful-set.yaml
@@ -43,7 +43,7 @@ spec:
                 secretKeyRef:
                   name: mcserver--common--config-secrets
                   key: MINIO_DEBUG_ACCESS_KEY
-            - name: MINIO_ACCESS_KEY
+            - name: MINIO_ACCESS_SECRET
               valueFrom:
                 secretKeyRef:
                   name: mcserver--common--config-secrets

--- a/terraform/onp_cluster_minecraft_secrets.tf
+++ b/terraform/onp_cluster_minecraft_secrets.tf
@@ -8,6 +8,8 @@ resource "kubernetes_secret" "onp_minecraft_debug_secrets" {
 
   data = {
     DISCORDSRV_TOKEN = var.minecraft__discordsrv_bot_token
+    MINIO_DEBUG_ACCESS_KEY = var.minio_debug_access_key
+    MINIO_DEBUG_ACCESS_SECRET = var.minio_debug_access_secret
   }
 
   type = "Opaque"

--- a/terraform/onp_cluster_minecraft_secrets.tf
+++ b/terraform/onp_cluster_minecraft_secrets.tf
@@ -7,8 +7,8 @@ resource "kubernetes_secret" "onp_minecraft_debug_secrets" {
   }
 
   data = {
-    DISCORDSRV_TOKEN = var.minecraft__discordsrv_bot_token
-    MINIO_DEBUG_ACCESS_KEY = var.minio_debug_access_key
+    DISCORDSRV_TOKEN          = var.minecraft__discordsrv_bot_token
+    MINIO_DEBUG_ACCESS_KEY    = var.minio_debug_access_key
     MINIO_DEBUG_ACCESS_SECRET = var.minio_debug_access_secret
   }
 


### PR DESCRIPTION
https://github.com/GiganticMinecraft/seichi_infra/pull/1397#pullrequestreview-1723718869

この返信を参考に、PRごとにデバッグサーバーを立ち上げる部分のinitContainerにmod-downloaderを追加しました