### PR TITLE
feat: seichiassist-downloaderをdebug-s1に追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/kustomization.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - "./ops-config.yaml"
   - "./multiverse-portals-config.yaml"
   - "./seichiassist-config.yaml"
+  - "./seichiassist-downloader.yaml"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/seichiassist-downloader.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/seichiassist-downloader.yaml
@@ -11,7 +11,7 @@ data:
 
     RELEASES=$(curl -s "https://api.github.com/repos/$owner/$repo/releases")
 
-    LATEST=$(echo $RELEASES | jq -r '.[] | select(.tag_name | startswith("v")) | .tag_name' | tail -n 1)
+    LATEST=$(echo $RELEASES | jq -r '.[] | select(.tag_name | startswith("v")) | .tag_name' | sort -V | tail -n 1)
 
     DOWNLOAD_URL=$(echo $RELEASES | jq -r --arg LATEST "$LATEST" '.[] | select(.tag_name == $LATEST) | .assets[0].browser_download_url')
 

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/seichiassist-downloader.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/seichiassist-downloader.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: seichiassist-downloader
+data:
+  seichiassist-downloader.sh: |
+    #!/bin/bash
+
+    owner="GiganticMinecraft"
+    repo="SeichiAssist"
+
+    RELEASES=$(curl -s "https://api.github.com/repos/$owner/$repo/releases")
+
+    LATEST=$(echo $RELEASES | jq -r '.[] | select(.tag_name | startswith("v")) | .tag_name' | tail -n 1)
+
+    DOWNLOAD_URL=$(echo $RELEASES | jq -r --arg LATEST "$LATEST" '.[] | select(.tag_name == $LATEST) | .assets[0].browser_download_url')
+
+    wget $DOWNLOAD_URL

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
@@ -61,6 +61,12 @@ spec:
           volumeMounts:
             - name: mod-downloader-volume
               mountPath: /plugins
+        - name: seichiassist-downloader
+          image: busybox:1.36.1
+          volumeMounts:
+            - name: seichiassist-downloader-volume
+              mountPath: /plugins
+          command: "./seichiassist-downloader.sh"
 
       containers:
         - resources:
@@ -84,9 +90,7 @@ spec:
               value: "TRUE"
 
             - name: MODS
-              # TODO: SeichiAssistのURLは決め打ちしたのでCI/CDで取得するようにする
               value: >-
-                https://github.com/GiganticMinecraft/SeichiAssist/releases/download/pr-2115-e5335a50d89c0bea7677e44dc9dca9eecfe79391/SeichiAssist.jar,
                 https://github.com/DiscordSRV/DiscordSRV/releases/download/v1.25.1/DiscordSRV-Build-1.25.1.jar,
                 https://github.com/GiganticMinecraft/LunaChat/releases/download/for-1.18.2-lunachat-3.0.17/LunaChat.jar,
                 https://download.luckperms.net/1526/bukkit/loader/LuckPerms-Bukkit-5.4.113.jar,
@@ -378,6 +382,9 @@ spec:
             - name: mod-downloader-volume
               mountPath: /plugins
 
+            - name: seichiassist-downloader-volume
+              mountPath: /plugins
+
             # サーバーデータが格納されているディレクトリのマウント設定
             - name: minecraft-server-data
               mountPath: /data
@@ -418,7 +425,12 @@ spec:
         # mod-downloaderからプラグインをinitContainerでダウンロードしてMinecraftに受け渡すためのvolume
         - name: mod-downloader-volume
           emptyDir: {}
-        
+
+        # seichiassist-downloaderからプラグインをinitContainerでダウンロードしてMinecraftに受け渡すためのvolume
+        - name: seichiassist-downloader-volume
+          configMap:
+            name: seichiassist-downloader
+
         # サーバーデータが格納されているディレクトリはNAS上の特定のiSCSIパスで公開されたLUNドライブを直接マウントする
         # このボリュームに保存されたデータのライフサイクルに関する管理(バックアップリストアほか)はkubernetes上で管理されずNASに一任される
         - name: minecraft-server-data


### PR DESCRIPTION
前に1.18用の固定デバッグサーバーはSeichiAssistのダウンロードだけ決め打ちしていたので、最新のリリースを持ってくるやつをかきました