### PR TITLE
  fix(valkey): update service names for new helm chart

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/minecraft-gateway-bungeecord/configs/plugin-configs.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/minecraft-gateway-bungeecord/configs/plugin-configs.yaml
@@ -50,7 +50,7 @@ data:
     synchronized-server-regex:
 
     redis:
-      host: seichi-bungeesemaphore-valkey-primary
+      host: seichi-bungeesemaphore-valkey
       port: 6379
 
     locale:
@@ -71,7 +71,7 @@ data:
 
     # The Redis server you use.
     # Get Redis from http://redis.io/
-    redis-server: seichi-redisbungee-valkey-primary
+    redis-server: seichi-redisbungee-valkey
     redis-port: 6379
     # OPTIONAL: If your Redis server uses AUTH, set the password required.
     redis-password: ""

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/common-configs/seichiassist-config.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/common-configs/seichiassist-config.yaml
@@ -140,7 +140,7 @@ data:
 
     # RedisBungeeが利用しているRedisインスタンスの接続情報
     RedisBungee:
-      redis-host: seichi-debug-redisbungee-valkey-primary.seichi-debug-gateway
+      redis-host: seichi-debug-redisbungee-valkey.seichi-debug-gateway
       redis-port: 6379
       # Redisサーバーがパスワードを持っている場合、次の行をアンコメントしてパスワードを入れること。
       # redis-password: ""
@@ -154,7 +154,7 @@ data:
       # デフォルトは55秒に設定されている。タイムアウトを無効にする場合負の値を設定すること。
       SaveTimeout: 55000
       Redis:
-        Host: seichi-debug-bungeesemaphore-valkey-primary.seichi-debug-gateway
+        Host: seichi-debug-bungeesemaphore-valkey.seichi-debug-gateway
         Port: 6379
         # Redisサーバーがパスワードを持っている場合、次の行をアンコメントしてパスワードを入れること。
         # Password: ""

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-gateway/bungeecord/bungeecord-plugin-configs-patch.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-gateway/bungeecord/bungeecord-plugin-configs-patch.yaml
@@ -15,7 +15,7 @@ data:
   BungeeSemaphore-config.yml: |
     synchronized-server-regex: "^(deb-s\\d+)$"
     redis:
-      host: seichi-debug-bungeesemaphore-valkey-primary.seichi-debug-gateway
+      host: seichi-debug-bungeesemaphore-valkey.seichi-debug-gateway
       port: 6379
 
     locale:
@@ -28,7 +28,7 @@ data:
   RedisBungee-config.yml: |
     server-id: ""
     use-random-id-string: true
-    redis-server: seichi-debug-redisbungee-valkey-primary.seichi-debug-gateway
+    redis-server: seichi-debug-redisbungee-valkey.seichi-debug-gateway
     redis-port: 6379
     redis-password: ""
     max-redis-connections: 8

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
@@ -133,13 +133,13 @@ spec:
                   key: SEICHIASSIST_DEBUG_S1_WEBHOOK_URL
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_REDISBUNGEE_REDIS_HOST
-              value: seichi-debug-redisbungee-valkey-primary.seichi-debug-gateway
+              value: seichi-debug-redisbungee-valkey.seichi-debug-gateway
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_REDISBUNGEE_REDIS_PORT
               value: "6379"
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_BUNGEESEMAPHORE_RESPONDER_REDIS_HOST
-              value: seichi-debug-bungeesemaphore-valkey-primary.seichi-debug-gateway
+              value: seichi-debug-bungeesemaphore-valkey.seichi-debug-gateway
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_BUNGEESEMAPHORE_RESPONDER_REDIS_PORT
               value: "6379"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-gateway/bungeecord/bungeecord-plugin-configs-patch.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-gateway/bungeecord/bungeecord-plugin-configs-patch.yaml
@@ -15,7 +15,7 @@ data:
   BungeeSemaphore-config.yml: |
     synchronized-server-regex: "^(s\\d+)$"
     redis:
-      host: seichi-bungeesemaphore-valkey-primary.seichi-minecraft
+      host: seichi-bungeesemaphore-valkey.seichi-minecraft
       port: 6379
 
     locale:
@@ -28,7 +28,7 @@ data:
   RedisBungee-config.yml: |
     server-id: ""
     use-random-id-string: true
