### PR TITLE
chore: backup workflow でイメージを mirror.gcr.io からとってくる

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/argo-workflows-backup.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/argo-workflows-backup.yaml
@@ -44,6 +44,7 @@ spec:
     - name: get-timestamp
       script:
         image: alpine
+        registry: mirror.gcr.io
         command: [sh]
         source: |
           echo $(date +%Y%m%d-%H%M%S)
@@ -51,6 +52,7 @@ spec:
     - name: patch-statefulset-to-0
       script:
         image: bitnami/kubectl:1.33.1
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           kubectl patch statefulset mcserver--s1 -n seichi-minecraft --type='merge' -p '{"spec": {"replicas": 0}}'
@@ -58,6 +60,7 @@ spec:
     - name: wait-for-scale-to-0
       script:
         image: bitnami/kubectl:1.33.1
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           echo "Waiting for statefulset to scale down..."
@@ -74,6 +77,7 @@ spec:
     - name: run-backup
       script:
         image: debian:12
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           set -e
@@ -142,6 +146,7 @@ spec:
     - name: delete-coreprotect--s1-db
       script:
         image: bitnami/kubectl:1.33.1
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           kubectl delete database coreprotect-s1 -n seichi-minecraft --wait=true
@@ -149,6 +154,7 @@ spec:
     - name: patch-statefulset-to-1
       script:
         image: bitnami/kubectl:1.33.1
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           kubectl patch statefulset mcserver--s1 -n seichi-minecraft --type='merge' -p '{"spec": {"replicas": 1}}'
@@ -157,6 +163,7 @@ spec:
       activeDeadlineSeconds: 300 # 5分待っても上がってこない場合は諦める
       script:
         image: bitnami/kubectl:1.33.1
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           echo "Waiting for StatefulSet to scale up..."

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/argo-workflows-backup.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/argo-workflows-backup.yaml
@@ -44,6 +44,7 @@ spec:
     - name: get-timestamp
       script:
         image: alpine
+        registry: mirror.gcr.io
         command: [sh]
         source: |
           echo $(date +%Y%m%d-%H%M%S)
@@ -51,6 +52,7 @@ spec:
     - name: patch-statefulset-to-0
       script:
         image: bitnami/kubectl:1.33.1
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           kubectl patch statefulset mcserver--s2 -n seichi-minecraft --type='merge' -p '{"spec": {"replicas": 0}}'
@@ -58,6 +60,7 @@ spec:
     - name: wait-for-scale-to-0
       script:
         image: bitnami/kubectl:1.33.1
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           echo "Waiting for statefulset to scale down..."
@@ -74,6 +77,7 @@ spec:
     - name: run-backup
       script:
         image: debian:12
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           set -e
@@ -142,6 +146,7 @@ spec:
     - name: delete-coreprotect--s2-db
       script:
         image: bitnami/kubectl:1.33.1
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           kubectl delete database coreprotect-s2 -n seichi-minecraft --wait=true
@@ -149,6 +154,7 @@ spec:
     - name: patch-statefulset-to-1
       script:
         image: bitnami/kubectl:1.33.1
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           kubectl patch statefulset mcserver--s2 -n seichi-minecraft --type='merge' -p '{"spec": {"replicas": 1}}'
@@ -157,6 +163,7 @@ spec:
       activeDeadlineSeconds: 300 # 5分待っても上がってこない場合は諦める
       script:
         image: bitnami/kubectl:1.33.1
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           echo "Waiting for StatefulSet to scale up..."

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/argo-workflows-backup.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/argo-workflows-backup.yaml
@@ -44,6 +44,7 @@ spec:
     - name: get-timestamp
       script:
         image: alpine
+        registry: mirror.gcr.io
         command: [sh]
         source: |
           echo $(date +%Y%m%d-%H%M%S)
