### PR TITLE
fix: matchManager として regex ではなく、kubernetes を指定する

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -18,7 +18,7 @@
       "schedule": ["at any time"]
     },
     {
-      matchManagers: ["dockerfile", "regex"],
+      matchManagers: ["dockerfile", "kubernetes"],
       matchPackageNames: [
         "ghcr.io/giganticminecraft/seichi_minecraft_server_*",
       ],


### PR DESCRIPTION
どうも検知されなくなっちゃったっぽいので、怪しいところを直す