### PR TITLE
migrate bgp control plane v2 before upgrading cilium to 1.16

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/cilium-networking/bgp-peering-policy-v2.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/cilium-networking/bgp-peering-policy-v2.yaml
@@ -1,0 +1,157 @@
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPClusterConfig
+metadata:
+  name: cilium-bgp-cluster-config-cp-1
+spec:
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/hostname: seichi-onp-k8s-cp-1
+  bgpInstances:
+  - name: "instance-65201"
+    localASN: 65201
+    peers:
+    - name: "peer-to-router"
+      peerASN: 65184
+      peerAddress: 192.168.3.254/32
+      peerConfigRef:
+        name: "common-peer-config"
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPClusterConfig
+metadata:
+  name: cilium-bgp-cluster-config-cp-2
+spec:
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/hostname: seichi-onp-k8s-cp-2
+  bgpInstances:
+  - name: "instance-65202"
+    localASN: 65202
+    peers:
+    - name: "peer-to-router"
+      peerASN: 65184
+      peerAddress: 192.168.3.254/32
+      peerConfigRef:
+        name: "common-peer-config"
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPClusterConfig
+metadata:
+  name: cilium-bgp-cluster-config-cp-3
+spec:
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/hostname: seichi-onp-k8s-cp-3
+  bgpInstances:
+  - name: "instance-65203"
+    localASN: 65203
+    peers:
+    - name: "peer-to-router"
+      peerASN: 65184
+      peerAddress: 192.168.3.254/32
+      peerConfigRef:
+        name: "common-peer-config"
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPClusterConfig
+metadata:
+  name: cilium-bgp-cluster-config-wk-1
+spec:
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/hostname: seichi-onp-k8s-wk-1
+  bgpInstances:
+  - name: "instance-65301"
+    localASN: 65301
+    peers:
+    - name: "peer-to-router"
+      peerASN: 65184
+      peerAddress: 192.168.3.254/32
+      peerConfigRef:
+        name: "common-peer-config"
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPClusterConfig
+metadata:
+  name: cilium-bgp-cluster-config-wk-2
+spec:
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/hostname: seichi-onp-k8s-wk-2
+  bgpInstances:
+  - name: "instance-65302"
+    localASN: 65302
+    peers:
+    - name: "peer-to-router"
+      peerASN: 65184
+      peerAddress: 192.168.3.254/32
+      peerConfigRef:
+        name: "common-peer-config"
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPClusterConfig
+metadata:
+  name: cilium-bgp-cluster-config-wk-3
+spec:
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/hostname: seichi-onp-k8s-wk-3
+  bgpInstances:
+  - name: "instance-65303"
+    localASN: 65303
+    peers:
+    - name: "peer-to-router"
+      peerASN: 65184
+      peerAddress: 192.168.3.254/32
+      peerConfigRef:
+        name: "common-peer-config"
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPPeerConfig
+metadata:
+  name: common-peer-config
+spec:
+  peerPort: 179
+  eBGPMultihopTTL: 1
+  timers:
+    connectRetryTimeSeconds: 120
+    holdTimeSeconds: 90
+    keepAliveTimeSeconds: 30
+  gracefulRestart:
+    enabled: true
+    restartTimeSeconds: 120
+  families:
+    - afi: ipv4
+      safi: unicast
+      advertisements:
+        matchLabels:
+          advertise: podcidr
+    - afi: ipv4
+      safi: unicast
+      advertisements:
+        matchLabels:
+          advertise: service
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPAdvertisement
+metadata:
+  name: podcidr-advertisement
+  labels:
+    advertise: podcidr
+spec:
+  advertisements:
+    - advertisementType: PodCIDR
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPAdvertisement
+metadata:
+  name: service-advertisement
+  labels:
+    advertise: service
+spec:
+  advertisements:
+    - advertisementType: Service
+      service:
+        addresses:
+          - LoadBalancerIP
+          - ClusterIP

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/cilium-networking/loadlbalancer-ip-pool.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/cilium-networking/loadlbalancer-ip-pool.yaml
@@ -3,6 +3,8 @@ kind: CiliumLoadBalancerIPPool
 metadata:
   name: "lb-pool"
 spec:
-  cidrs:
+  blocks:
   # 10.96.0.0-10.96.3.255 をloadBalancerのIPに割当可能
   - cidr: "10.96.0.0/22"
+  # allowFirstLastIPs デフォルトの挙動が no -> yes になったので注意
+  allowFirstLastIPs: yes


### PR DESCRIPTION
[公式ドキュメント](https://docs.cilium.io/en/stable/network/bgp-control-plane/bgp-control-plane-v2/) によれば、`CiliumBGPPeeringPolicy` と `CiliumBGPClusterConfig` が同時に存在し、Cilium エージェントが両方の `nodeSelector` にマッチする場合、 `CiliumBGPPeeringPolicy` が優先されるそうです。

ほか、[Upgrade Guide](https://docs.cilium.io/en/stable/operations/upgrade/) によると、

1. `CiliumLoadBalancerIPPool.spec.allowFirstLastIPs` のデフォルト値が `yes` に変更されました。
つまり、明示的に設定を変更しない限り、IP プールの最初と最後の IP アドレスも割り当て可能になります。
以前の動作（最初と最後の IP アドレスは割り当て不可）に依存している場合は、アップグレード前に IP プールの設定で `allowFirstLastIPs: no` を明示的に設定する必要があります。

2. `CiliumLoadBalancerIPPool.spec.cidrs` フィールドは v1.15 で非推奨となり、 `CiliumLoadBalancerIPPool.spec.blocks` が代わりに推奨されるようになりました。
v1.15 の時点では両方のフィールドは同じ動作をしますが、`cidrs` フィールドは v1.16 で削除されます。
アップグレード前に、IP プールの設定を `cidrs` から `blocks` に更新してください。 