### PR TITLE
Add jmx-remote configuration to Minecraft server manifests

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-lobby/lobby-server.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-lobby/lobby-server.yaml
@@ -105,6 +105,12 @@ spec:
             - name: JVM_OPTS
               value: >-
                 -javaagent:/jmx-exporter/jmx-exporter-javaagent.jar=18321:/jmx-exporter/jmx-exporter-config.yaml
+                -Dcom.sun.management.jmxremote
+                -Dcom.sun.management.jmxremote.port=32000
+                -Dcom.sun.management.jmxremote.rmi.port=32000
+                -Dcom.sun.management.jmxremote.authenticate=false
+                -Dcom.sun.management.jmxremote.ssl=false
+                -Dcom.sun.management.jmxremote.local.only=false
 
             - name: COPY_CONFIG_DEST
               # /config をサーバーディレクトリにコピーするようにする
@@ -154,6 +160,8 @@ spec:
               name: jmx-metrics
             - containerPort: 9225
               name: mc-metrics
+            - containerPort: 32000
+              name: jmx-remote
 
           startupProbe:
             tcpSocket:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-lobby/service.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-lobby/service.yaml
@@ -21,5 +21,9 @@ spec:
       port: 9225
       protocol: TCP
       targetPort: mc-metrics
+    - name: jmx-remote
+      port: 32000
+      protocol: TCP
+      targetPort: jmx-remote
   selector:
     mcserver: debug-lobby

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
@@ -117,6 +117,12 @@ spec:
                 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:SurvivorRatio=32 -XX:+PerfDisableSharedMem 
                 -XX:MaxTenuringThreshold=1 -Dusing.aikars.flags=https://mcflags.emc.gs 
                 -Daikars.new.flags=true
+                -Dcom.sun.management.jmxremote
+                -Dcom.sun.management.jmxremote.port=32000
+                -Dcom.sun.management.jmxremote.rmi.port=32000
+                -Dcom.sun.management.jmxremote.authenticate=false
+                -Dcom.sun.management.jmxremote.ssl=false
+                -Dcom.sun.management.jmxremote.local.only=false
 
             - name: COPY_CONFIG_DEST
               # /config をサーバーディレクトリにコピーするようにする
@@ -191,6 +197,8 @@ spec:
               name: jmx-metrics
             - containerPort: 9225
               name: mc-metrics
+            - containerPort: 32000
+              name: jmx-remote
 
           startupProbe:
             tcpSocket:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/service.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/service.yaml
@@ -21,5 +21,9 @@ spec:
       port: 9225
       protocol: TCP
       targetPort: mc-metrics
+    - name: jmx-remote
+      port: 32000
+      protocol: TCP
+      targetPort: jmx-remote
   selector:
     mcserver: debug-s1

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/cilium-networking/bgp-peering-policy.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/cilium-networking/bgp-peering-policy.yaml
@@ -9,7 +9,7 @@ spec:
       kubernetes.io/hostname: seichi-onp-k8s-cp-1
   virtualRouters:
   - localASN: 65201
-    exportPodCIDR: true
+    exportPodCIDR: false
     # 全てのServiceIPとLoadBalancerIPを広報するためのおまじない的なserviceSelector
     # https://docs.cilium.io/en/stable/network/bgp-control-plane/#service-announcements
     serviceSelector:
@@ -17,6 +17,7 @@ spec:
         - {key: somekey, operator: NotIn, values: ['never-used-value']}
     serviceAdvertisements:
       - LoadBalancerIP
+      - ClusterIP
     neighbors:
     - peerAddress: "192.168.3.254/32"
       peerASN: 65184
@@ -39,7 +40,7 @@ spec:
       kubernetes.io/hostname: seichi-onp-k8s-cp-2
   virtualRouters:
   - localASN: 65202
-    exportPodCIDR: true
+    exportPodCIDR: false
     # 全てのServiceIPとLoadBalancerIPを広報するためのおまじない的なserviceSelector
     # https://docs.cilium.io/en/stable/network/bgp-control-plane/#service-announcements
     serviceSelector:
@@ -47,6 +48,7 @@ spec:
         - {key: somekey, operator: NotIn, values: ['never-used-value']}
     serviceAdvertisements:
       - LoadBalancerIP
