### PR TITLE
fix: minio にファイルをコピーするコマンドが間違っているのを修正

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/sensor.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/sensor.yaml
@@ -91,7 +91,7 @@ spec:
                       command: [sh, -c]
                       args: [
                         "mc alias set myminio http://seichi-private-plugin-blackhole-minio.minio:9000/ ${MINIO_ACCESS_KEY} ${MINIO_ACCESS_SECRET} && \
-                        mc cp SeichiAssist.jar myminio/seichiassist/{{ workflow.parameters.target-branch }}/SeichiAssist.jar"
+                        mc cp SeichiAssist.jar myminio/seichiassist/{{ workflow.parameters.target-branch }}"
                       ]
           parameters:
             - src:


### PR DESCRIPTION
`mc cp` コマンドではアップロードするオブジェクト名まで指定する必要がないらしいです