### PR TITLE
fix: set default instance to production MariaDB

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard.yaml
@@ -361,7 +361,7 @@ data:
           },
           {
             "allValue": ".*",
-            "current": { "selected": false, "text": "All", "value": "$__all" },
+            "current": { "selected": true, "text": "mariadb-0.mariadb-internal.seichi-minecraft.svc.cluster.local", "value": "mariadb-0.mariadb-internal.seichi-minecraft.svc.cluster.local" },
             "datasource": { "type": "prometheus", "uid": "${datasource}" },
             "definition": "label_values(mysql_up, instance)",
             "hide": 0,


### PR DESCRIPTION
Change default instance from "All" to the production MariaDB instance (mariadb-0.mariadb-internal.seichi-minecraft.svc.cluster.local)