### PR TITLE
fix: redisbungee-redis の auth.usePasswordFiles を false にする

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-gateway/bungeecord/redisbungee-redis.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-gateway/bungeecord/redisbungee-redis.yaml
@@ -16,6 +16,7 @@ spec:
         architecture: standalone
         auth:
           enabled: false
+          usePasswordFiles: false
         commonConfiguration: |-
           notify-keyspace-events "Eg$x"
         master:


### PR DESCRIPTION
https://github.com/bitnami/charts/pull/32117 によると、2.10.0 から `usePasswordFiles` のデフォルト値が `true` になったらしく、その影響か redis が起動しなくなったので一度 `false` にしてみます