### PR TITLE
chore: seichi-debug-minecraft の mariadb の tsl を無効化する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mariadb/mariadb.yaml
@@ -4,6 +4,8 @@ metadata:
   namespace: seichi-debug-minecraft
   name: mariadb
 spec:
+  tls:
+    enabled: false
   rootPasswordSecretKeyRef:
     name: mariadb
     generate: false


### PR DESCRIPTION
https://github.com/mariadb-operator/mariadb-operator/blob/a0bc88ae6ca26e85f5183b87bf144bb2438cff99/docs/TLS.md#mariadb-configuration