### PR TITLE
fix: use `itzg/mc-proxy:java21`

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/minecraft-gateway-bungeecord/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/minecraft-gateway-bungeecord/deployment.yaml
@@ -86,7 +86,7 @@ spec:
               value: >-
                 -javaagent:/jmx-exporter/jmx-exporter-javaagent.jar=18321:/jmx-exporter/jmx-exporter-config.yaml
 
-          image: itzg/mc-proxy:java21-2024.6.0
+          image: itzg/mc-proxy:java21
           name: bungeecord
           ports:
             - containerPort: 25577


### PR DESCRIPTION
`java21-2024.6.0`だと、古いAPIを参照しているため、ひとまずリリース番号を外す