### PR TITLE
refactor: migrate cloudflare_filter/firewall_rule to cloudflare_ruleset

### DIFF
--- a/terraform/cloudflare_firewall_rules.tf
+++ b/terraform/cloudflare_firewall_rules.tf
@@ -1,27 +1,27 @@
-resource "cloudflare_filter" "minio_api_requests" {
+resource "cloudflare_ruleset" "waf_bypass_rules" {
   zone_id     = local.cloudflare_zone_id
-  description = "MinIO API requests"
-  expression  = "http.host eq \"minio-console.onp-k8s.admin.seichi.click\""
-}
+  name        = "WAF Bypass Rules"
+  description = "WAFルールをバイパスするカスタムファイアウォールルール"
+  kind        = "zone"
+  phase       = "http_request_firewall_custom"
 
-resource "cloudflare_firewall_rule" "bypass_waf_on_minio_api_requests" {
-  zone_id     = local.cloudflare_zone_id
-  description = "Let MinIO API requests bypass WAF rules"
-  filter_id   = cloudflare_filter.minio_api_requests.id
-  action      = "bypass"
-  products    = toset(["waf"])
-}
+  rules {
+    action      = "skip"
+    expression  = "http.host eq \"minio-console.onp-k8s.admin.seichi.click\""
+    description = "Let MinIO API requests bypass WAF rules"
+    action_parameters {
+      products = ["waf"]
+    }
+    enabled = true
+  }
 
-resource "cloudflare_filter" "phpmyadmin_api_requests" {
-  zone_id     = local.cloudflare_zone_id
-  description = "phpMyAdmin API requests"
-  expression  = "http.host eq \"phpmyadmin.onp-k8s.admin.seichi.click\""
-}
-
-resource "cloudflare_firewall_rule" "bypass_waf_on_phpmyadmin_requests" {
-  zone_id     = local.cloudflare_zone_id
-  description = "Let phpMyAdmin requests bypass WAF rules"
-  filter_id   = cloudflare_filter.phpmyadmin_api_requests.id
-  action      = "bypass"
-  products    = toset(["waf"])
+  rules {
+    action      = "skip"
+    expression  = "http.host eq \"phpmyadmin.onp-k8s.admin.seichi.click\""
+    description = "Let phpMyAdmin requests bypass WAF rules"
+    action_parameters {
+      products = ["waf"]
+    }
+    enabled = true
+  }
 }


### PR DESCRIPTION
## Summary
- `cloudflare_filter`（2個）+ `cloudflare_firewall_rule`（2個）を削除し、`cloudflare_ruleset`（1個）に置き換え
- `cloudflare_filter` / `cloudflare_firewall_rule` は deprecated であり、v5 では削除されるため事前に移行
- WAF バイパスルール（MinIO コンソール、phpMyAdmin）の動作は同等

## 適用手順
1. `terraform plan` で旧リソース4個の destroy + 新リソース1個の create を確認
2. `terraform apply`

## Test plan
- [x] `terraform plan` で予期しない差分がないことを確認
- [ ] apply 後、MinIO コンソールおよび phpMyAdmin が WAF にブロックされずアクセスできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)