### PR TITLE
feat: update itzg/bungeecord from `java17-2022.4.1` to `java17-2024.6.0`

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/minecraft-gateway-bungeecord/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/minecraft-gateway-bungeecord/deployment.yaml
@@ -86,7 +86,7 @@ spec:
               value: >-
                 -javaagent:/jmx-exporter/jmx-exporter-javaagent.jar=18321:/jmx-exporter/jmx-exporter-config.yaml
 
-          image: itzg/bungeecord:java17-2022.4.1
+          image: itzg/bungeecord:java17-2024.6.0
           name: bungeecord
           ports:
             - containerPort: 25577


### PR DESCRIPTION
内部で使用しているBungeecordをダウンロードするPaperMCのAPIが変更され、サーバが起動しなくなってしまったため、ひとまずitzg/bungeecordのバージョン更新を試みる。