### PR TITLE
fix: add logging block to new firewall rules

### DIFF
--- a/terraform/cloudflare_firewall_rules.tf
+++ b/terraform/cloudflare_firewall_rules.tf
@@ -69,6 +69,9 @@ resource "cloudflare_ruleset" "custom_firewall_rules" {
     action_parameters {
       products = ["waf"]
     }
+    logging {
+      enabled = true
+    }
     enabled = true
   }
 
@@ -78,6 +81,9 @@ resource "cloudflare_ruleset" "custom_firewall_rules" {
     description = "Let phpMyAdmin requests bypass WAF rules"
     action_parameters {
       products = ["waf"]
+    }
+    logging {
+      enabled = true
     }
     enabled = true
   }


### PR DESCRIPTION
The Cloudflare provider automatically adds a logging block to rules after apply, causing an inconsistent result error. Adding explicit logging blocks to match the existing rules.