### PR TITLE
デバッグサーバーのメモリ量を増やす

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
@@ -82,13 +82,13 @@ spec:
         - resources:
             requests:
               cpu: 6
-              memory: 8Gi
+              memory: 12Gi
             limits:
               cpu: 8
-              memory: 8Gi
+              memory: 12Gi
           env:
             - name: MEMORY
-              value: 6G
+              value: 10G
             - name: TYPE
               value: PAPER
             - name: VERSION


### PR DESCRIPTION
増やすことにした経緯:
- SeichiAssistが行うワールドマイグレーションを走らせると`OutOfMemoryError`が発生するようになった
- [Paper公式が推奨しているJVMオプション](https://docs.papermc.io/paper/aikars-flags)を追加した
- `OutOfMemoryError`は発生しなくなったが、Grafanaを見るとメモリが限界値に張り付いた後に落ちるようになった
- メモリが足りていないことは明らかなので、試しに増やしたい(少し増やせば足りるのか、根本的に処理を見直さないといけないのか見たい(できれば処理の書き直しはしたくない))