### PR TITLE
fix: initContainers -> initContianer

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
@@ -29,7 +29,7 @@ spec:
                     operator: In
                     values:
                       - seichi-onp-k8s-wk-1 # CPUの多いwk-1だけにスケジュールする
-      initContainers:
+      initContainer:
         - name: jmx-exporter-downloader
           image: busybox:1.37.0
           env:


### PR DESCRIPTION
`initContainer` でした
https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/API_REFERENCE.md#resourcerequirements