### PR TITLE
seichiassist-downlaoderのapplyに失敗するのを修正

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
@@ -389,7 +389,7 @@ spec:
               mountPath: /plugins
 
             - name: seichiassist-downloader-volume
-              mountPath: /plugins
+              mountPath: /data/plugins
 
             # サーバーデータが格納されているディレクトリのマウント設定
             - name: minecraft-server-data

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
@@ -66,7 +66,13 @@ spec:
           volumeMounts:
             - name: seichiassist-downloader-volume
               mountPath: /plugins
-          command: "chmod +x /plugins/seichiassist-downloader.sh && /plugins/seichiassist-downloader.sh"
+          command:
+            - "chmod"
+            - "+x"
+            - "/plugins/seichiassist-downloader.sh"
+            - "&&"
+            - "sh"
+            - "/plugins/seichiassist-downloader.sh"
 
       containers:
         - resources:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
@@ -65,7 +65,7 @@ spec:
           image: busybox:1.36.1
           volumeMounts:
             - name: seichiassist-downloader-volume
-              mountPath: /plugins
+              mountPath: /data/plugins
           command:
             - "chmod"
             - "+x"


### PR DESCRIPTION
- ArgoCDのエラーを見るとcommandは配列形式で指定されるべきらしいのでそのように修正しました
- 同じくエラーによるとmountPathは重複してはいけないようなので修正(とはいえ`/data`ディレクトリがすでにマウントされていて、`/data/plugins`ディレクトリは`/data`ディレクトリに内包されるので、これが許されるかどうかは実行してみないとわからない)