@@ -51,6 +52,7 @@ spec:
     - name: patch-statefulset-to-0
       script:
         image: bitnami/kubectl:1.33.1
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           kubectl patch statefulset mcserver--s3 -n seichi-minecraft --type='merge' -p '{"spec": {"replicas": 0}}'
@@ -58,6 +60,7 @@ spec:
     - name: wait-for-scale-to-0
       script:
         image: bitnami/kubectl:1.33.1
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           echo "Waiting for statefulset to scale down..."
@@ -74,6 +77,7 @@ spec:
     - name: run-backup
       script:
         image: debian:12
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           set -e
@@ -142,6 +146,7 @@ spec:
     - name: delete-coreprotect--s3-db
       script:
         image: bitnami/kubectl:1.33.1
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           kubectl delete database coreprotect-s3 -n seichi-minecraft --wait=true
@@ -149,6 +154,7 @@ spec:
     - name: patch-statefulset-to-1
       script:
         image: bitnami/kubectl:1.33.1
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           kubectl patch statefulset mcserver--s3 -n seichi-minecraft --type='merge' -p '{"spec": {"replicas": 1}}'
@@ -157,6 +163,7 @@ spec:
       activeDeadlineSeconds: 300 # 5分待っても上がってこない場合は諦める
       script:
         image: bitnami/kubectl:1.33.1
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           echo "Waiting for StatefulSet to scale up..."

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/argo-workflows-backup.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/argo-workflows-backup.yaml
@@ -44,6 +44,7 @@ spec:
     - name: get-timestamp
       script:
         image: alpine
+        registry: mirror.gcr.io
         command: [sh]
         source: |
           echo $(date +%Y%m%d-%H%M%S)
@@ -51,6 +52,7 @@ spec:
     - name: patch-statefulset-to-0
       script:
         image: bitnami/kubectl:1.33.1
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           kubectl patch statefulset mcserver--s5 -n seichi-minecraft --type='merge' -p '{"spec": {"replicas": 0}}'
@@ -58,6 +60,7 @@ spec:
     - name: wait-for-scale-to-0
       script:
         image: bitnami/kubectl:1.33.1
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           echo "Waiting for statefulset to scale down..."
@@ -74,6 +77,7 @@ spec:
     - name: run-backup
       script:
         image: debian:12
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           set -e
@@ -142,6 +146,7 @@ spec:
     - name: delete-coreprotect--s5-db
       script:
         image: bitnami/kubectl:1.33.1
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           kubectl delete database coreprotect-s5 -n seichi-minecraft --wait=true
@@ -149,6 +154,7 @@ spec:
     - name: patch-statefulset-to-1
       script:
         image: bitnami/kubectl:1.33.1
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           kubectl patch statefulset mcserver--s5 -n seichi-minecraft --type='merge' -p '{"spec": {"replicas": 1}}'
@@ -157,6 +163,7 @@ spec:
       activeDeadlineSeconds: 300 # 5分待っても上がってこない場合は諦める
       script:
         image: bitnami/kubectl:1.33.1
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           echo "Waiting for StatefulSet to scale up..."

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/argo-workflows-backup.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/argo-workflows-backup.yaml
@@ -44,6 +44,7 @@ spec:
     - name: get-timestamp
       script:
         image: alpine
+        registry: mirror.gcr.io
         command: [sh]
         source: |
           echo $(date +%Y%m%d-%H%M%S)
@@ -51,6 +52,7 @@ spec:
     - name: patch-statefulset-to-0
       script:
         image: bitnami/kubectl:1.33.1
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           kubectl patch statefulset mcserver--s7 -n seichi-minecraft --type='merge' -p '{"spec": {"replicas": 0}}'
@@ -58,6 +60,7 @@ spec:
     - name: wait-for-scale-to-0
       script:
         image: bitnami/kubectl:1.33.1
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           echo "Waiting for statefulset to scale down..."
@@ -74,6 +77,7 @@ spec:
     - name: run-backup
       script:
         image: debian:12
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           set -e
@@ -142,6 +146,7 @@ spec:
     - name: delete-coreprotect--s7-db
       script:
         image: bitnami/kubectl:1.33.1
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           kubectl delete database coreprotect-s7 -n seichi-minecraft --wait=true
@@ -149,6 +154,7 @@ spec:
     - name: patch-statefulset-to-1
       script:
         image: bitnami/kubectl:1.33.1
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           kubectl patch statefulset mcserver--s7 -n seichi-minecraft --type='merge' -p '{"spec": {"replicas": 1}}'
@@ -157,6 +163,7 @@ spec:
       activeDeadlineSeconds: 300 # 5分待っても上がってこない場合は諦める
       script:
         image: bitnami/kubectl:1.33.1
+        registry: mirror.gcr.io
         command: ["/bin/sh", "-c"]
         source: |
           echo "Waiting for StatefulSet to scale up..."


### PR DESCRIPTION
backup ワークフローで落ちるとめんどくさいので