### PR TITLE
ArgoEvents が Webhook リクエストを正しく受け付けないのを修正

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/event-bus.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/event-bus.yaml
@@ -1,0 +1,9 @@
+apiVersion: argoproj.io/v1alpha1
+kind: EventBus
+metadata:
+  name: seichiassist-downloader
+  namespace: seichi-minecraft
+spec:
+  nats:
+    native:
+      replicas: 3


### PR DESCRIPTION
ArgoEvents の EventSource と Sensor のやり取りには EventBus が定義されている必要があるようですが、定義していなかったので定義しました。

[ArgoWorkflows 上の status](https://argo-workflows.onp-k8s.admin.seichi.click/event-sources/seichi-minecraft/seichiassist-downloader?tab=manifest) で `EventBusNotFound` と表示されているので、定義を追加しました。

[このページ](https://argoproj.github.io/argo-events/eventbus/stan/)を参考にしました