### PR TITLE
chore: mariadb のストレージサイズを変更

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
@@ -17,7 +17,7 @@ spec:
   port: 3306
 
   storage:
-    size: 100Gi
+    size: 200Gi
     storageClassName: synology-iscsi-storage
     resizeInUseVolumes: true
     waitForVolumeResize: true


### PR DESCRIPTION
```
2025-05-24 12:24:03 0 [Warning] mariadbd: Disk is full writing './mysql/db.MAD' (Errcode: 28 "No space left on device"). Waiting for someone to free space... (Expect up to 60 secs delay for server to continue after freeing disk space)
2025-05-24 12:24:03 0 [Warning] mariadbd: Retry in 60 secs. Message reprinted in 600 secs
```

ストレージサイズが足りなくて全サーバーが落ちた