### PR TITLE
fix: 一時的にMariaDBのPVCのサイズを増やす

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
@@ -17,7 +17,8 @@ spec:
   port: 3306
 
   storage:
-    size: 500Gi
+    # FIXME: Revert to 500Gi
+    size: 580Gi
     storageClassName: synology-iscsi-storage
     resizeInUseVolumes: true
     waitForVolumeResize: true


### PR DESCRIPTION
`resizeInUseVolumes`が`true`になっていて、使用しているStorage Class（`synology-iscsi-storage`）がストレージの自動拡張をサポートしているので、これでOK
https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/api_reference.md#storage
https://github.com/SynologyOpenSource/synology-csi?tab=readme-ov-file
