### PR TITLE
ネザーゲートを使用禁止にする

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/common-configs/mcserver-configs.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/common-configs/mcserver-configs.yaml
@@ -421,7 +421,7 @@ data:
     max-build-height=256
     server-ip=
     resource-pack-prompt=
-    allow-nether=true
+    allow-nether=false
     server-port=25565
     enable-rcon=false
     sync-chunk-writes=true


### PR DESCRIPTION
整地鯖ではネザーゲートは使用できないようです