### PR TITLE
fix: Grafana の不要な piechart Angular プラグイン削除と sidecar エラー修正

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
@@ -43,7 +43,7 @@ spec:
               isDefaultDatasource: false
             dashboards:
               enabled: true
-              defaultFolderName: "General"
+              defaultFolderName: ""
               label: grafana_dashboard
               labelValue: "1"
               folderAnnotation: grafana_folder
@@ -52,7 +52,6 @@ spec:
                 foldersFromFilesStructure: true
           defaultDashboardsTimezone: Asia/Tokyo
           plugins:
-            - grafana-piechart-panel
             - isovalent-hubble-datasource
             - grafana-sentry-datasource
           grafana.ini:


### PR DESCRIPTION
- grafana-piechart-panel は Angular プラグインで Grafana v11+ では サポート外。ビルトインの piechart パネルで代替できるため削除
- defaultFolderName を空にして /tmp/dashboards/General が存在しない ことによる sidecar のプロビジョニングエラーを解消