### PR TITLE
fix: download-seichiassist の apt-get update に -y を追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/sensor.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/sensor.yaml
@@ -71,6 +71,7 @@ spec:
                           mountPath: /work
                       command:
                         - "apt-get"
+                        - "-y"
                         - "update"
                         - "&&"
                         - "apt-get"


### PR DESCRIPTION
`E: The update command takes no arguments` と言われていたので追加しました