### PR TITLE
chore: coreprotect の削除ワークフローをコメントアウト

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/argo-workflows-backup.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/argo-workflows-backup.yaml
@@ -34,8 +34,8 @@ spec:
             template: wait-for-scale-to-0
         - - name: run-backup
             template: run-backup
-        - - name: delete-coreprotect--s1-db
-            template: delete-coreprotect--s1-db
+        # - - name: delete-coreprotect--s1-db
+        #     template: delete-coreprotect--s1-db
         - - name: patch-statefulset-to-1
             template: patch-statefulset-to-1
         - - name: wait-for-scale-to-1

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/argo-workflows-backup.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/argo-workflows-backup.yaml
@@ -34,8 +34,8 @@ spec:
             template: wait-for-scale-to-0
         - - name: run-backup
             template: run-backup
-        - - name: delete-coreprotect--s2-db
-            template: delete-coreprotect--s2-db
+        # - - name: delete-coreprotect--s2-db
+        #     template: delete-coreprotect--s2-db
         - - name: patch-statefulset-to-1
             template: patch-statefulset-to-1
         - - name: wait-for-scale-to-1

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/argo-workflows-backup.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/argo-workflows-backup.yaml
@@ -34,8 +34,8 @@ spec:
             template: wait-for-scale-to-0
         - - name: run-backup
             template: run-backup
-        - - name: delete-coreprotect--s3-db
-            template: delete-coreprotect--s3-db
+        # - - name: delete-coreprotect--s3-db
+        #     template: delete-coreprotect--s3-db
         - - name: patch-statefulset-to-1
             template: patch-statefulset-to-1
         - - name: wait-for-scale-to-1

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/argo-workflows-backup.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/argo-workflows-backup.yaml
@@ -34,8 +34,8 @@ spec:
             template: wait-for-scale-to-0
         - - name: run-backup
             template: run-backup
-        - - name: delete-coreprotect--s5-db
-            template: delete-coreprotect--s5-db   
+        # - - name: delete-coreprotect--s5-db
+        #     template: delete-coreprotect--s5-db   
         - - name: patch-statefulset-to-1
             template: patch-statefulset-to-1
         - - name: wait-for-scale-to-1

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/argo-workflows-backup.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/argo-workflows-backup.yaml
@@ -34,8 +34,8 @@ spec:
             template: wait-for-scale-to-0
         - - name: run-backup
             template: run-backup
-        - - name: delete-coreprotect--s7-db
-            template: delete-coreprotect--s7-db
+        # - - name: delete-coreprotect--s7-db
+        #     template: delete-coreprotect--s7-db
         - - name: patch-statefulset-to-1
             template: patch-statefulset-to-1
         - - name: wait-for-scale-to-1


### PR DESCRIPTION
現状のままワークフローを動かすと、以下のような挙動をしてマインクラフトサーバーが起動してこなくなるので、コメントアウトしていったん削除します
1. 午前4時になってバックアップワークフローが走る
2. CoreProtect 用 DB が削除される
3. マインクラフトサーバーが立ち上がる
4. CoreProtect が DB を読めなくなる(CoreProtect は自身をアンロードする)
5. 午前7時に Sync Window が切れ、Auto Sync が有効になる
6. CoreProtect DB が作られる

これを解決するには、CoreProtect 用データベースを削除するのではなく、すべてのテーブルを `TRUNCATE` するか、削除が終わった段階で Argo CD CLI などをもちいて seichi-minecraft の mariadb を Sync するなどの方法が考えれる。