### PR TITLE
fix: disable spawn-protection

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/common-configs/mcserver-configs.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/common-configs/mcserver-configs.yaml
@@ -447,7 +447,7 @@ data:
     text-filtering-config=
     spawn-monsters=true
     enforce-whitelist=false
-    spawn-protection=16
+    spawn-protection=0
     resource-pack-sha1=
     max-world-size=29999984
 


### PR DESCRIPTION
https://docs.papermc.io/paper/reference/server-properties
1.12.2では、spawn-protection は無効化されている。