### PR TITLE
fix: set random false in AutoMessage config

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/common-configs/plugin-configs.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/common-configs/plugin-configs.yaml
@@ -1541,7 +1541,7 @@ data:
 
   AutoMessage-config.yml: |
     timer: 300 # default: 10
-    Random: true # default: false
+    Random: false
     UseTellRawMessages: false
     Messages:
     - '&6[Tips]&f岩盤までぶち抜いた後&eY5&fにハーフブロックを敷く文化があるらしい。'


### PR DESCRIPTION
AutoMessageの設定ファイル中の`random`は、時間が来たときにメッセージを表示するかどうかをランダムに決めるかどうかを示すものであり、どのメッセージを表示させるかをランダムにするものではないっぽい。