### PR TITLE
chore: fix shellcheck action versioning

### DIFF
--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: shellcheck
-        uses: reviewdog/action-shellcheck@5ebd09ddbe2ebb471646ce234c6c8dd18663ca7c # 1.30.0
+        uses: reviewdog/action-shellcheck@5ebd09ddbe2ebb471646ce234c6c8dd18663ca7c # v1.30.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review


### PR DESCRIPTION
action-shellcheck のバージョンタグには v というプレフィックスがついているが、ワークフローのコメントに記載されていないので、renovateがバージョン検知に失敗している。
https://github.com/reviewdog/action-shellcheck/releases