### PR TITLE
argo-wf-proxy の Deployment に labels を追加する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/argo-workflows-reverse-proxy.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/argo-workflows-reverse-proxy.yaml
@@ -22,6 +22,8 @@ metadata:
   # そうすると53文字を超えてしまい、エラーが発生するのでやむを得ず短縮している。
   name: argo-wf-proxy
   namespace: argo
+  labels:
+    app: argo-wf-proxy
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
そもそも定義したリバースプロキシの Pod が立ち上がっていない(少なくとも ArgoCD 上で検索しても出てこない)ように見えるので、それを直すためのものです。
これが原因かはわかりませんが、他の定義と見比べると `argo-wf-proxy` には `Deployment` の `labels` を追加しました。

的はずれな変更だったら教えて下さい