### PR TITLE
feat: set simulation-distance to 6 in s5

### DIFF
--- a/docker-images/mcservers/production/seichi-servers/individual-images/s5/custom-minecraft-server-configs/server.properties
+++ b/docker-images/mcservers/production/seichi-servers/individual-images/s5/custom-minecraft-server-configs/server.properties
@@ -29,6 +29,7 @@ spawn-npcs=true
 allow-flight=true
 level-name=world
 view-distance=4
+simulation-distance=6
 resource-pack=
 spawn-animals=true
 white-list=false


### PR DESCRIPTION
s5はserver.propertiesが独立しているのでそちらでも修正
https://github.com/GiganticMinecraft/seichi_infra/pull/3692