### PR TITLE
Revert "fix: download-seichiassist の apt-get update に -y を追加"

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/sensor.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/sensor.yaml
@@ -71,7 +71,6 @@ spec:
                           mountPath: /work
                       command:
                         - "apt-get"
-                        - "-y"
                         - "update"
                         - "&&"
                         - "apt-get"


### PR DESCRIPTION
Reverts GiganticMinecraft/seichi_infra#2208

関係なかったので Revert します