### PR TITLE
fix: bungeecord-config からコメントアウトされているものを削除

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-gateway/bungeecord/bungeecord-config.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-gateway/bungeecord/bungeecord-config.yaml
@@ -23,8 +23,6 @@ spec:
 
       listeners:
         - priorities:
-            # FIXME: PR が一個も出ていない時に壊れる。そもそもそのような状況で繋ぐサーバーを用意すべきかも
-            # - debug-pr-{{ (index . 0) }}-lobby
             - debug-s1
           forced_hosts:
             play-debug.seichi.click: debug-s1


### PR DESCRIPTION
```
Exception in thread "main" java.lang.ClassCastException: class java.lang.String cannot be cast to class java.util.Map (java.lang.String and java.util.Map are in module java.base of loader 'bootstrap')
```

というエラーを吐いていて、怪しそうなので