+      - ClusterIP
     neighbors:
     - peerAddress: "192.168.3.254/32"
       peerASN: 65184
@@ -69,7 +71,7 @@ spec:
       kubernetes.io/hostname: seichi-onp-k8s-cp-3
   virtualRouters:
   - localASN: 65203
-    exportPodCIDR: true
+    exportPodCIDR: false
     # 全てのServiceIPとLoadBalancerIPを広報するためのおまじない的なserviceSelector
     # https://docs.cilium.io/en/stable/network/bgp-control-plane/#service-announcements
     serviceSelector:
@@ -77,6 +79,7 @@ spec:
         - {key: somekey, operator: NotIn, values: ['never-used-value']}
     serviceAdvertisements:
       - LoadBalancerIP
+      - ClusterIP
     neighbors:
     - peerAddress: "192.168.3.254/32"
       peerASN: 65184
@@ -99,7 +102,7 @@ spec:
       kubernetes.io/hostname: seichi-onp-k8s-wk-1
   virtualRouters:
   - localASN: 65301
-    exportPodCIDR: true
+    exportPodCIDR: false
     # 全てのServiceIPとLoadBalancerIPを広報するためのおまじない的なserviceSelector
     # https://docs.cilium.io/en/stable/network/bgp-control-plane/#service-announcements
     serviceSelector:
@@ -107,6 +110,7 @@ spec:
         - {key: somekey, operator: NotIn, values: ['never-used-value']}
     serviceAdvertisements:
       - LoadBalancerIP
+      - ClusterIP
     neighbors:
     - peerAddress: "192.168.3.254/32"
       peerASN: 65184
@@ -129,7 +133,7 @@ spec:
       kubernetes.io/hostname: seichi-onp-k8s-wk-2
   virtualRouters:
   - localASN: 65302
-    exportPodCIDR: true
+    exportPodCIDR: false
     # 全てのServiceIPとLoadBalancerIPを広報するためのおまじない的なserviceSelector
     # https://docs.cilium.io/en/stable/network/bgp-control-plane/#service-announcements
     serviceSelector:
@@ -137,6 +141,7 @@ spec:
         - {key: somekey, operator: NotIn, values: ['never-used-value']}
     serviceAdvertisements:
       - LoadBalancerIP
+      - ClusterIP
     neighbors:
     - peerAddress: "192.168.3.254/32"
       peerASN: 65184
@@ -159,7 +164,7 @@ spec:
       kubernetes.io/hostname: seichi-onp-k8s-wk-3
   virtualRouters:
   - localASN: 65303
-    exportPodCIDR: true
+    exportPodCIDR: false
     # 全てのServiceIPとLoadBalancerIPを広報するためのおまじない的なserviceSelector
     # https://docs.cilium.io/en/stable/network/bgp-control-plane/#service-announcements
     serviceSelector:
@@ -167,6 +172,7 @@ spec:
         - {key: somekey, operator: NotIn, values: ['never-used-value']}
     serviceAdvertisements:
       - LoadBalancerIP
+      - ClusterIP
     neighbors:
     - peerAddress: "192.168.3.254/32"
       peerASN: 65184

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/service.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/service.yaml
@@ -21,5 +21,9 @@ spec:
       port: 9225
       protocol: TCP
       targetPort: mc-metrics
+    - name: jmx-remote
+      port: 32000
+      protocol: TCP
+      targetPort: jmx-remote
   selector:
     mcserver: debug-s1

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
@@ -108,6 +108,12 @@ spec:
                 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:SurvivorRatio=32 -XX:+PerfDisableSharedMem 
                 -XX:MaxTenuringThreshold=1 -Dusing.aikars.flags=https://mcflags.emc.gs 
                 -Daikars.new.flags=true
+                -Dcom.sun.management.jmxremote
+                -Dcom.sun.management.jmxremote.port=32000
+                -Dcom.sun.management.jmxremote.rmi.port=32000
+                -Dcom.sun.management.jmxremote.authenticate=false
+                -Dcom.sun.management.jmxremote.ssl=false
+                -Dcom.sun.management.jmxremote.local.only=false
 
             - name: COPY_CONFIG_DEST
               # /config をサーバーディレクトリにコピーするようにする
@@ -210,6 +216,8 @@ spec:
               name: jmx-metrics
             - containerPort: 9225
               name: mc-metrics
