### PR TITLE
fix: メンテナンスモードのreadinessProbeをConfigMapボリュームマウントに変更

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--kagawa/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--kagawa/stateful-set.yaml
@@ -106,9 +106,8 @@ spec:
                 - sh
                 - -c
                 - |
-                  # メンテナンスモードチェック（ConfigMapを直接読み取り、Pod再起動不要で即座反映）
-                  MAINTENANCE_ENABLED=$(kubectl get configmap maintenance-mode -n seichi-minecraft -o jsonpath='{.data.enabled}' 2>/dev/null || echo "false")
-                  if [ "$MAINTENANCE_ENABLED" = "true" ]; then
+                  # メンテナンスモードチェック（ConfigMapをボリュームマウントで読み取り）
+                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null; then
                     echo "Maintenance mode is enabled"
                     exit 1
                   fi
@@ -120,6 +119,11 @@ spec:
             failureThreshold: 18
 
           volumeMounts:
+            # メンテナンスモードの状態確認用ConfigMap
+            - name: maintenance-mode
+              mountPath: /maintenance-mode
+              readOnly: true
+
             # itzg/minecraft-server は /config に設定ファイルをマウントしておけばコピーをしてくれる。
             # 環境変数の置き換えはPrefix等の設定が必要なので、必要になったら設定するように。
             # https://github.com/itzg/docker-minecraft-server/tree/9458005b5bd78b8139e13e66c29a449a12dd6218#replacing-variables-inside-configs
@@ -154,6 +158,11 @@ spec:
               mountPath: /downloaded-plugins
 
       volumes:
+        # メンテナンスモードの状態を保持するConfigMap
+        - name: maintenance-mode
+          configMap:
+            name: maintenance-mode
+
         # mod-downloaderからプラグインをinitContainerでダウンロードしてMinecraftに受け渡すためのvolume
         - name: mod-downloader-volume
           emptyDir: {}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/stateful-set.yaml
@@ -187,9 +187,8 @@ spec:
                 - sh
                 - -c
                 - |
-                  # メンテナンスモードチェック（ConfigMapを直接読み取り、Pod再起動不要で即座反映）
-                  MAINTENANCE_ENABLED=$(kubectl get configmap maintenance-mode -n seichi-minecraft -o jsonpath='{.data.enabled}' 2>/dev/null || echo "false")
-                  if [ "$MAINTENANCE_ENABLED" = "true" ]; then
+                  # メンテナンスモードチェック（ConfigMapをボリュームマウントで読み取り）
+                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null; then
                     echo "Maintenance mode is enabled"
                     exit 1
                   fi
@@ -201,6 +200,11 @@ spec:
             failureThreshold: 18
 
           volumeMounts:
+            # メンテナンスモードの状態確認用ConfigMap
+            - name: maintenance-mode
+              mountPath: /maintenance-mode
+              readOnly: true
+
             # itzg/minecraft-server は /config に設定ファイルをマウントしておけばコピーをしてくれる。
             # 環境変数の置き換えはPrefix等の設定が必要なので、必要になったら設定するように。
             # https://github.com/itzg/docker-minecraft-server/tree/9458005b5bd78b8139e13e66c29a449a12dd6218#replacing-variables-inside-configs
@@ -241,6 +245,11 @@ spec:
               mountPath: /data
 
       volumes:
+        # メンテナンスモードの状態を保持するConfigMap
+        - name: maintenance-mode
+          configMap:
+            name: maintenance-mode
+
         # mod-downloaderからプラグインをinitContainerでダウンロードしてMinecraftに受け渡すためのvolume
         - name: mod-downloader-volume
           emptyDir: {}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--one-day-to-reset/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--one-day-to-reset/stateful-set.yaml
@@ -105,9 +105,8 @@ spec:
                 - sh
                 - -c
                 - |
-                  # メンテナンスモードチェック（ConfigMapを直接読み取り、Pod再起動不要で即座反映）
-                  MAINTENANCE_ENABLED=$(kubectl get configmap maintenance-mode -n seichi-minecraft -o jsonpath='{.data.enabled}' 2>/dev/null || echo "false")
-                  if [ "$MAINTENANCE_ENABLED" = "true" ]; then
+                  # メンテナンスモードチェック（ConfigMapをボリュームマウントで読み取り）
+                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null; then
                     echo "Maintenance mode is enabled"
                     exit 1
                   fi
