### PR TITLE
fix: Cloudflare provider v4 の deprecation warning を修正

### DIFF
--- a/terraform/cloudflare_access_github.tf
+++ b/terraform/cloudflare_access_github.tf
@@ -6,4 +6,8 @@ resource "cloudflare_access_identity_provider" "github_oauth" {
     client_id     = var.github_cloudflare_oauth_client_id
     client_secret = var.github_cloudflare_oauth_client_secret
   }
+
+  lifecycle {
+    ignore_changes = [config[0].client_secret]
+  }
 }

--- a/terraform/cloudflare_dns_records.tf
+++ b/terraform/cloudflare_dns_records.tf
@@ -3,7 +3,7 @@
 resource "cloudflare_record" "play" {
   zone_id = local.cloudflare_zone_id
   name    = "play"
-  value   = "nrt.premium-aws.tcpshield.com"
+  content = "nrt.premium-aws.tcpshield.com"
   type    = "CNAME"
   ttl     = 1 # automatic
 }
@@ -11,7 +11,7 @@ resource "cloudflare_record" "play" {
 resource "cloudflare_record" "play_debug" {
   zone_id = local.cloudflare_zone_id
   name    = "play-debug"
-  value   = "nrt.premium-aws.tcpshield.com"
+  content = "nrt.premium-aws.tcpshield.com"
   type    = "CNAME"
   ttl     = 1 # automatic
 }
@@ -19,7 +19,7 @@ resource "cloudflare_record" "play_debug" {
 resource "cloudflare_record" "github_pages" {
   zone_id = local.cloudflare_zone_id
   name    = "_github-pages-challenge-GiganticMinecraft"
-  value   = "e6145d3fd4824da7133309fa2dd2c6"
+  content = "e6145d3fd4824da7133309fa2dd2c6"
   type    = "TXT"
   ttl     = 1 # automatic
 }
@@ -27,7 +27,7 @@ resource "cloudflare_record" "github_pages" {
 resource "cloudflare_record" "github_pages_command_reference" {
   zone_id = local.cloudflare_zone_id
   name    = "cmd"
-  value   = "giganticminecraft.github.io"
+  content = "giganticminecraft.github.io"
   type    = "CNAME"
   ttl     = 1 # automatic
 }
@@ -35,7 +35,7 @@ resource "cloudflare_record" "github_pages_command_reference" {
 resource "cloudflare_record" "portal" {
   zone_id = local.cloudflare_zone_id
   name    = "portal"
-  value   = "${cloudflare_pages_project.seichi_portal.name}.pages.dev"
+  content = "${cloudflare_pages_project.seichi_portal.name}.pages.dev"
   type    = "CNAME"
   ttl     = 1 # automatic
 }
@@ -43,7 +43,7 @@ resource "cloudflare_record" "portal" {
 resource "cloudflare_record" "playguide" {
   zone_id = local.cloudflare_zone_id
   name    = "playguide"
-  value   = "${cloudflare_pages_project.seichi_playguide.name}.pages.dev"
+  content = "${cloudflare_pages_project.seichi_playguide.name}.pages.dev"
   type    = "CNAME"
   ttl     = 1 # automatic
 }
@@ -60,7 +60,7 @@ resource "cloudflare_record" "playguide" {
 resource "cloudflare_record" "local_tunnels" {
   zone_id = local.cloudflare_zone_id
   name    = "*.local-tunnels.seichi.click"
-  value   = "127.0.0.1"
+  content = "127.0.0.1"
   type    = "A"
   ttl     = 1 # automatic
 }


### PR DESCRIPTION
- cloudflare_record の `value` 属性を `content` に変更
- cloudflare_access_identity_provider の client_secret drift を ignore_changes で抑制