### PR TITLE
fix: valueに改行コードが含まれないようにする

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
@@ -118,7 +118,7 @@ spec:
               value: "1054159676964622426"
 
             - name: RCON_CMDS_STARTUP
-              value: |
+              value: |-
                 gamerule keepInventory true
                 mv create world_SW NORMAL
                 mv create world_SW_2 NORMAL


### PR DESCRIPTION
https://docker-minecraft-server.readthedocs.io/en/latest/configuration/auto-rcon-commands/

に「When declaring several commands within a compose file environment variable, it's easiest to use YAML's |- [block style indicator](https://yaml-multiline.info/).」と書かれていました