### PR TITLE
chore: LuckParamsのダウンロードリンクを消す

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-lobby/lobby-server.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-lobby/lobby-server.yaml
@@ -98,7 +98,6 @@ spec:
               value: >-
                 https://github.com/DiscordSRV/DiscordSRV/releases/download/v1.25.1/DiscordSRV-Build-1.25.1.jar,
                 https://github.com/GiganticMinecraft/LunaChat/releases/download/for-1.18.2-lunachat-3.0.17/LunaChat.jar,
-                https://download.luckperms.net/1526/bukkit/loader/LuckPerms-Bukkit-5.4.113.jar,
                 https://github.com/DmitryRendov/BungeePortals/releases/download/1.2.3/BungeePortals-1.2.3.jar,
                 https://github.com/sladkoff/minecraft-prometheus-exporter/releases/download/v2.5.0/minecraft-prometheus-exporter-2.5.0.jar,
                 https://github.com/GiganticMinecraft/OriginSpawn/releases/download/v0.2.7/OriginSpawn-0.2.7-SNAPSHOT.jar,

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
@@ -104,7 +104,6 @@ spec:
                 https://github.com/GiganticMinecraft/SeichiAssist/releases/download/pr-{{ .Values.SeichiAssistPullRequestNumber }}-{{ .Values.PullRequestBranchHeadSHA }}/SeichiAssist.jar,
                 https://github.com/DiscordSRV/DiscordSRV/releases/download/v1.25.1/DiscordSRV-Build-1.25.1.jar,
                 https://github.com/GiganticMinecraft/LunaChat/releases/download/for-1.18.2-lunachat-3.0.17/LunaChat.jar,
-                https://download.luckperms.net/1526/bukkit/loader/LuckPerms-Bukkit-5.4.113.jar,
                 https://github.com/GiganticMinecraft/Elytra/releases/download/release-at-3d2239a54b1c0cfa5c1b5017ee36256056df911f/Elytra-1.0-SNAPSHOT.jar,
                 https://github.com/GiganticMinecraft/OriginSpawn/releases/download/v0.2.7/OriginSpawn-0.2.7-SNAPSHOT.jar,
                 https://github.com/GiganticMinecraft/ByeByeWither/releases/download/sha-e2a0a69/ByeByeWither-1.0.0.jar,


### PR DESCRIPTION
一定期間経過後にLuckParamsのリンクが無効化されるようなので、minioからダウンロードするために削除しました