### PR TITLE
fix: mariadb の設定に bind-address の設定を追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mariadb/mariadb.yaml
@@ -29,6 +29,7 @@ spec:
 
   myCnf: |
     [mariadb]
+    bind-address=*
     innodb_buffer_pool_size = 1G
     innodb_log_file_size = 256M
     innodb_flush_log_at_trx_commit = 2


### PR DESCRIPTION
https://github.com/mariadb-operator/mariadb-operator/blob/a0bc88ae6ca26e85f5183b87bf144bb2438cff99/docs/CONFIGURATION.md?plain=1#L30 

mcserver--debug-s1 から mariadb に接続できない問題の改善を試みています