### PR TITLE
fix: s1 の coreprotect で使用する mysql のポートの環境変数を文字列として渡す

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
@@ -167,7 +167,7 @@ spec:
               value: mariadb
 
             - name: CFG_REPLACEMENT__COREPROTECT_MYSQL_PORT
-              value: 3306
+              value: "3306"
 
             - name: CFG_REPLACEMENT__COREPROTECT_MYSQL_USER
               value: root


### PR DESCRIPTION
数値として認識されてうまく読み込んでくれなかった