### PR TITLE
fix: Fix download link 

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/minecraft-gateway-bungeecord/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/minecraft-gateway-bungeecord/deployment.yaml
@@ -68,17 +68,15 @@ spec:
               #   https://github.com/ProxioDev/RedisBungee/releases/download/0.6.5/RedisBungee-0.6.5.jar
               # bungeecord-prometheus-exporter:
               #   https://github.com/weihao/bungeecord-prometheus-exporter/releases/download/3.1.5/bungeecord-prometheus-exporter-3.1.5.jar
+              # MagicMOTD:
+              #   https://github.com/obfuscatedgenerated/MagicMOTD/releases/download/1.1.0/MagicMOTD-v1.1.0.jar
               value: >-
                 https://github.com/GiganticMinecraft/BungeeKick/releases/download/release-at-bdbef2f162815b6805aaf7379c213136a077cf04/bungeekick-1.3.jar,
                 https://github.com/GiganticMinecraft/BungeeHubCommand/releases/download/release-at-4c5449d8aecf6bf5a6b810fb85a1bfa75c0fd03f/bungeehubcommand-1.jar,
                 https://github.com/GiganticMinecraft/BungeeSemaphore/releases/download/release-at-9eb31735e2406785ad4be27a1dfd5401663a7fe9/BungeeSemaphore.jar,
                 https://github.com/ProxioDev/RedisBungee/releases/download/0.6.5/RedisBungee-0.6.5.jar,
                 https://github.com/weihao/bungeecord-prometheus-exporter/releases/download/3.1.5/bungeecord-prometheus-exporter-3.1.5.jar
-
-            # MagicMOTD:
-            #   https://www.spigotmc.org/resources/magicmotd.110063/
-            - name: SPIGET_PLUGINS
-              value: 110063
+                https://github.com/obfuscatedgenerated/MagicMOTD/releases/download/1.1.0/MagicMOTD-v1.1.0.jar
 
             - name: JVM_OPTS
               value: >-


### PR DESCRIPTION
github.com の HTML を .jar って名前送りつけてごめん (2)
(ダウンロード先のリンクを修正します)