### PR TITLE
Revert "chore(deps): update registry-1.docker.io/bitnamicharts/redis docker tag to v20.10.0"

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-gateway/bungeecord/bungeesemaphore-redis.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-gateway/bungeecord/bungeesemaphore-redis.yaml
@@ -9,7 +9,7 @@ spec:
     chart: redis
     repoURL: 'registry-1.docker.io/bitnamicharts'
     path: 'redis'
-    targetRevision: 20.10.0
+    targetRevision: 20.9.0
     helm:
       releaseName: seichi-debug-bungeesemaphore-redis
       values: |

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-gateway/bungeecord/redisbungee-redis.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-gateway/bungeecord/redisbungee-redis.yaml
@@ -9,7 +9,7 @@ spec:
     chart: redis
     repoURL: 'registry-1.docker.io/bitnamicharts'
     path: 'redis'
-    targetRevision: 20.10.0
+    targetRevision: 20.9.0
     helm:
       releaseName: seichi-debug-redisbungee-redis
       values: |

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/redis/bungeesemaphore-redis.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/redis/bungeesemaphore-redis.yaml
@@ -9,7 +9,7 @@ spec:
     chart: redis
     repoURL: 'registry-1.docker.io/bitnamicharts'
     path: 'redis'
-    targetRevision: 20.10.0
+    targetRevision: 20.9.0
     helm:
       releaseName: seichi-bungeesemaphore-redis
       values: |

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/redis/redisbungee-redis.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/redis/redisbungee-redis.yaml
@@ -9,7 +9,7 @@ spec:
     chart: redis
     repoURL: 'registry-1.docker.io/bitnamicharts'
     path: 'redis'
-    targetRevision: 20.10.0
+    targetRevision: 20.9.0
     helm:
       releaseName: seichi-redisbungee-redis
       values: |


### PR DESCRIPTION
Reverts GiganticMinecraft/seichi_infra#2572

https://github.com/GiganticMinecraft/seichi_infra/pull/2577 これでも上がってこず、原因がわからないので一度 revert します