-    redis-server: seichi-redisbungee-valkey-primary.seichi-minecraft
+    redis-server: seichi-redisbungee-valkey.seichi-minecraft
     redis-port: 6379
     redis-password: ""
     max-redis-connections: 8

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
@@ -147,13 +147,13 @@ spec:
                   key: SEICHIASSIST_S1_WEBHOOK_URL
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_REDISBUNGEE_REDIS_HOST
-              value: seichi-redisbungee-valkey-primary
+              value: seichi-redisbungee-valkey
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_REDISBUNGEE_REDIS_PORT
               value: "6379"
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_BUNGEESEMAPHORE_RESPONDER_REDIS_HOST
-              value: seichi-bungeesemaphore-valkey-primary
+              value: seichi-bungeesemaphore-valkey
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_BUNGEESEMAPHORE_RESPONDER_REDIS_PORT
               value: "6379"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/stateful-set.yaml
@@ -147,13 +147,13 @@ spec:
                   key: SEICHIASSIST_S2_WEBHOOK_URL
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_REDISBUNGEE_REDIS_HOST
-              value: seichi-redisbungee-valkey-primary
+              value: seichi-redisbungee-valkey
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_REDISBUNGEE_REDIS_PORT
               value: "6379"
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_BUNGEESEMAPHORE_RESPONDER_REDIS_HOST
-              value: seichi-bungeesemaphore-valkey-primary
+              value: seichi-bungeesemaphore-valkey
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_BUNGEESEMAPHORE_RESPONDER_REDIS_PORT
               value: "6379"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/stateful-set.yaml
@@ -147,13 +147,13 @@ spec:
                   key: SEICHIASSIST_S3_WEBHOOK_URL
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_REDISBUNGEE_REDIS_HOST
-              value: seichi-redisbungee-valkey-primary
+              value: seichi-redisbungee-valkey
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_REDISBUNGEE_REDIS_PORT
               value: "6379"
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_BUNGEESEMAPHORE_RESPONDER_REDIS_HOST
-              value: seichi-bungeesemaphore-valkey-primary
+              value: seichi-bungeesemaphore-valkey
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_BUNGEESEMAPHORE_RESPONDER_REDIS_PORT
               value: "6379"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
@@ -147,13 +147,13 @@ spec:
                   key: SEICHIASSIST_S5_WEBHOOK_URL
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_REDISBUNGEE_REDIS_HOST
-              value: seichi-redisbungee-valkey-primary
+              value: seichi-redisbungee-valkey
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_REDISBUNGEE_REDIS_PORT
               value: "6379"
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_BUNGEESEMAPHORE_RESPONDER_REDIS_HOST
-              value: seichi-bungeesemaphore-valkey-primary
+              value: seichi-bungeesemaphore-valkey
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_BUNGEESEMAPHORE_RESPONDER_REDIS_PORT
               value: "6379"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/stateful-set.yaml
@@ -147,13 +147,13 @@ spec:
                   key: SEICHIASSIST_S7_WEBHOOK_URL
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_REDISBUNGEE_REDIS_HOST
-              value: seichi-redisbungee-valkey-primary
+              value: seichi-redisbungee-valkey
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_REDISBUNGEE_REDIS_PORT
               value: "6379"
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_BUNGEESEMAPHORE_RESPONDER_REDIS_HOST
-              value: seichi-bungeesemaphore-valkey-primary
+              value: seichi-bungeesemaphore-valkey
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_BUNGEESEMAPHORE_RESPONDER_REDIS_PORT
               value: "6379"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--votelistener/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--votelistener/stateful-set.yaml
@@ -140,13 +140,13 @@ spec:
                   key: mcserver-password
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_REDISBUNGEE_REDIS_HOST
-              value: seichi-redisbungee-valkey-primary
+              value: seichi-redisbungee-valkey
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_REDISBUNGEE_REDIS_PORT
               value: "6379"
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_BUNGEESEMAPHORE_RESPONDER_REDIS_HOST
-              value: seichi-bungeesemaphore-valkey-primary
+              value: seichi-bungeesemaphore-valkey
 
             - name: CFG_REPLACEMENT__SEICHIASSIST_BUNGEESEMAPHORE_RESPONDER_REDIS_PORT
               value: "6379"


### PR DESCRIPTION
  Remove '-primary' suffix from valkey service references to match
  the official valkey-helm chart's service naming convention.