### PR TITLE
fix: volumeMounts を削除

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mariadb/mariadb.yaml
@@ -108,10 +108,6 @@ spec:
     serviceMonitor:
       prometheusRelease: prometheus
 
-  volumeMounts:
-  - name: sqldump-volume
-    mountPath: /
-
   volumes:
   # 本番サーバーからもってきた sqldump をマウントするためのボリューム
   - name: sqldump-volume


### PR DESCRIPTION
https://github.com/mariadb-operator/mariadb-operator/blob/a0bc88ae6ca26e85f5183b87bf144bb2438cff99/examples/manifests/mariadb_init_and_sidecar.yaml#L49 によるとデフォルトで全てのボリュームがマウントされているらしい