### PR TITLE
fix: ここは実はStringらしい

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/cilium-networking/loadlbalancer-ip-pool.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/cilium-networking/loadlbalancer-ip-pool.yaml
@@ -7,4 +7,4 @@ spec:
   # 10.96.0.0-10.96.3.255 をloadBalancerのIPに割当可能
   - cidr: "10.96.0.0/22"
   # allowFirstLastIPs デフォルトの挙動が no -> yes になったので注意
-  allowFirstLastIPs: yes
+  allowFirstLastIPs: "Yes"


### PR DESCRIPTION
`Failed to compare desired state to live state: failed to calculate diff: error calculating structured merge diff: error building typed value from config resource: .spec.allowFirstLastIPs: expected string, got &value.valueUnstructured{Value:true}`