@@ -119,6 +118,11 @@ spec:
             failureThreshold: 18
 
           volumeMounts:
+            # メンテナンスモードの状態確認用ConfigMap
+            - name: maintenance-mode
+              mountPath: /maintenance-mode
+              readOnly: true
+
             # itzg/minecraft-server は /config に設定ファイルをマウントしておけばコピーをしてくれる。
             # 環境変数の置き換えはPrefix等の設定が必要なので、必要になったら設定するように。
             # https://github.com/itzg/docker-minecraft-server/tree/9458005b5bd78b8139e13e66c29a449a12dd6218#replacing-variables-inside-configs
@@ -153,6 +157,11 @@ spec:
               mountPath: /downloaded-plugins
 
       volumes:
+        # メンテナンスモードの状態を保持するConfigMap
+        - name: maintenance-mode
+          configMap:
+            name: maintenance-mode
+
         # mod-downloaderからプラグインをinitContainerでダウンロードしてMinecraftに受け渡すためのvolume
         - name: mod-downloader-volume
           emptyDir: {}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
@@ -291,9 +291,8 @@ spec:
                 - sh
                 - -c
                 - |
-                  # メンテナンスモードチェック（ConfigMapを直接読み取り、Pod再起動不要で即座反映）
-                  MAINTENANCE_ENABLED=$(kubectl get configmap maintenance-mode -n seichi-minecraft -o jsonpath='{.data.enabled}' 2>/dev/null || echo "false")
-                  if [ "$MAINTENANCE_ENABLED" = "true" ]; then
+                  # メンテナンスモードチェック（ConfigMapをボリュームマウントで読み取り）
+                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null; then
                     echo "Maintenance mode is enabled"
                     exit 1
                   fi
@@ -305,6 +304,11 @@ spec:
             failureThreshold: 18
 
           volumeMounts:
+            # メンテナンスモードの状態確認用ConfigMap
+            - name: maintenance-mode
+              mountPath: /maintenance-mode
+              readOnly: true
+
             # itzg/minecraft-server は /config に設定ファイルをマウントしておけばコピーをしてくれる。
             # 環境変数の置き換えはPrefix等の設定が必要なので、必要になったら設定するように。
             # https://github.com/itzg/docker-minecraft-server/tree/9458005b5bd78b8139e13e66c29a449a12dd6218#replacing-variables-inside-configs
@@ -369,6 +373,11 @@ spec:
               mountPath: /data
 
       volumes:
+        # メンテナンスモードの状態を保持するConfigMap
+        - name: maintenance-mode
+          configMap:
+            name: maintenance-mode
+
         # mod-downloaderからプラグインをinitContainerでダウンロードしてMinecraftに受け渡すためのvolume
         - name: mod-downloader-volume
           emptyDir: {}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/stateful-set.yaml
@@ -291,9 +291,8 @@ spec:
                 - sh
                 - -c
                 - |
-                  # メンテナンスモードチェック（ConfigMapを直接読み取り、Pod再起動不要で即座反映）
-                  MAINTENANCE_ENABLED=$(kubectl get configmap maintenance-mode -n seichi-minecraft -o jsonpath='{.data.enabled}' 2>/dev/null || echo "false")
-                  if [ "$MAINTENANCE_ENABLED" = "true" ]; then
+                  # メンテナンスモードチェック（ConfigMapをボリュームマウントで読み取り）
+                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null; then
                     echo "Maintenance mode is enabled"
                     exit 1
                   fi
@@ -305,6 +304,11 @@ spec:
             failureThreshold: 18
 
           volumeMounts:
+            # メンテナンスモードの状態確認用ConfigMap
+            - name: maintenance-mode
+              mountPath: /maintenance-mode
+              readOnly: true
+
             # itzg/minecraft-server は /config に設定ファイルをマウントしておけばコピーをしてくれる。
             # 環境変数の置き換えはPrefix等の設定が必要なので、必要になったら設定するように。
             # https://github.com/itzg/docker-minecraft-server/tree/9458005b5bd78b8139e13e66c29a449a12dd6218#replacing-variables-inside-configs
@@ -369,6 +373,11 @@ spec:
               mountPath: /data
 
       volumes:
+        # メンテナンスモードの状態を保持するConfigMap
+        - name: maintenance-mode
+          configMap:
+            name: maintenance-mode
+
         # mod-downloaderからプラグインをinitContainerでダウンロードしてMinecraftに受け渡すためのvolume
         - name: mod-downloader-volume
           emptyDir: {}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/stateful-set.yaml
