### PR TITLE
fix: `babyrite-config-volume` mount path

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/babyrite/babyrite.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/babyrite/babyrite.yaml
@@ -27,7 +27,7 @@ spec:
               memory: 32Mi
           volumeMounts:
             - name: babyrite-config-volume
-              mountPath: /home/babyrite/config
+              mountPath: /config
           env:
               # 相対パスを指定する
             - name: CONFIG_FILE_PATH


### PR DESCRIPTION
https://github.com/m1sk9/babyrite/blob/7aa11624bd8def06d903c72ba98501316113f7e8/Dockerfile#L8-L12

v0.13.0 で Docker Image で使用する Runner Image を `gcr.io/distroless/cc-debian12` に変更した際, 実行ファイルをルートディレクトリ上に配置するよう Dockerfile を書き換えたため, `babyrite-config-volume` のパスが不正になっていました