### PR TITLE
1dayサーバの定義において、volumeの定義位置がずれているのを修正

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--one-day-to-reset/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--one-day-to-reset/stateful-set.yaml
@@ -89,6 +89,6 @@ spec:
             - name: mod-downloader-volume
               mountPath: /plugins
 
-    volumes:
-      - name: mod-downloader-volume
-        emptyDir: {}
+      volumes:
+        - name: mod-downloader-volume
+          emptyDir: {}


### PR DESCRIPTION
> create Pod mcserver--one-day-to-reset-0 in StatefulSet mcserver--one-day-to-reset failed error: Pod "mcserver--one-day-to-reset-0" is invalid: [spec.containers[0].volumeMounts[0].name: Not found: "mod-downloader-volume", spec.initContainers[0].volumeMounts[0].name: Not found: "mod-downloader-volume"]

s1とかは`.spec.template.spec`以下（=今回の修正後）に`volume`の定義があるので、そちらに合わせました。
（kagawaがなぜ`.spec.template`に`volume`の定義がある状態で動いているのかよくわからないですけど）