### PR TITLE
fix: debug-minecraft の mariadb の initContainer 指定を直す

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mariadb/mariadb.yaml
@@ -4,7 +4,7 @@ metadata:
   namespace: seichi-debug-minecraft
   name: mariadb
 spec:
-  initContainer:
+  initContainers:
   - name: init-0
     image: mariadb:10.11.11
     imagePullPolicy: IfNotPresent


### PR DESCRIPTION
https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/API_REFERENCE.md#mariadbspec

`initContainers` でした