### PR TITLE
fix: Grafana メモリ limit メトリクス修正 + kagawa Java 8 互換性修正

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/jvm-metrics/grafana-dashboard.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/jvm-metrics/grafana-dashboard.yaml
@@ -904,7 +904,7 @@ data:
             "tooltip": { "mode": "multi", "sort": "desc" }
           },
           "targets": [
-            { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "container_memory_working_set_bytes{namespace=\"seichi-minecraft\", pod=~\"mcserver--$server-0\", container=\"minecraft\"} / container_spec_memory_limit_bytes{namespace=\"seichi-minecraft\", pod=~\"mcserver--$server-0\", container=\"minecraft\"}", "legendFormat": "{{pod}}", "refId": "A" }
+            { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "container_memory_working_set_bytes{namespace=\"seichi-minecraft\", pod=~\"mcserver--$server-0\", container=\"minecraft\"} / on(pod, namespace) group_left() kube_pod_container_resource_limits{namespace=\"seichi-minecraft\", pod=~\"mcserver--$server-0\", container=\"minecraft\", resource=\"memory\"}", "legendFormat": "{{pod}}", "refId": "A" }
           ],
           "title": "Container Memory Usage vs Limit",
           "type": "timeseries"
@@ -932,7 +932,7 @@ data:
           },
           "targets": [
             { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "container_memory_working_set_bytes{namespace=\"seichi-minecraft\", pod=~\"mcserver--$server-0\", container=\"minecraft\"}", "legendFormat": "{{pod}} used", "refId": "A" },
-            { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "container_spec_memory_limit_bytes{namespace=\"seichi-minecraft\", pod=~\"mcserver--$server-0\", container=\"minecraft\"}", "legendFormat": "{{pod}} limit", "refId": "B" }
+            { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "kube_pod_container_resource_limits{namespace=\"seichi-minecraft\", pod=~\"mcserver--$server-0\", container=\"minecraft\", resource=\"memory\"}", "legendFormat": "{{pod}} limit", "refId": "B" }
           ],
           "title": "Container Memory (Working Set vs Limit)",
           "type": "timeseries"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--kagawa/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--kagawa/stateful-set.yaml
@@ -66,7 +66,7 @@ spec:
             - name: JVM_XX_OPTS
               value: >-
                 -XX:ErrorFile=/data/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError
-                -XX:HeapDumpPath=/data/ -XX:+CreateCoredumpOnCrash
+                -XX:HeapDumpPath=/data/
                 -XX:NativeMemoryTracking=summary
 
             - name: CFG_REPLACEMENT__DISCORDSRV_TOKEN


### PR DESCRIPTION
## Summary
- Grafana ダッシュボード「Container Memory Usage vs Limit」パネルが No Data だった問題を修正
  - `container_spec_memory_limit_bytes` (存在しないメトリクス) → `kube_pod_container_resource_limits{resource="memory"}` (kube-state-metrics 提供)
- kagawa サーバーが `-XX:+CreateCoredumpOnCrash` で起動失敗する問題を修正
  - kagawa は Java 8 ベースのため、Java 9+ のオプション `CreateCoredumpOnCrash` を削除

## Test plan
- [ ] Grafana の Minecraft Servers ダッシュボードで s1 の「Container Memory Usage vs Limit」にデータが表示される
- [ ] kagawa サーバーが正常に起動する

🤖 Generated with [Claude Code](https://claude.com/claude-code)