### PR TITLE
fix: DynMap周りを調整する

### DIFF
--- a/docker-images/mcservers/production/seichi-servers/common-image/additional-plugin-configs/dynmap/configuration.txt
+++ b/docker-images/mcservers/production/seichi-servers/common-image/additional-plugin-configs/dynmap/configuration.txt
@@ -332,7 +332,7 @@ render-triggers:
   #- blockredstone
 
 # Title for the web page - if not specified, defaults to the server's name (unless it is the default of 'Unknown Server')
-webpage-title: "${CFG_REPLACEMENT__LITEBANS_MYSQL_DATABASE_NAME}サーバマップ - ギガンティック☆整地鯖"
+webpage-title: "${CFG_REPLACEMENT__DYNMAP_SERVER_NAME}サーバマップ - ギガンティック☆整地鯖"
 
 # The path where the tile-files are placed.
 tilespath: web/tiles

--- a/docker-images/mcservers/production/seichi-servers/common-image/additional-plugin-configs/dynmap/configuration.txt
+++ b/docker-images/mcservers/production/seichi-servers/common-image/additional-plugin-configs/dynmap/configuration.txt
@@ -332,7 +332,7 @@ render-triggers:
   #- blockredstone
 
 # Title for the web page - if not specified, defaults to the server's name (unless it is the default of 'Unknown Server')
-webpage-title: "${CFG_DYNMAP_SERVER_NAME}サーバマップ - ギガンティック☆整地鯖"
+webpage-title: "${CFG_REPLACEMENT__LITEBANS_MYSQL_DATABASE_NAME}サーバマップ - ギガンティック☆整地鯖"
 
 # The path where the tile-files are placed.
 tilespath: web/tiles

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/dynmap-nginx-conf--s1.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/dynmap-nginx-conf--s1.yaml
@@ -14,7 +14,7 @@ data:
       default_type application/octet-stream;
 
       server {
-        listen       80;
+        listen       80 default_server;
         server_name  s1.map.gigantic.seichi.click;
         root         /data/plugins/dynmap/web/;
         index        index.php index.html index.htm;

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/dynmap-nginx-conf--s1.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/dynmap-nginx-conf--s1.yaml
@@ -4,6 +4,7 @@ metadata:
   name: dynmap-nginx-conf--s1
   namespace: seichi-minecraft
 data:
+  # Note: https://github.com/webbukkit/dynmap/wiki/%5BTutorial%5D-Setting-up-a-standalone-web-server-with-MySQL-SQLite/#editing-the-website-config-file
   nginx.conf: |
     events {
         worker_connections 32;

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/dynmap-nginx-conf--s1.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/dynmap-nginx-conf--s1.yaml
@@ -22,5 +22,9 @@ data:
         location / {
           try_files $uri $uri/ =404;
         }
+
+        # deny access to .htaccess files, if Apache's document root concurs with nginx's one
+        location ~ /\.ht {
+          deny all;
       }
     }

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
@@ -233,6 +233,9 @@ spec:
                   name: mariadb
                   key: litebans-password
 
+            - name: CFG_REPLACEMENT__LITEBANS_MYSQL_DATABASE_NAME
+              value: アルカディア
+
             - name: REMOVE_OLD_MODS
               value: "TRUE"
 

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
@@ -243,7 +243,7 @@ spec:
                   name: mariadb
                   key: litebans-password
 
-            - name: CFG_REPLACEMENT__LITEBANS_MYSQL_DATABASE_NAME
+            - name: CFG_REPLACEMENT__DYNMAP_SERVER_NAME
               value: アルカディア
 
             - name: REMOVE_OLD_MODS

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
@@ -65,7 +65,7 @@ spec:
           volumeMounts:
             - name: mod-downloader-volume
               mountPath: /downloaded-plugins
-        # TODO: 1回実行したら不要なの削除する
+        # TODO: 1.12.2時代に生成されたDynMapのWebコンテンツを削除する。1回実行すれば、このコンテナ定義は削除しなくてはいけない
         - name: remove-old-dynmap-web-contents
           image: busybox:1.37.0
           volumeMounts:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
@@ -65,6 +65,16 @@ spec:
           volumeMounts:
             - name: mod-downloader-volume
               mountPath: /downloaded-plugins
+        # TODO: 1回実行したら不要なの削除する
+        - name: remove-old-dynmap-web-contents
+          image: busybox:1.37.0
+          volumeMounts:
+            - name: mcserver--s1-data
+              mountPath: /data
+          command:
+            - "sh"
+            - "-c"
+            - 'rm -rf /data/plugins/dynmap/web/'
 
       containers:
         - resources:


### PR DESCRIPTION
- Webページのタイトル内に含まれるサーバ名の設定ができていなかったので修正
- DynMapが公開している「自分でWebサーバを立てるとき用の設定」ページに記載されたnginx.confを見て、必要そうなものを追加
- `Web files are not matched with plugin version: All files need to be same version (3.7-SNAPSHOT-948) - try refreshing browser cache (shift-reload)`と言われたので、1.12.2時代に生成されたDynMapのWebコンテンツを一旦削除する