@@ -291,9 +291,8 @@ spec:
                 - sh
                 - -c
                 - |
-                  # メンテナンスモードチェック（ConfigMapを直接読み取り、Pod再起動不要で即座反映）
-                  MAINTENANCE_ENABLED=$(kubectl get configmap maintenance-mode -n seichi-minecraft -o jsonpath='{.data.enabled}' 2>/dev/null || echo "false")
-                  if [ "$MAINTENANCE_ENABLED" = "true" ]; then
+                  # メンテナンスモードチェック（ConfigMapをボリュームマウントで読み取り）
+                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null; then
                     echo "Maintenance mode is enabled"
                     exit 1
                   fi
@@ -305,6 +304,11 @@ spec:
             failureThreshold: 18
 
           volumeMounts:
+            # メンテナンスモードの状態確認用ConfigMap
+            - name: maintenance-mode
+              mountPath: /maintenance-mode
+              readOnly: true
+
             # itzg/minecraft-server は /config に設定ファイルをマウントしておけばコピーをしてくれる。
             # 環境変数の置き換えはPrefix等の設定が必要なので、必要になったら設定するように。
             # https://github.com/itzg/docker-minecraft-server/tree/9458005b5bd78b8139e13e66c29a449a12dd6218#replacing-variables-inside-configs
@@ -369,6 +373,11 @@ spec:
               mountPath: /data
 
       volumes:
+        # メンテナンスモードの状態を保持するConfigMap
+        - name: maintenance-mode
+          configMap:
+            name: maintenance-mode
+
         # mod-downloaderからプラグインをinitContainerでダウンロードしてMinecraftに受け渡すためのvolume
         - name: mod-downloader-volume
           emptyDir: {}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
@@ -273,9 +273,8 @@ spec:
                 - sh
                 - -c
                 - |
-                  # メンテナンスモードチェック（ConfigMapを直接読み取り、Pod再起動不要で即座反映）
-                  MAINTENANCE_ENABLED=$(kubectl get configmap maintenance-mode -n seichi-minecraft -o jsonpath='{.data.enabled}' 2>/dev/null || echo "false")
-                  if [ "$MAINTENANCE_ENABLED" = "true" ]; then
+                  # メンテナンスモードチェック（ConfigMapをボリュームマウントで読み取り）
+                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null; then
                     echo "Maintenance mode is enabled"
                     exit 1
                   fi
@@ -287,6 +286,11 @@ spec:
             failureThreshold: 18
 
           volumeMounts:
+            # メンテナンスモードの状態確認用ConfigMap
+            - name: maintenance-mode
+              mountPath: /maintenance-mode
+              readOnly: true
+
             # itzg/minecraft-server は /config に設定ファイルをマウントしておけばコピーをしてくれる。
             # 環境変数の置き換えはPrefix等の設定が必要なので、必要になったら設定するように。
             # https://github.com/itzg/docker-minecraft-server/tree/9458005b5bd78b8139e13e66c29a449a12dd6218#replacing-variables-inside-configs
@@ -351,6 +355,11 @@ spec:
               mountPath: /data
 
       volumes:
+        # メンテナンスモードの状態を保持するConfigMap
+        - name: maintenance-mode
+          configMap:
+            name: maintenance-mode
+
         # mod-downloaderからプラグインをinitContainerでダウンロードしてMinecraftに受け渡すためのvolume
         - name: mod-downloader-volume
           emptyDir: {}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/stateful-set.yaml
@@ -267,9 +267,8 @@ spec:
                 - sh
                 - -c
                 - |
-                  # メンテナンスモードチェック（ConfigMapを直接読み取り、Pod再起動不要で即座反映）
-                  MAINTENANCE_ENABLED=$(kubectl get configmap maintenance-mode -n seichi-minecraft -o jsonpath='{.data.enabled}' 2>/dev/null || echo "false")
-                  if [ "$MAINTENANCE_ENABLED" = "true" ]; then
+                  # メンテナンスモードチェック（ConfigMapをボリュームマウントで読み取り）
+                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null; then
                     echo "Maintenance mode is enabled"
                     exit 1
                   fi
@@ -281,6 +280,11 @@ spec:
             failureThreshold: 18
 
           volumeMounts:
