### PR TITLE
fix: add PROCESS privilege to monitoring user for slow query dashboard

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/monitoring-db-user.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/monitoring-db-user.yaml
@@ -27,6 +27,7 @@ spec:
     - "SELECT"
     - "SHOW DATABASES"
     - "SHOW VIEW"
+    - "PROCESS"
   database: "*"
   table: "*"
   username: "monitoring"


### PR DESCRIPTION
## Summary

- MariaDBの `performance_schema` を直接クエリするスロークエリ分析ダッシュボードを追加
- `monitoring`ユーザーに`PROCESS`権限を追加 (PROCESSLIST参照に必要)

## 変更内容

### 新規: grafana-dashboard-slow-queries.yaml
- Top Queries by Total Time
- Slowest Queries by Average Time
- Query Statistics by Database (円グラフ)
- Currently Running Queries
- Queries Examining Most Rows (フルスキャン検出)
- Queries with Errors

### 修正: monitoring-db-user.yaml
- `PROCESS`権限を追加

## Test plan

- [ ] ArgoCDで `seichi-minecraft-mariadb` がSyncされることを確認
- [ ] Grafanaの「MariaDB Slow Query Analysis」ダッシュボードが表示されることを確認
- [ ] 「Currently Running Queries」パネルにデータが表示されることを確認