### PR TITLE
fix: redisbungge/bunmgeesemaphore の接続先情報が間違っているのを修正

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
@@ -135,13 +135,13 @@ spec:
                   key: SEICHIASSIST_S1_WEBHOOK_URL
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_REDISBUNGEE_REDIS_HOST
-              value: seichi-redisbungee-redis-master.seichi-gateway
+              value: seichi-redisbungee-redis-master
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_REDISBUNGEE_REDIS_PORT
               value: "6379"
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_BUNGEESEMAPHORE_RESPONDER_REDIS_HOST
-              value: seichi-bungeesemaphore-redis-master.seichi-gateway
+              value: seichi-bungeesemaphore-redis-master
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_BUNGEESEMAPHORE_RESPONDER_REDIS_PORT
               value: "6379"


### PR DESCRIPTION
`seichi-minecraft` 内にいるらしい