### PR TITLE
deps: bump babyrite v0.12.0

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/babyrite/babyrite-config.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/babyrite/babyrite-config.yaml
@@ -8,18 +8,27 @@ kind: ConfigMap
 metadata:
   name: babyrite-config
 data:
-  config.yaml: |
+  config.toml: |
     ### babyrite configuration ###
+    # This file is used to configure babyrite.
+    # You can change the settings here to customize babyrite's behavior.
+    # For more information, see the babyrite documentation at https://babyrite.m1sk9.dev/configuration.html
 
-    # Sets whether the guild check process is bypassed when quoting.
-    # If the guild check process is bypassed, messages can be shared and quoted from all guilds in which babyrite is installed.
-    # However, the message will be shared to members who do not belong to that guild. This setting is recommended when babyrite is used by multiple private guilds.
-    bypass_guilds: false
-
-    # Whether to enable mentions in quoted messages.
-    citation_mention: false
+    ## == General settings == ##
 
     # Sets the format of babyrite log output.
     # * `compact`: output logs in normal format.
     # * `json`: Output logs in JSON format. This is the recommended setting if you are using Grafana Loki or similar.
-    logger_format: 'json'
+    logger_format='json'
+
+    ## == Preview settings == ##
+
+    [preview]
+
+    # Sets whether the guild check process is bypassed when quoting.
+    # If the guild check process is bypassed, messages can be shared and quoted from all guilds in which babyrite is installed.
+    # However, the message will be shared to members who do not belong to that guild. This setting is recommended when babyrite is used by multiple private guilds.
+    bypass_guild_check=false
+
+    # Whether to enable mentions in quoted messages.
+    is_mention=false

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/babyrite/babyrite.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/babyrite/babyrite.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: babyrite
-          image: ghcr.io/m1sk9/babyrite:v0.11.1
+          image: ghcr.io/m1sk9/babyrite:v0.12.0
           resources:
             requests:
               cpu: 250m
@@ -31,7 +31,7 @@ spec:
           env:
               # 相対パスを指定する
             - name: CONFIG_FILE_PATH
-              value: "config/config.yaml"
+              value: "config/config.toml"
             - name: DISCORD_API_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
ref: https://github.com/m1sk9/babyrite/issues/220

`serde_yaml` 非推奨に伴い, serde がメンテナンスしている `toml` ( `serde_toml` ) に切り替えました. 

v0.11.0 はサポートを打ち切っています.

https://babyrite.m1sk9.dev/changelog.html#v0120