### PR TITLE
chore: force build `ghcr.io/giganticminecraft/seichi_minecraft_server_production_common`

### DIFF
--- a/.github/workflows/build_mcserver_images.yaml
+++ b/.github/workflows/build_mcserver_images.yaml
@@ -27,6 +27,7 @@ jobs:
           - image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_common
             build_context: ./docker-images/mcservers/production/seichi-servers/common-image
             image_ver: 1.0.0
+            force_build: true
           - image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_s1
             build_context: ./docker-images/mcservers/production/seichi-servers/individual-images/s1
             image_ver: 1.0.0


### PR DESCRIPTION
1.0.0タグ付きの`common`イメージを作るために、一旦強制的にビルドさせる