### PR TITLE
revert: WGの禁止動作を'on-place'に統一したものが動作しなくなっているので戻す

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/common-configs/worldguard-config.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/common-configs/worldguard-config.yaml
@@ -170,7 +170,7 @@ data:
     # エンドクリスタルの設置無効化
     [end_crystal]
     ignore-groups=admin
-    on-place=deny,log,tell
+    on-use=deny,log,tell
 
     # リスポーンアンカーの設置無効化
     [respawn_anchor]
@@ -254,7 +254,7 @@ data:
     # ベッドの設置無効化
     [white_bed, orange_bed, magenta_bed, light_blue_bed, yellow_bed, lime_bed, pink_bed, gray_bed, light_gray_bed, cyan_bed, purple_bed, blue_bed, brown_bed, green_bed, red_bed, black_bed]
     ignore-groups=admin
-    on-place=deny,log,tell
+    on-use=deny,log,tell
 
     # オブザーバーの設置無効化
     [observer]
@@ -264,7 +264,7 @@ data:
     # エンドクリスタルの設置無効化
     [end_crystal]
     ignore-groups=admin
-    on-place=deny,log,tell
+    on-use=deny,log,tell
 
     # リスポーンアンカーの設置無効化
     [respawn_anchor]

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/common-configs/worldguard-config.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/common-configs/worldguard-config.yaml
@@ -170,7 +170,7 @@ data:
     # エンドクリスタルの設置無効化
     [end_crystal]
     ignore-groups=admin
-    on-place=deny,log,tell
+    on-use=deny,log,tell
 
     # リスポーンアンカーの設置無効化
     [respawn_anchor]
@@ -254,7 +254,7 @@ data:
     # ベッドの設置無効化
     [white_bed, orange_bed, magenta_bed, light_blue_bed, yellow_bed, lime_bed, pink_bed, gray_bed, light_gray_bed, cyan_bed, purple_bed, blue_bed, brown_bed, green_bed, red_bed, black_bed]
     ignore-groups=admin
-    on-place=deny,log,tell
+    on-use=deny,log,tell
 
     # オブザーバーの設置無効化
     [observer]
@@ -264,7 +264,7 @@ data:
     # エンドクリスタルの設置無効化
     [end_crystal]
     ignore-groups=admin
-    on-place=deny,log,tell
+    on-use=deny,log,tell
 
     # リスポーンアンカーの設置無効化
     [respawn_anchor]


### PR DESCRIPTION
以下2件（実質1件）のコミットをした後、エンドクリスタルが設置できるようになってしまっているので、たぶん変えてはいけないやつだったようなので、一旦戻します。

- Revert "refactor: WGのブロック設置拒否を'on-place'で統一"
This reverts commit a2c1e14ec9d89cba0dbf677bd443d1841ab97602.

- Revert "refactor: WGのブロック設置拒否を'on-place'で統一"
This reverts commit 083d610a1bcb558004a66f66eae4ad95b4b45f14.