### PR TITLE
fix: fix hub name in BungeeHubCommand

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-gateway/bungeecord/bungeecord-plugin-configs-patch.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-gateway/bungeecord/bungeecord-plugin-configs-patch.yaml
@@ -4,7 +4,7 @@ metadata:
   name: bungeecord-plugin-configs
 data:
   BungeeHubCommand-config.yml: |
-    hub-server-name: deb-s1
+    hub-server-name: debug-pr-2115-lobby
     already-connected-message: "You are already at the hub server!"
 
   BungeeKick-config.yml: |


### PR DESCRIPTION
すみません、BungeeHubCommandではなくてBungeeKickの設定を編集していました..。
ref. #2443, [GiganticMinecraft/SeichiAssist-ExternalLibs#192](https://github.com/GiganticMinecraft/SeichiAssist-ExternalLib/issues/192)