### PR TITLE
fix: renovate が mcserver_base_image を更新しないのを修正

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,7 +38,7 @@
     {
       "fileMatch": ["^.github/workflows/build_mcserver_base_images.yaml$"],
       "matchStrings": [
-        "- mcserver_base_image_tag: (?<currentValue>.*)\n\\s+mcserver_base_image_digest: \"(?<currentDigest>sha256:[a-f0-9]+)\""
+        "- mcserver_base_image_tag: (?<currentValue>.*)\\n\\s+mcserver_base_image_digest: \\\"(?<currentDigest>sha256:[a-f0-9]+)\\\""
       ],
       "depNameTemplate": "itzg/minecraft-server",
       "extractVersionTemplate": "^(?<version>\\d+\\.\\d+\\.\\d+)-.*",


### PR DESCRIPTION
エスケープが足りていなく、json としてパースした後に正しい正規表現となっていないため、 mcserver_base_image が更新されていない？