### PR TITLE
seichiassist-downloaderを追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cloudflared-tunnel-exits/http-exits.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cloudflared-tunnel-exits/http-exits.yaml
@@ -90,6 +90,11 @@ spec:
             external-hostname: gachadata.public-gigantic-api.seichi.click
             internal-authority: "gachadata-server.seichi-minecraft:80"
 
+          # seichiassist-downloaderにアクセスするためのエンドポイント。
+          - name: seichiassist-downloader
+            external-hostname: seichiassist-downloader.public-gigantic-api.seichi.click
+            internal-authority: "seichiassist-downloader.seichi-minecraft:80"
+
           # phpMyAdmin
           - name: phpmyadmin
             external-hostname: phpmyadmin.onp-k8s.admin.seichi.click

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: seichiassist-downloader
+  namespace: seichi-minecraft
+  labels:
+    app: seichiassist-downloader
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: seichiassist-downloader
+  template:
+    metadata:
+      labels:
+        app: seichiassist-downloader
+    spec:
+      containers:
+        - name: seichiassist-downloader
+          image: ghcr.io/giganticminecraft/seichiassist-downloader:sha-7d9becf
+          resources:
+            # seichiassist-downloaderはSeichiAssistをビルドするのでメモリが多めにほしい
+            requests:
+              cpu: 1
+              memory: 4Gi
+            limits:
+              cpu: 1
+              memory: 4Gi
+          env:
+            - name: HTTP_PORT
+              value: "80"
+            # STABLE_BRANCHとDEVELOP_BRANCHは本来別のブランチにするべきだが、
+            # seichiassist-builderは1.18のビルド用に設計されているため、
+            # 一時的に1_18ブランチで固定する
+            # TODO: あとでブランチ名を直す
+            - name: STABLE_BRANCH
+              value: "1_18"
+            - name: DEVELOP_BRANCH
+              value: "1_18"
+            - name: TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: seichiassist-downloader-token
+                  key: SEICHIASSIST_DOWNLOADER_TOKEN

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/service.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: seichi-minecraft
+  name: gachadata-server
+spec:
+  type: ClusterIP
+  ports:
+    - name: gachadata-server-web
+      port: 80
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: gachadata-server

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/service.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/service.yaml
@@ -2,13 +2,13 @@ apiVersion: v1
 kind: Service
 metadata:
   namespace: seichi-minecraft
-  name: gachadata-server
+  name: seichiassist-downloader
 spec:
   type: ClusterIP
   ports:
-    - name: gachadata-server-web
+    - name: seichiassist-downloader-web
       port: 80
       protocol: TCP
       targetPort: 80
   selector:
-    app: gachadata-server
+    app: seichiassist-downloader

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -349,3 +349,13 @@ variable "hackmd_mariadb_hackmd_db_url" {
 }
 
 #endregion
+
+#region env variables for seichiassist-downloader
+
+variable "seichiassist_downloader_token" {
+  description = "Publish endpoint token for seichiassist-downloader"
+  type        = string
+  sensitive   = true
+}
+
+#endregion

--- a/terraform/onp_cluster_secrets.tf
+++ b/terraform/onp_cluster_secrets.tf
@@ -280,6 +280,19 @@ resource "kubernetes_secret" "idea_reaction_discord_token" {
   }
 }
 
+resource "kubernetes_secret" "seichiassist_downloader_token" {
+  depends_on = [kubernetes_namespace.onp_seichi_minecraft]
+
+  metadata {
+    name      = "seichiassist-downloader-token"
+    namespace = "seichi-minecraft"
+  }
+
+  data = {
+    SEICHIASSIST_DOWNLOADER_TOKEN = var.seichiassist_downloader_token
+  }
+}
+
 resource "kubernetes_secret" "growi_github_sso" {
   depends_on = [kubernetes_namespace.growi_system]
 


### PR DESCRIPTION
[seichiassist-downloader](https://github.com/GiganticMinecraft/seichiassist-downloader)の定義を追加しました。

細かい機能はリポジトリを確認してほしいですが、大まかに言えば指定ブランチのSeichiAssistの最新ビルドをキャッシュしながら固定リンクでダウンロードできるようにするためのアプリケーションです。

1.18用の固定のデバッグサーバーを作るときに、最新のSeichiAssistが固定のリンクでダウンロードできると便利なので作成しました