### PR TITLE
Renovateの設定中のキー指定が誤っているので修正

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,13 +12,13 @@
     },
     {
       "managers": ["terraform"],
-      "matchPackagePatterns": ["*"],
+      "matchPackageNames": ["*"],
       "groupName": "terraform packages",
       "enabled": true,
       "schedule": ["at any time"]
     },
     {
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "^ghcr.io/giganticminecraft/seichi_minecraft_server_production_.+$"
       ],
       "versioning": "loose"


### PR DESCRIPTION
https://docs.renovatebot.com/configuration-options/#matchpackagenames
`matchPackagePatterns`という設定は存在せず、やりたいことは`matchPackageNames`という名前だと思われる