### PR TITLE
chore: renovate に packageName:sha- 形式のイメージを検知させる

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,12 @@
       "groupName": "terraform packages",
       "enabled": true,
       "schedule": ["at any time"]
+    },
+    {
+      "matchPackagePatterns": [
+        "^ghcr.io/giganticminecraft/.+$"
+      ],
+      "versioning": "loose"
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
renovate は `:sha-410bcbb` のようなバージョニングのイメージを標準だと検知してくれないようで、GiganticMinecraft のイメージはこのようなバージョニングを持つものが多いので検知されるようにしました。