### PR TITLE
fix: argo workflows のリバースプロキシの定義を直す

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/argo-workflows-reverse-proxy.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/argo-workflows-reverse-proxy.yaml
@@ -1,22 +1,28 @@
 # 外部から Argo Workflows を発火するためには Cloudflared を使えば機能的には問題がないが、
 # 任意のクライアントから GET を受け付けると面倒なので、POST だけに限定するためのリバースプロキシを挟む。
-apiVersion: v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: argo-workflows-reverse-proxy
   namespace: argocd
 spec:
-  containers:
-    - name: nginx
-      image: nginx:1.26.0
-      volumeMounts:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: argo-workflows-reverse-proxy
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.26.0
+          volumeMounts:
+            - name: conf
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+      volumes:
         - name: conf
-          mountPath: /etc/nginx/nginx.conf
-          subPath: nginx.conf
-  volumes:
-    - name: conf
-      configMap:
-        name: argo-workflows-reverse-proxy-config-map
+          configMap:
+            name: argo-workflows-reverse-proxy-config-map
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
`Deployment` の定義としては不十分な定義だったので直しました