### PR TITLE
`/hub`コマンドを`/server`コマンドのエイリアスとして設定することはできなかったのでrevertする

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/common-configs/mcserver-configs.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/common-configs/mcserver-configs.yaml
@@ -644,5 +644,3 @@ data:
       - version $1-
       spawn:
       - originspawn
-      hub:
-      - server debug-pr-2115-lobby


### PR DESCRIPTION
Reverts #2440.

See: https://github.com/GiganticMinecraft/SeichiAssist-ExternalLib/issues/192