### PR TITLE
ワールドを作成するコマンドが起動時に実行されるようにする

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
@@ -117,6 +117,14 @@ spec:
             - name: CFG_DISCORDSRV_CONSOLE_CHANNEL_ID
               value: "1054159676964622426"
 
+            - name: RCON_CMDS_STARTUP
+              value: |
+                gamerule keepInventory true
+                mv create world_SW NORMAL
+                mv create world_SW_2 NORMAL
+                mv create world_SW_nether NETHER
+                mv create world_SW_the_end END
+
           image: ghcr.io/giganticminecraft/seichi_minecraft_server_debug_base_1_18_2:sha-1267b49
           name: minecraft
           ports:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
@@ -140,6 +140,19 @@ spec:
             failureThreshold: 6
             periodSeconds: 20
 
+          readinessProbe:
+            exec:
+              command:
+                - mc-monitor 
+                - status 
+                - --host 
+                - localhost 
+                - --port
+                - "25565"
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            failureThreshold: 18
+
           volumeMounts:
             # itzg/minecraft-server は /config に設定ファイルをマウントしておけばコピーをしてくれる。
             # 環境変数の置き換えはPrefix等の設定が必要なので、必要になったら設定するように。


### PR DESCRIPTION
検証環境として、最低限整地ワールドがないといけないので作成するコマンドがサーバー起動時に実行されるようにしました
https://docker-minecraft-server.readthedocs.io/en/latest/configuration/auto-rcon-commands/