### PR TITLE
EventSource と Sensor に `eventBusName` を指定する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/event-source.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/event-source.yaml
@@ -4,6 +4,7 @@ metadata:
   name: seichiassist-downloader
   namespace: seichi-minecraft
 spec:
+  eventBusName: seichiassist-downloader
   github:
     SeichiAssistReleaseEventSource:
       repositories:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/sensor.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/sensor.yaml
@@ -4,6 +4,7 @@ metadata:
   name: seichiassist-downloader
   namespace: seichi-minecraft
 spec:
+  eventBusName: seichiassist-downloader
   dependencies:
     - name: from-seichiassist-downloader
       eventSourceName: seichiassist-downloader


### PR DESCRIPTION
EventBus の `name` を `default` 以外にするときは Sensor と EventSource の定義に `eventBusName` を定義しないといけないそうなので追加しました。

https://argoproj.github.io/argo-events/eventbus/eventbus/