### PR TITLE
feat: add activeDeadlineSeconds to Argo Workflows to prevent hanging

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/minio-backup-to-pbs/argo-workflows-backup.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/minio-backup-to-pbs/argo-workflows-backup.yaml
@@ -23,6 +23,7 @@ spec:
   serviceAccountName: minio-workflow-sa
   ttlStrategy:
     secondsAfterCompletion: 86400
+  activeDeadlineSeconds: 7200 # 2時間でタイムアウト（image pullの失敗等での長時間ハングを防ぐ）
   entrypoint: default
   templates:
     - name: default

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/argo-workflows-backup-all-databases.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/argo-workflows-backup-all-databases.yaml
@@ -22,6 +22,7 @@ metadata:
     workflows.argoproj.io/description: "Namespace内の全Database CRDを対象に、各.spec.databaseを指定してBackup CRを作成する"
 spec:
   serviceAccountName: mariadb-workflow-sa
+  activeDeadlineSeconds: 7200 # 2時間でタイムアウト（image pullの失敗等での長時間ハングを防ぐ）
   entrypoint: default
   templates:
     - name: default

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/argo-workflows-stop-server.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/argo-workflows-stop-server.yaml
@@ -9,6 +9,7 @@ spec:
   serviceAccountName: mcserver--s1-workflow-sa
   ttlStrategy:
     secondsAfterCompletion: 86400
+  activeDeadlineSeconds: 600 # 10分でタイムアウト（image pullの失敗等での長時間ハングを防ぐ）
   entrypoint: default
   templates:
     - name: default

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/argo-workflows-stop-server.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/argo-workflows-stop-server.yaml
@@ -9,6 +9,7 @@ spec:
   serviceAccountName: mcserver--s2-workflow-sa
   ttlStrategy:
     secondsAfterCompletion: 86400
+  activeDeadlineSeconds: 600 # 10分でタイムアウト（image pullの失敗等での長時間ハングを防ぐ）
   entrypoint: default
   templates:
     - name: default

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/argo-workflows-stop-server.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/argo-workflows-stop-server.yaml
@@ -9,6 +9,7 @@ spec:
   serviceAccountName: mcserver--s3-workflow-sa
   ttlStrategy:
     secondsAfterCompletion: 86400
+  activeDeadlineSeconds: 600 # 10分でタイムアウト（image pullの失敗等での長時間ハングを防ぐ）
   entrypoint: default
   templates:
     - name: default

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/argo-workflows-stop-server.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/argo-workflows-stop-server.yaml
@@ -9,6 +9,7 @@ spec:
   serviceAccountName: mcserver--s5-workflow-sa
   ttlStrategy:
     secondsAfterCompletion: 86400
+  activeDeadlineSeconds: 600 # 10分でタイムアウト（image pullの失敗等での長時間ハングを防ぐ）
   entrypoint: default
   templates:
     - name: default

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/argo-workflows-stop-server.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/argo-workflows-stop-server.yaml
@@ -9,6 +9,7 @@ spec:
   serviceAccountName: mcserver--s7-workflow-sa
   ttlStrategy:
     secondsAfterCompletion: 86400
+  activeDeadlineSeconds: 600 # 10分でタイムアウト（image pullの失敗等での長時間ハングを防ぐ）
   entrypoint: default
   templates:
     - name: default

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--votelistener/argo-workflows-stop-server.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--votelistener/argo-workflows-stop-server.yaml
@@ -9,6 +9,7 @@ spec:
   serviceAccountName: mcserver--votelistener-workflow-sa
   ttlStrategy:
     secondsAfterCompletion: 86400
+  activeDeadlineSeconds: 600 # 10分でタイムアウト（image pullの失敗等での長時間ハングを防ぐ）
   entrypoint: default
   templates:
     - name: default

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/cron-workflow.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/cron-workflow.yaml
@@ -9,6 +9,7 @@ spec:
   concurrencyPolicy: "Forbid"
   workflowSpec:
     serviceAccountName: mcserver--backup-workflow-sa
+    activeDeadlineSeconds: 14400 # 4時間でタイムアウト（image pullの失敗等での長時間ハングを防ぐ）
     entrypoint: run-mcserver-backups
 
     # ref: https://argo-workflows.readthedocs.io/en/latest/walk-through/loops/#withparam-example

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/workflow-template.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/workflow-template.yaml
@@ -7,6 +7,7 @@ spec:
   serviceAccountName: mcserver--backup-workflow-sa
   ttlStrategy:
     secondsAfterCompletion: 86400
+  activeDeadlineSeconds: 14400 # 4時間でタイムアウト（image pullの失敗等での長時間ハングを防ぐ）
   entrypoint: mcserver-backup-entrypoint
   arguments:
     # NOTE: Argo Workflows の Example やドキュメントには spec.arguments.parameters で指定する parameter には必ず value を指定しているように見えるが、


### PR DESCRIPTION
## Summary
image pullの失敗などで長時間ハングするのを防ぐため、各ワークフローに適切な`activeDeadlineSeconds`を設定しました。

## 変更内容
以下の10個のワークフローに`activeDeadlineSeconds`を追加：

### バックアップワークフロー
- **MinIO Backup**: 7200秒（2時間）
- **MariaDB All Databases Backup**: 7200秒（2時間）
- **MCServer Backup (CronWorkflow + WorkflowTemplate)**: 14400秒（4時間、5サーバー分）

### サーバー停止ワークフロー（6個）
- mcserver--s1, s2, s3, s5, s7, votelistener: 各600秒（10分）

## 背景
`backup--seichi-private-plugin-blackhole-minio` CronWorkflowでimage pullが失敗し、20日間ハングしていた問題を受けて、すべてのワークフローに適切なタイムアウトを設定しました。

## 仕様確認
Argo Workflows公式ドキュメントに基づき、`WorkflowSpec.activeDeadlineSeconds`および`CronWorkflow.workflowSpec.activeDeadlineSeconds`に設定することを確認済みです。

参考: https://argo-workflows.readthedocs.io/en/latest/walk-through/timeouts/

🤖 Generated with [Claude Code](https://claude.com/claude-code)