### PR TITLE
minioの`access-key`と`access-secret`を`onp_cluster_secrets.tf`の`minio-access-secret`から取る

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/stateful-set.yaml
@@ -41,12 +41,12 @@ spec:
             - name: MINIO_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: clustersecret
+                  name: minio-secrets
                   key: MINIO_ACCESS_KEY
             - name: MINIO_ACCESS_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: clustersecret
+                  name: minio-secrets
                   key: MINIO_ACCESS_SECRET
             - name: BUCKET_NAME
               value: seichi-plugins

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/stateful-set.yaml
@@ -41,12 +41,12 @@ spec:
             - name: MINIO_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: minio-access-secret
+                  name: clustersecret
                   key: MINIO_ACCESS_KEY
             - name: MINIO_ACCESS_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: minio-access-secret
+                  name: clustersecret
                   key: MINIO_ACCESS_SECRET
             - name: BUCKET_NAME
               value: seichi-plugins

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/stateful-set.yaml
@@ -41,13 +41,13 @@ spec:
             - name: MINIO_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: mcserver--common--config-secrets
-                  key: MINIO_DEBUG_ACCESS_KEY
+                  name: minio-access-secret
+                  key: MINIO_ACCESS_KEY
             - name: MINIO_ACCESS_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: mcserver--common--config-secrets
-                  key: MINIO_DEBUG_ACCESS_SECRET
+                  name: minio-access-secret
+                  key: MINIO_ACCESS_SECRET
             - name: BUCKET_NAME
               value: seichi-plugins
             - name: BUCKET_PREFIX_NAME

--- a/terraform/onp_cluster_minecraft_secrets.tf
+++ b/terraform/onp_cluster_minecraft_secrets.tf
@@ -115,7 +115,7 @@ resource "kubernetes_secret" "onp_minecraft_debug_mariadb_root_password" {
   type = "Opaque"
 }
 
-resource "helm_release" "onp_minecraft_debug_minio_secrets" { 
+resource "helm_release" "onp_minecraft_debug_minio_secrets" {
   depends_on = [kubernetes_namespace.onp_seichi_debug_minecraft]
 
   repository = "https://giganticminecraft.github.io/seichi_infra/"

--- a/terraform/onp_cluster_minecraft_secrets.tf
+++ b/terraform/onp_cluster_minecraft_secrets.tf
@@ -7,9 +7,7 @@ resource "kubernetes_secret" "onp_minecraft_debug_secrets" {
   }
 
   data = {
-    DISCORDSRV_TOKEN          = var.minecraft__discordsrv_bot_token
-    MINIO_DEBUG_ACCESS_KEY    = var.minio_debug_access_key
-    MINIO_DEBUG_ACCESS_SECRET = var.minio_debug_access_secret
+    DISCORDSRV_TOKEN = var.minecraft__discordsrv_bot_token
   }
 
   type = "Opaque"

--- a/terraform/onp_cluster_minecraft_secrets.tf
+++ b/terraform/onp_cluster_minecraft_secrets.tf
@@ -114,3 +114,31 @@ resource "kubernetes_secret" "onp_minecraft_debug_mariadb_root_password" {
 
   type = "Opaque"
 }
+
+resource "helm_release" "onp_minecraft_mariadb_monitoring_password" { 
+  depends_on = [kubernetes_namespace.onp_seichi_debug_minecraft]
+
+  repository = "https://giganticminecraft.github.io/seichi_infra/"
+  chart      = "raw-resources"
+  name       = "seichi-debug-minecraft-minio-secrets"
+  namespace  = "kube-system"
+  version    = "0.3.0"
+
+  set_list {
+    name = "manifests"
+    value = [<<-EOS
+      kind: ClusterSecret
+      apiVersion: clustersecret.io/v1
+      metadata:
+        namespace: clustersecret
+        name: minio-secrets
+      matchNamespace:
+        - seichi-debug-minecraft-on-seichiassist-pr-*
+      data:
+        MINIO_ACCESS_KEY: ${base64encode(var.minio_debug_access_key)}
+        MINIO_DEBUG_ACCESS_SECRET: ${base64encode(var.minio_debug_access_secret)}
+    EOS
+    ]
+  }
+
+}

--- a/terraform/onp_cluster_minecraft_secrets.tf
+++ b/terraform/onp_cluster_minecraft_secrets.tf
@@ -115,7 +115,7 @@ resource "kubernetes_secret" "onp_minecraft_debug_mariadb_root_password" {
   type = "Opaque"
 }
 
-resource "helm_release" "onp_minecraft_mariadb_monitoring_password" { 
+resource "helm_release" "onp_minecraft_debug_minio_secrets" { 
   depends_on = [kubernetes_namespace.onp_seichi_debug_minecraft]
 
   repository = "https://giganticminecraft.github.io/seichi_infra/"


### PR DESCRIPTION
https://discord.com/channels/237758724121427969/959299646725951580/1175598364344205412

`MINIO_DEBUG_ACCESS_KEY`が見つけられないというエラーが出ていたので、すでにminioの`key`と`secret`が定義された`onp_cluster_secrets.tf`から取得するように修正しました。

`mcserver--common--config-secrets`から`key`と`secret`が取得できなかった原因が分からなくて、とりあえずminioのアクセス情報が定義されているところがあったのでそこから取得するようにしてみましたが、これで動くのかどうかはわかっていないのでそもそも方向性が正しいかを見てほしいです。