### PR TITLE
fix: ブランチ名をエスケープする

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/sensor.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/sensor.yaml
@@ -24,9 +24,9 @@ spec:
             # 1.18のリリースになるまで1_18ブランチも追加する
             # TODO: 1_18ブランチがマージされたら削除する
             value:
-              - master
-              - develop
-              - 1_18
+              - "master"
+              - "develop"
+              - "1_18"
   triggers:
     - template:
         name: seichiassist-release-trigger


### PR DESCRIPTION
`1_18`というブランチ名が数字として解釈されていることが原因ぽいので修正しました