### PR TITLE
chore: WGの設定ファイルを出力するinitContainerを追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
@@ -79,7 +79,7 @@ spec:
               cat /data/plugins/WorldGuard/worlds/world_SW_3/blacklist.txt
               cat /data/plugins/WorldGuard/worlds/world_SW_4/blacklist.txt
           volumeMounts:
-            - name: mcserver--lobby-data
+            - name: mcserver--s1-data
               mountPath: /data
 
       containers:


### PR DESCRIPTION
第3、第4整地のWGの設定ファイルが定義されておらず、最大保護可能ブロック数の設定などが不明なので確認したいです