### PR TITLE
feat: set `TIME_ZONE` in bugsink

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/bugsink/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/bugsink/deployment.yaml
@@ -60,6 +60,9 @@ spec:
               value: "https://bugsink-dsn.onp-k8s.admin.seichi.click"
             - name: ALLOWED_HOSTS
               value: "bugsink.onp-k8s.admin.seichi.click,bugsink-dsn.onp-k8s.admin.seichi.click,bugsink.seichi-minecraft"
+            # https://github.com/bugsink/bugsink/blob/bddc2e8f640e82b7d1f861f1b8b363535d8a22a1/bugsink/conf_templates/singleserver.py.template#L41
+            - name: TIME_ZONE
+              value: "Asia/Tokyo"
           resources:
             limits:
               cpu: 200m


### PR DESCRIPTION
Web UI上での時間表記のタイムゾーンを`Asia/Tokyo`にする。（DBに格納される日時はUTCで変わらない）
なお、以下確認済み。

- Djangoでは、タイムゾーンの表記にzoneinfoモジュールが使用されること（https://docs.djangoproject.com/ja/5.2/topics/i18n/timezones/ ）
- zoneinfoモジュールはPython 3.9以降に含まれるが、コンテナイメージに含まれるシステムのデフォルトのPythonは3.12であること
- コンテナイメージでは、システムのデフォルトのPythonを使用していること（https://hub.docker.com/layers/bugsink/bugsink/2.0.6/images/sha256-b22e6cbe9b061166dbbdbfc12ead8f46ab079d15717783e98dbb3431575a30d3 ）
- zoneinfoモジュールはシステムのタイムゾーン情報を使用すること（https://docs.python.org/3/library/zoneinfo.html#module-zoneinfo ）
- tzdataがコンテナイメージに含まれていること