+            - containerPort: 32000
+              name: jmx-remote
 
           startupProbe:
             tcpSocket:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/service.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/service.yaml
@@ -21,5 +21,9 @@ spec:
       port: 9225
       protocol: TCP
       targetPort: mc-metrics
+    - name: jmx-remote
+      port: 32000
+      protocol: TCP
+      targetPort: jmx-remote
   selector:
     mcserver: lobby

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/service.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/service.yaml
@@ -21,5 +21,9 @@ spec:
       port: 9225
       protocol: TCP
       targetPort: mc-metrics
+    - name: jmx-remote
+      port: 32000
+      protocol: TCP
+      targetPort: jmx-remote
   selector:
     mcserver: s1

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
@@ -94,6 +94,12 @@ spec:
                 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:SurvivorRatio=32 -XX:+PerfDisableSharedMem 
                 -XX:MaxTenuringThreshold=1 -Dusing.aikars.flags=https://mcflags.emc.gs 
                 -Daikars.new.flags=true
+                -Dcom.sun.management.jmxremote
+                -Dcom.sun.management.jmxremote.port=32000
+                -Dcom.sun.management.jmxremote.rmi.port=32000
+                -Dcom.sun.management.jmxremote.authenticate=false
+                -Dcom.sun.management.jmxremote.ssl=false
+                -Dcom.sun.management.jmxremote.local.only=false
 
             - name: COPY_CONFIG_DEST
               # /config をサーバーディレクトリにコピーするようにする
@@ -244,6 +250,8 @@ spec:
               name: jmx-metrics
             - containerPort: 9225
               name: mc-metrics
+            - containerPort: 32000
+              name: jmx-remote
 
           startupProbe:
             tcpSocket:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/service.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/service.yaml
@@ -21,5 +21,9 @@ spec:
       port: 9225
       protocol: TCP
       targetPort: mc-metrics
+    - name: jmx-remote
+      port: 32000
+      protocol: TCP
+      targetPort: jmx-remote
   selector:
     mcserver: s2

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/stateful-set.yaml
@@ -94,6 +94,12 @@ spec:
                 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:SurvivorRatio=32 -XX:+PerfDisableSharedMem 
                 -XX:MaxTenuringThreshold=1 -Dusing.aikars.flags=https://mcflags.emc.gs 
                 -Daikars.new.flags=true
+                -Dcom.sun.management.jmxremote
+                -Dcom.sun.management.jmxremote.port=32000
+                -Dcom.sun.management.jmxremote.rmi.port=32000
+                -Dcom.sun.management.jmxremote.authenticate=false
+                -Dcom.sun.management.jmxremote.ssl=false
+                -Dcom.sun.management.jmxremote.local.only=false
 
             - name: COPY_CONFIG_DEST
               # /config をサーバーディレクトリにコピーするようにする
@@ -244,6 +250,8 @@ spec:
               name: jmx-metrics
             - containerPort: 9225
               name: mc-metrics
+            - containerPort: 32000
+              name: jmx-remote
 
           startupProbe:
             tcpSocket:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/service.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/service.yaml
@@ -21,5 +21,9 @@ spec:
       port: 9225
       protocol: TCP
       targetPort: mc-metrics
+    - name: jmx-remote
+      port: 32000
+      protocol: TCP
+      targetPort: jmx-remote
   selector:
     mcserver: s3

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/stateful-set.yaml
@@ -94,6 +94,12 @@ spec:
                 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:SurvivorRatio=32 -XX:+PerfDisableSharedMem 
                 -XX:MaxTenuringThreshold=1 -Dusing.aikars.flags=https://mcflags.emc.gs 
                 -Daikars.new.flags=true
+                -Dcom.sun.management.jmxremote
+                -Dcom.sun.management.jmxremote.port=32000
+                -Dcom.sun.management.jmxremote.rmi.port=32000
+                -Dcom.sun.management.jmxremote.authenticate=false
+                -Dcom.sun.management.jmxremote.ssl=false
+                -Dcom.sun.management.jmxremote.local.only=false
 
             - name: COPY_CONFIG_DEST
               # /config をサーバーディレクトリにコピーするようにする
@@ -244,6 +250,8 @@ spec:
               name: jmx-metrics
             - containerPort: 9225
               name: mc-metrics
