### PR TITLE
chore: デバッグサーバーのワールドデータを復元しないようにする

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
@@ -300,8 +300,8 @@ spec:
             - name: worldedit-schematica-volume
               mountPath: /worldedit-schematica
 
-            - name: mcserver--debug-s1-data
-              mountPath: /data
+            # - name: mcserver--debug-s1-data
+            #   mountPath: /data
 
       volumes:
         # mod-downloaderからプラグインをinitContainerでダウンロードしてMinecraftに受け渡すためのvolume


### PR DESCRIPTION
サーバーが上がってこないので切り分けのために