### PR TITLE
fix: mod-downloader から配置されるプラグインを /data/plugins に配置する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
@@ -256,7 +256,7 @@ spec:
               subPath: jmx-exporter-javaagent.jar
 
             - name: mod-downloader-volume
-              mountPath: /plugins
+              mountPath: /data/plugins
 
             - name: worldedit-schematica-volume
               mountPath: /worldedit-schematica


### PR DESCRIPTION
`/plugins` ディレクトリには上位イメージですでに config ファイルが含まれているが、そこに mod-downloader のボリュームをマウントすることでデータが消えている？