### PR TITLE
fix: replace "サーバ" with "サーバー" in dynmap webpage title

### DIFF
--- a/docker-images/mcservers/production/seichi-servers/individual-images/s1/Dockerfile
+++ b/docker-images/mcservers/production/seichi-servers/individual-images/s1/Dockerfile
@@ -6,7 +6,7 @@ COPY --link ./additional-plugin-configs /plugins
 ###
 # 環境変数として指定されるべきプラグインの設定
 #
-ENV CFG_REPLACEMENT__DYNMAP_WEBPAGE_TITLE="アルカディアサーバマップ - ギガンティック☆整地鯖"
+ENV CFG_REPLACEMENT__DYNMAP_WEBPAGE_TITLE="アルカディアサーバーマップ - ギガンティック☆整地鯖"
 
 ENV CFG_REPLACEMENT__LUCKPERMS_SERVER_NAME="s1"
 

--- a/docker-images/mcservers/production/seichi-servers/individual-images/s2/Dockerfile
+++ b/docker-images/mcservers/production/seichi-servers/individual-images/s2/Dockerfile
@@ -6,7 +6,7 @@ COPY --link ./additional-plugin-configs /plugins
 ###
 # 環境変数として指定されるべきプラグインの設定
 #
-ENV CFG_REPLACEMENT__DYNMAP_WEBPAGE_TITLE="エデンサーバマップ - ギガンティック☆整地鯖"
+ENV CFG_REPLACEMENT__DYNMAP_WEBPAGE_TITLE="エデンサーバーマップ - ギガンティック☆整地鯖"
 
 ENV CFG_REPLACEMENT__LUCKPERMS_SERVER_NAME="s2"
 

--- a/docker-images/mcservers/production/seichi-servers/individual-images/s3/Dockerfile
+++ b/docker-images/mcservers/production/seichi-servers/individual-images/s3/Dockerfile
@@ -6,7 +6,7 @@ COPY --link ./additional-plugin-configs /plugins
 ###
 # 環境変数として指定されるべきプラグインの設定
 #
-ENV CFG_REPLACEMENT__DYNMAP_WEBPAGE_TITLE="ヴァルハラサーバマップ - ギガンティック☆整地鯖"
+ENV CFG_REPLACEMENT__DYNMAP_WEBPAGE_TITLE="ヴァルハラサーバーマップ - ギガンティック☆整地鯖"
 
 ENV CFG_REPLACEMENT__LUCKPERMS_SERVER_NAME="s3"
 

--- a/docker-images/mcservers/production/seichi-servers/individual-images/s5/Dockerfile
+++ b/docker-images/mcservers/production/seichi-servers/individual-images/s5/Dockerfile
@@ -8,7 +8,7 @@ COPY --link ./custom-minecraft-server-configs /config
 ###
 # 環境変数として指定されるべきプラグインの設定
 #
-ENV CFG_REPLACEMENT__DYNMAP_WEBPAGE_TITLE="第1整地専用サーバマップ - ギガンティック☆整地鯖"
+ENV CFG_REPLACEMENT__DYNMAP_WEBPAGE_TITLE="第1整地専用サーバーマップ - ギガンティック☆整地鯖"
 
 ENV CFG_REPLACEMENT__LUCKPERMS_SERVER_NAME="s5"
 

--- a/docker-images/mcservers/production/seichi-servers/individual-images/s7/Dockerfile
+++ b/docker-images/mcservers/production/seichi-servers/individual-images/s7/Dockerfile
@@ -8,7 +8,7 @@ COPY --link ./custom-minecraft-server-configs /config
 ###
 # 環境変数として指定されるべきプラグインの設定
 #
-ENV CFG_REPLACEMENT__DYNMAP_WEBPAGE_TITLE="公共施設鯖マップ - ギガンティック☆整地鯖"
+ENV CFG_REPLACEMENT__DYNMAP_WEBPAGE_TITLE="公共施設サーバーマップ - ギガンティック☆整地鯖"
 
 ENV CFG_REPLACEMENT__LUCKPERMS_SERVER_NAME="s7"
 


### PR DESCRIPTION
整地鯖の内部方針として、横文字で語尾に「ー」がついたりつかなかったりするものは、つくものに統一する