### PR TITLE
fix: use UUID for WG member

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
@@ -174,9 +174,9 @@ spec:
                 mv gamerule doInsomnia false world_SW_nether
                 mv gamerule doInsomnia false world_SW_the_end
                 mvm set difficulty peaceful world_2
-                rg addmember -w world_2 __global__ unchama
+                rg addmember -w world_2 __global__ b66cc3f6-a045-42ad-b4b8-320f20caf140
                 rg flag -w world_2 __global__ build -g members allow
-                rg addmember -w world_SW_2 __global__ unchama
+                rg addmember -w world_SW_2 __global__ b66cc3f6-a045-42ad-b4b8-320f20caf140
                 rg flag -w world_SW_2 __global__ build -g members allow
                 rg flag -w world_SW_the_end __global__ deny-spawn ENDER_DRAGON
                 lp group default permission set multiverse.core.list.who true


### PR DESCRIPTION
unchamaさんをメインワールドや第2整地の`__global__`保護のメンバーに追加するコマンドをサーバ起動時に実行するが、プレイヤー名をUUIDに変換する処理が行えない（*）ので、UUIDを直接指定する
*: Failed to add new members: Unable to resolve the names