### PR TITLE
fix(snmp-exporter): change auth param to list format

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-snmp-exporter.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-snmp-exporter.yaml
@@ -28,7 +28,8 @@ spec:
               target: 192.168.19.253
               module:
                 - if_mib
-              auth: seichi_prod_v2
+              auth:
+                - seichi_prod_v2
               labels:
                 release: prometheus
               interval: 30s
@@ -39,7 +40,8 @@ spec:
               target: 192.168.1.1
               module:
                 - if_mib
-              auth: seichi_prod_v2
+              auth:
+                - seichi_prod_v2
               labels:
                 release: prometheus
               interval: 30s
@@ -50,7 +52,8 @@ spec:
               target: 192.168.16.240
               module:
                 - synology
-              auth: synology_v2
+              auth:
+                - synology_v2
               labels:
                 release: prometheus
               interval: 30s
@@ -61,7 +64,8 @@ spec:
               target: 192.168.16.230
               module:
                 - synology
-              auth: synology_v2
+              auth:
+                - synology_v2
               labels:
                 release: prometheus
               interval: 30s


### PR DESCRIPTION
ServiceMonitor CRD expects params to be map[string][]string. The auth field was incorrectly specified as a string instead of a list, causing sync failures with error:
".spec.endpoints[0].params.auth: expected list, got &{synology_v2}"

Ref: https://github.com/prometheus/snmp_exporter/blob/main/auth-split-migration.md