### PR TITLE
fix(mariadb): update ephemeralStorage to new API format

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mariadb/mariadb.yaml
@@ -46,7 +46,8 @@ spec:
 
   port: 3306
 
-  ephemeralStorage: true
+  storage:
+    ephemeral: true
 
   myCnf: |
     [mariadb]


### PR DESCRIPTION
mariadb-operator v0.0.26 introduced a breaking change where `spec.ephemeralStorage` was moved to `spec.storage.ephemeral`.

This fixes the seichi-debug-minecraft-mariadb ArgoCD application which has been failing with schema validation error since 2025-12-22.

Ref: https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_v0.0.26.md