### PR TITLE
minecraft-server-dataは直接LUNをマウント

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
@@ -418,12 +418,12 @@ spec:
         # mod-downloaderからプラグインをinitContainerでダウンロードしてMinecraftに受け渡すためのvolume
         - name: mod-downloader-volume
           emptyDir: {}
-
-  volumeClaimTemplates:
-    - metadata:
-        name: minecraft-server-data
-      spec:
-        accessModes: ["ReadWriteOnce"]
-        resources:
-          requests:
-            storage: 10Gi
+        
+        # サーバーデータが格納されているディレクトリはNAS上の特定のiSCSIパスで公開されたLUNドライブを直接マウントする
+        # このボリュームに保存されたデータのライフサイクルに関する管理(バックアップリストアほか)はkubernetes上で管理されずNASに一任される
+        - name: minecraft-server-data
+          iscsi:
+            targetPortal: 192.168.16.240:3260
+            iqn: iqn.2000-01.com.synology:seichi-cloud.k8s-static-pv--minecraft-server-data-mcserver--debug-s1-0
+            lun: 0
+            readOnly: false


### PR DESCRIPTION
https://x.com/tsukkkkkun/status/1767035874607522232
> オンプレk8sでクラスタ吹っ飛び前提のPVのバックアップリストアの仕組みを考えてるんですが、ダイナミックプロビジョンな仕組み経由でディスク側の識別情報(名前とか)を固定化するのは難しそうなのでゴリゴリに環境依存なPVを書くかみたいなお気持ちになってる。(要約:運用設計むずかしい)

そもそもPVすら書いてない気がする。