### PR TITLE
fix: s1 の volumeClaimTemplates に apiVersion と kind を指定

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
@@ -297,8 +297,9 @@ spec:
         - name: worldedit-schematica-volume
           emptyDir: {}
   volumeClaimTemplates:
-    - metadata:
-        name: minecraft-server-data
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
       spec:
         accessModes:
           - ReadWriteOnce


### PR DESCRIPTION
ArgoCD 上で out of sync になり続けていて、Diff を見ると差分が出ているのでその影響？
関係なさそうだったら revert します
