### PR TITLE
chore: grouping `mariadb-operator` in Renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -42,6 +42,13 @@
       "groupName": "itzg/minecraft-server images",
       "schedule": ["at any time"],
       "automerge": true
+    },
+    {
+      "matchPackageNames": [
+        "mariadb-operator",
+        "mariadb-operator-crds"
+      ],
+      "groupName": "mariadb-operator"
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
#4114 #4120 