### PR TITLE
deps: bump 1day-to-reset

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--one-day-to-reset/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--one-day-to-reset/stateful-set.yaml
@@ -24,7 +24,7 @@ spec:
         mcserver: one-day-to-reset
     spec:
       containers:
-        - image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_one_day_to_reset:sha-31f0bf5
+        - image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_one_day_to_reset:sha-d8d88b7
           name: minecraft
           resources:
             requests:


### PR DESCRIPTION
- [x] ViaVersion のアップデート

マージは PR 作成日の 1day to reset が終了した後. ( Approve はその前に出してもらって構いません)