### PR TITLE
切り分けのためデバッグサーバーに対する直前の設定変更をすべてrevert

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/common-configs/plugin-configs.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/common-configs/plugin-configs.yaml
@@ -1084,7 +1084,7 @@ data:
       block-item-frame-destroy: true
       block-plugin-spawning: true
       block-above-ground-slimes: false
-      block-other-explosions: true
+      block-other-explosions: false
       block-zombie-door-destruction: false
       block-creature-spawn: []
     player-damage:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/common-configs/worldguard-config.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/common-configs/worldguard-config.yaml
@@ -71,19 +71,19 @@ data:
     #ignore-groups=admins,mods
     #on-break=notify,deny,log
 
-    # 岩盤の設置・破壊無効化
+    # 岩盤設置無効化
     [bedrock]
     ignore-groups=admin
     on-place=deny,log,tell
     on-break=deny,log,tell
 
-    # コーラスフルーツの使用・インタラクト無効化
+    # コーラスフルーツ無効化
     [chorus_fruit]
     ignore-groups=admin
     on-use=deny,log,tell
     on-interact=deny,log,tell
 
-    # オブザーバーの設置無効化
+    # オブザーバーブロック設置無効化
     [observer]
     ignore-groups=admin
     on-place=deny,log,tell
@@ -156,26 +156,21 @@ data:
     #ignore-groups=admins,mods
     #on-break=notify,deny,log
 
-    # 岩盤の設置・破壊無効化
+    # 岩盤設置無効化
     [bedrock]
     ignore-groups=admin
     on-place=deny,log,tell
     on-break=deny,log,tell
 
-    # オブザーバーの設置無効化
+    # オブザーバーブロック設置無効化
     [observer]
     ignore-groups=admin
     on-place=deny,log,tell
 
-    # エンドクリスタルの設置無効化
+    # エンドクリスタル設置無効化
     [end_crystal]
     ignore-groups=admin
-    on-place=deny,log,tell
-
-    # リスポーンアンカーの設置無効化
-    [respawn_anchor]
-    ignore-groups=admin
-    on-place=deny,log,tell
+    on-use=deny,log,tell
 
   # エンド整地、ネザー整地
   world_SW_the_end-Blacklist.txt: |
@@ -245,31 +240,26 @@ data:
     #ignore-groups=admins,mods
     #on-break=notify,deny,log
 
-    # 岩盤の設置・破壊無効化
+    # 岩盤設置無効化
     [bedrock]
     ignore-groups=admin
     on-place=deny,log,tell
     on-break=deny,log,tell
 
-    # ベッドの設置無効化
-    [white_bed, orange_bed, magenta_bed, light_blue_bed, yellow_bed, lime_bed, pink_bed, gray_bed, light_gray_bed, cyan_bed, purple_bed, blue_bed, brown_bed, green_bed, red_bed, black_bed]
+    # ベッド設置無効化
+    [bed]
     ignore-groups=admin
-    on-place=deny,log,tell
+    on-use=deny,log,tell
 
-    # オブザーバーの設置無効化
+    # オブザーバーブロック設置無効化
     [observer]
     ignore-groups=admin
     on-place=deny,log,tell
 
-    # エンドクリスタルの設置無効化
+    # エンドクリスタル設置無効化
     [end_crystal]
     ignore-groups=admin
-    on-place=deny,log,tell
-
-    # リスポーンアンカーの設置無効化
-    [respawn_anchor]
-    ignore-groups=admin
-    on-place=deny,log,tell
+    on-use=deny,log,tell
 
   # メイン
   main-config.yml: |

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
@@ -169,9 +169,7 @@ spec:
                 mv gamerule doInsomnia false world_SW_nether
                 mv gamerule doInsomnia false world_SW_the_end
                 mvm set difficulty peaceful world_2
-                rg addmember -w world_2 __global__ unchama
                 rg flag -w world_2 __global__ build -g members allow
-                rg addmember -w world_SW_2 __global__ unchama
                 rg flag -w world_SW_2 __global__ build -g members allow
                 rg flag -w world_2_the_end __global__ deny-spawn ENDER_DRAGON
                 rg flag -w world_SW_the_end __global__ deny-spawn ENDER_DRAGON


### PR DESCRIPTION
昨日の設定変更後にデバッグサーバーが起動しなくなったので、一旦変更をすべてrevertします。

revert対象は

- #1900
- #1901
- #1902 

の3件です。