### PR TITLE
fix: BungeePortalのポータル設定のうち、ポータルが設置されているワールドが間違っているので修正

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-lobby/bungee-portals-config.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-lobby/bungee-portals-config.yaml
@@ -4,15 +4,15 @@ metadata:
   name: bungee-portals-config
 data:
   portals.yml: |
-    world#-2#68#0: debug-pr-{{ .Values.SeichiAssistPullRequestNumber }}-s1
-    world#-2#68#1: debug-pr-{{ .Values.SeichiAssistPullRequestNumber }}-s1
-    world#-2#69#0: debug-pr-{{ .Values.SeichiAssistPullRequestNumber }}-s1
-    world#-2#69#1: debug-pr-{{ .Values.SeichiAssistPullRequestNumber }}-s1
-    world#-1#69#0: debug-pr-{{ .Values.SeichiAssistPullRequestNumber }}-s1
-    world#-1#69#1: debug-pr-{{ .Values.SeichiAssistPullRequestNumber }}-s1
-    world#-1#68#1: debug-pr-{{ .Values.SeichiAssistPullRequestNumber }}-s1
-    world#-1#68#0: debug-pr-{{ .Values.SeichiAssistPullRequestNumber }}-s1
-    world#-1#70#1: debug-pr-{{ .Values.SeichiAssistPullRequestNumber }}-s1
-    world#-1#70#0: debug-pr-{{ .Values.SeichiAssistPullRequestNumber }}-s1
-    world#-2#70#0: debug-pr-{{ .Values.SeichiAssistPullRequestNumber }}-s1
-    world#-2#70#1: debug-pr-{{ .Values.SeichiAssistPullRequestNumber }}-s1
+    world_2#-2#68#0: debug-pr-{{ .Values.SeichiAssistPullRequestNumber }}-s1
+    world_2#-2#68#1: debug-pr-{{ .Values.SeichiAssistPullRequestNumber }}-s1
+    world_2#-2#69#0: debug-pr-{{ .Values.SeichiAssistPullRequestNumber }}-s1
+    world_2#-2#69#1: debug-pr-{{ .Values.SeichiAssistPullRequestNumber }}-s1
+    world_2#-1#69#0: debug-pr-{{ .Values.SeichiAssistPullRequestNumber }}-s1
+    world_2#-1#69#1: debug-pr-{{ .Values.SeichiAssistPullRequestNumber }}-s1
+    world_2#-1#68#1: debug-pr-{{ .Values.SeichiAssistPullRequestNumber }}-s1
+    world_2#-1#68#0: debug-pr-{{ .Values.SeichiAssistPullRequestNumber }}-s1
+    world_2#-1#70#1: debug-pr-{{ .Values.SeichiAssistPullRequestNumber }}-s1
+    world_2#-1#70#0: debug-pr-{{ .Values.SeichiAssistPullRequestNumber }}-s1
+    world_2#-2#70#0: debug-pr-{{ .Values.SeichiAssistPullRequestNumber }}-s1
+    world_2#-2#70#1: debug-pr-{{ .Values.SeichiAssistPullRequestNumber }}-s1


### PR DESCRIPTION
ロビーサーバーにある最初にスポーンするワールドの名前は「world」ではなくて「world_2」
