### PR TITLE
fix: Tempo datasource の URL ポートを 3100 から 3200 に修正

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
@@ -123,7 +123,7 @@ spec:
                 - name: Tempo
                   type: tempo
                   access: proxy
-                  url: http://tempo:3100
+                  url: http://tempo:3200
                   isDefault: false
                   jsonData:
                     tracesToLogsV2:


### PR DESCRIPTION
Tempo の HTTP API ポートは 3200 だが、Loki のデフォルトポート 3100 が 誤って設定されていたため、Grafana Explore Traces が動作しなかった。