### PR TITLE
Adjust SyncWindows for Minecraft server resources

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/projects.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/projects.yaml
@@ -205,3 +205,15 @@ spec:
   clusterResourceWhitelist:
     - group: "*"
       kind: "*"
+  syncWindows:
+    # 朝4時〜実行しているバックアップの際に kubectl patch で replicas に干渉しているので
+    # selfHeal の実行される時間を制限しておく (デバッグでの実行も想定し長めに指定)
+    - kind: allow
+      schedule: "00 7 * * *" # 7:00 から
+      duration: 1h           # 1時間 selfHeal を有効化
+      applications: ["*"]
+      manualSync: false
+    - kind: deny
+      schedule: "00 8 * * *" # 毎日 8:00 から
+      duration: 23h          # 23時間 selfHeal を無効化
+      applications: ["*"]


### PR DESCRIPTION
Modify SyncWindows settings to manage selfHeal execution times, preventing interference during scheduled backups.