### PR TITLE
feat: Timings v2 を廃止し，Spark に移行する

### DIFF
--- a/docker-images/mcservers/base-server-image/common-minecraft-server-configs/paper.yml
+++ b/docker-images/mcservers/base-server-image/common-minecraft-server-configs/paper.yml
@@ -96,7 +96,9 @@ messages:
     flying-vehicle: Flying is not enabled on this server
 timings:
   url: https://timings.aikar.co/
-  enabled: true
+  # Timings はメンテナンスが終了しているため，Spark に移行している
+  # この設定で Timings を無効化する
+  enabled: false
   verbose: true
   server-name-privacy: false
   hidden-config-entries:


### PR DESCRIPTION
Timings V2 はすでにメンテナンスが終了しており， Paper は LuckPerms の開発者が開発・保守しているプロファイリングプラグインである Spark への移行を推奨している．

1.21 以降の Paper には Spark が内蔵されているが，1.18.2 には内蔵されていないため別で Spark を導入する必要がある．
このプルリクエストでは Timings の機能を無力化する．

https://docs.papermc.io/paper/profiling/#spark

- [x] minio の common-plugins に Spark を入れる
- [ ] 運営向けに使用方法を周知する