+            # メンテナンスモードの状態確認用ConfigMap
+            - name: maintenance-mode
+              mountPath: /maintenance-mode
+              readOnly: true
+
             # itzg/minecraft-server は /config に設定ファイルをマウントしておけばコピーをしてくれる。
             # 環境変数の置き換えはPrefix等の設定が必要なので、必要になったら設定するように。
             # https://github.com/itzg/docker-minecraft-server/tree/9458005b5bd78b8139e13e66c29a449a12dd6218#replacing-variables-inside-configs
@@ -345,6 +349,11 @@ spec:
               mountPath: /data
 
       volumes:
+        # メンテナンスモードの状態を保持するConfigMap
+        - name: maintenance-mode
+          configMap:
+            name: maintenance-mode
+
         # mod-downloaderからプラグインをinitContainerでダウンロードしてMinecraftに受け渡すためのvolume
         - name: mod-downloader-volume
           emptyDir: {}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--votelistener/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--votelistener/stateful-set.yaml
@@ -207,9 +207,8 @@ spec:
                 - sh
                 - -c
                 - |
-                  # メンテナンスモードチェック（ConfigMapを直接読み取り、Pod再起動不要で即座反映）
-                  MAINTENANCE_ENABLED=$(kubectl get configmap maintenance-mode -n seichi-minecraft -o jsonpath='{.data.enabled}' 2>/dev/null || echo "false")
-                  if [ "$MAINTENANCE_ENABLED" = "true" ]; then
+                  # メンテナンスモードチェック（ConfigMapをボリュームマウントで読み取り）
+                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null; then
                     echo "Maintenance mode is enabled"
                     exit 1
                   fi
@@ -221,6 +220,11 @@ spec:
             failureThreshold: 18
 
           volumeMounts:
+            # メンテナンスモードの状態確認用ConfigMap
+            - name: maintenance-mode
+              mountPath: /maintenance-mode
+              readOnly: true
+
             # itzg/minecraft-server は /config に設定ファイルをマウントしておけばコピーをしてくれる。
             # 環境変数の置き換えはPrefix等の設定が必要なので、必要になったら設定するように。
             # https://github.com/itzg/docker-minecraft-server/tree/9458005b5bd78b8139e13e66c29a449a12dd6218#replacing-variables-inside-configs
@@ -261,6 +265,11 @@ spec:
               mountPath: /data
 
       volumes:
+        # メンテナンスモードの状態を保持するConfigMap
+        - name: maintenance-mode
+          configMap:
+            name: maintenance-mode
+
         # mod-downloaderからプラグインをinitContainerでダウンロードしてMinecraftに受け渡すためのvolume
         - name: mod-downloader-volume
           emptyDir: {}


### PR DESCRIPTION
## 概要

kubectl未インストールのコンテナ内でkubectlコマンドを実行していたため、メンテナンスモードが正しく機能していなかった問題を修正。

## 問題

readinessProbe内で`kubectl get configmap`を実行していたが、Minecraftサーバーのコンテナイメージにはkubectlがインストールされていなかった。そのため、コマンドが失敗して常に`|| echo "false"`のフォールバックが実行され、メンテナンスモードが有効にならなかった。

## 解決策

ConfigMapをボリュームマウントし、ファイルシステム経由で`enabled`の値を読み取るように変更。これにより：
- kubectlのインストールが不要
- RBAC権限の設定が不要
- ConfigMapの変更が数秒〜数十秒で自動的にPodに反映される

## 変更内容

以下の全Minecraftサーバーで修正を適用：
- mcserver--s1
- mcserver--s2
- mcserver--s3
- mcserver--s5
- mcserver--s7
- mcserver--lobby
- mcserver--votelistener
- mcserver--kagawa
- mcserver--one-day-to-reset

各サーバーで以下の3箇所を修正：

1. **readinessProbe**: `kubectl get configmap`から`grep -q "^true$" /maintenance-mode/enabled`に変更
2. **volumeMounts**: maintenance-mode ConfigMapを`/maintenance-mode`にマウント（readOnly）
3. **volumes**: maintenance-mode ConfigMapをvolumesに追加

## テスト方法

```bash
# メンテナンスモードを有効化
kubectl patch configmap maintenance-mode -n seichi-minecraft -p '{"data":{"enabled":"true"}}'

# 数秒〜数十秒後、Podがエンドポイントから除外されることを確認
kubectl get endpoints -n seichi-minecraft

# メンテナンスモードを無効化
kubectl patch configmap maintenance-mode -n seichi-minecraft -p '{"data":{"enabled":"false"}}'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)