### PR TITLE
Revert "chore(deps): update ghcr.io/giganticminecraft/seichi_minecraft_server_base:1.0.0-java17-jdk docker digest to 627736a"

### DIFF
--- a/docker-images/mcservers/debug/seichi-servers/base-images/1_18_2/Dockerfile
+++ b/docker-images/mcservers/debug/seichi-servers/base-images/1_18_2/Dockerfile
@@ -1,5 +1,5 @@
 FROM ghcr.io/giganticminecraft/chunk-search-rs:sha-74140b1 as chunk-search-provider
-FROM ghcr.io/giganticminecraft/seichi_minecraft_server_base:1.0.0-java17-jdk@sha256:627736a353740a50c6a319a1eb8dd04d77b252e57993bfb1fd5088bfc4b00e0e
+FROM ghcr.io/giganticminecraft/seichi_minecraft_server_base:1.0.0-java17-jdk@sha256:d47cadf56eebde3d7174f7a05ed98bf12cb1c6ab30c0961bfa7ebb619a9c6910
 
 ENV VERSION="1.18.2"
 


### PR DESCRIPTION
Reverts GiganticMinecraft/seichi_infra#2388

`mcserver--debug--pr-2115` で paper の jar ファイルを取得できない原因の切り分けのために、一旦 revert します