### PR TITLE
base-server-image の additional-plugin-list から ViaBackwards と ViaVersion を 削除

### DIFF
--- a/docker-images/mcservers/base-server-image/common-plugin-list.ini
+++ b/docker-images/mcservers/base-server-image/common-plugin-list.ini
@@ -3,9 +3,3 @@ https://github.com/DiscordSRV/DiscordSRV/releases/download/v1.26.2/DiscordSRV-Bu
 
 # LunaChat
 https://github.com/ucchyocean/LunaChat/releases/download/v3.0.16/LunaChat.jar
-
-# ViaBackwards
-https://github.com/ViaVersion/ViaBackwards/releases/download/4.4.2/ViaBackwards-4.4.2.jar
-
-# ViaVersion
-https://github.com/ViaVersion/ViaVersion/releases/download/4.4.2/ViaVersion-4.4.2.jar

--- a/docker-images/mcservers/production/lobby/additional-plugin-list.ini
+++ b/docker-images/mcservers/production/lobby/additional-plugin-list.ini
@@ -1,0 +1,5 @@
+# ViaBackwards
+https://github.com/ViaVersion/ViaBackwards/releases/download/4.4.2/ViaBackwards-4.4.2.jar
+
+# ViaVersion
+https://github.com/ViaVersion/ViaVersion/releases/download/4.4.2/ViaVersion-4.4.2.jar


### PR DESCRIPTION
base-image を使用するすべてのマインクラフトサーバーが必要としているプラグインではない