+            - containerPort: 32000
+              name: jmx-remote
 
           startupProbe:
             tcpSocket:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/service.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/service.yaml
@@ -21,5 +21,9 @@ spec:
       port: 9225
       protocol: TCP
       targetPort: mc-metrics
+    - name: jmx-remote
+      port: 32000
+      protocol: TCP
+      targetPort: jmx-remote
   selector:
     mcserver: s5

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
@@ -94,6 +94,12 @@ spec:
                 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:SurvivorRatio=32 -XX:+PerfDisableSharedMem 
                 -XX:MaxTenuringThreshold=1 -Dusing.aikars.flags=https://mcflags.emc.gs 
                 -Daikars.new.flags=true
+                -Dcom.sun.management.jmxremote
+                -Dcom.sun.management.jmxremote.port=32000
+                -Dcom.sun.management.jmxremote.rmi.port=32000
+                -Dcom.sun.management.jmxremote.authenticate=false
+                -Dcom.sun.management.jmxremote.ssl=false
+                -Dcom.sun.management.jmxremote.local.only=false
 
             - name: COPY_CONFIG_DEST
               # /config をサーバーディレクトリにコピーするようにする
@@ -229,6 +235,8 @@ spec:
               name: jmx-metrics
             - containerPort: 9225
               name: mc-metrics
+            - containerPort: 32000
+              name: jmx-remote
 
           startupProbe:
             tcpSocket:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/service.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/service.yaml
@@ -21,5 +21,9 @@ spec:
       port: 9225
       protocol: TCP
       targetPort: mc-metrics
+    - name: jmx-remote
+      port: 32000
+      protocol: TCP
+      targetPort: jmx-remote
   selector:
     mcserver: s7

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/stateful-set.yaml
@@ -94,6 +94,12 @@ spec:
                 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:SurvivorRatio=32 -XX:+PerfDisableSharedMem 
                 -XX:MaxTenuringThreshold=1 -Dusing.aikars.flags=https://mcflags.emc.gs 
                 -Daikars.new.flags=true
+                -Dcom.sun.management.jmxremote
+                -Dcom.sun.management.jmxremote.port=32000
+                -Dcom.sun.management.jmxremote.rmi.port=32000
+                -Dcom.sun.management.jmxremote.authenticate=false
+                -Dcom.sun.management.jmxremote.ssl=false
+                -Dcom.sun.management.jmxremote.local.only=false
 
             - name: COPY_CONFIG_DEST
               # /config をサーバーディレクトリにコピーするようにする
@@ -227,6 +233,8 @@ spec:
               name: jmx-metrics
             - containerPort: 9225
               name: mc-metrics
+            - containerPort: 32000
+              name: jmx-remote
 
           startupProbe:
             tcpSocket:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--votelistener/service.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--votelistener/service.yaml
@@ -21,5 +21,9 @@ spec:
       port: 9225
       protocol: TCP
       targetPort: mc-metrics
+    - name: jmx-remote
+      port: 32000
+      protocol: TCP
+      targetPort: jmx-remote
   selector:
     mcserver: votelistener

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--votelistener/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--votelistener/stateful-set.yaml
@@ -94,6 +94,12 @@ spec:
                 -XX:G1RSetUpdatingPauseTimePercent=5 -XX:SurvivorRatio=32 -XX:+PerfDisableSharedMem 
                 -XX:MaxTenuringThreshold=1 -Dusing.aikars.flags=https://mcflags.emc.gs 
                 -Daikars.new.flags=true
+                -Dcom.sun.management.jmxremote
+                -Dcom.sun.management.jmxremote.port=32000
+                -Dcom.sun.management.jmxremote.rmi.port=32000
+                -Dcom.sun.management.jmxremote.authenticate=false
+                -Dcom.sun.management.jmxremote.ssl=false
+                -Dcom.sun.management.jmxremote.local.only=false
 
             - name: COPY_CONFIG_DEST
               # /config をサーバーディレクトリにコピーするようにする
@@ -167,6 +173,8 @@ spec:
               name: jmx-metrics
             - containerPort: 9225
               name: mc-metrics
+            - containerPort: 32000
+              name: jmx-remote
 
           startupProbe:
             tcpSocket:


### PR DESCRIPTION
tailscaleのadvertise-routeされたPodIP or ServiceIPから触りに行く想定