### PR TITLE
chore: update argo-cd helm to v8.3.5

### DIFF
--- a/terraform/onp_cluster_argocd.tf
+++ b/terraform/onp_cluster_argocd.tf
@@ -4,7 +4,7 @@ resource "helm_release" "onp_cluster_argocd" {
   chart      = "argo-cd"
   name       = "argocd"
   namespace  = "argocd"
-  version    = "8.3.3"
+  version    = "8.3.5"
 
   reset_values    = true
   recreate_pods   = true


### PR DESCRIPTION
https://github.com/argoproj/argo-helm/releases/tag/argo-cd-8.3.5
このバージョンアップにより、Argo CDを現在の3.1.1から3.1.4までアップグレードでき、CVE-2025-55190を回避します。