### PR TITLE
fix: remove Replace=true syncOption to allow ServerSideApply for larg…

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
@@ -210,7 +210,6 @@ spec:
       selfHeal: true
     syncOptions:
       - ServerSideApply=true
-      - Replace=true
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -239,4 +238,3 @@ spec:
       selfHeal: true
     syncOptions:
       - ServerSideApply=true
-      - Replace=true


### PR DESCRIPTION
…e CRDs

Replace=true takes precedence over ServerSideApply=true, causing "metadata.annotations: Too long" errors for kube-prometheus-stack CRDs that exceed the 256KB annotation limit.