### PR TITLE
feat: seichi-portal-backend の依存インフラ (Valkey, MeiliSearch, RabbitMQ) を追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/meilisearch/meilisearch.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/meilisearch/meilisearch.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: seichi-portal-meilisearch
+  namespace: argocd
+spec:
+  project: seichi-minecraft
+  source:
+    chart: meilisearch
+    repoURL: 'https://meilisearch.github.io/meilisearch-kubernetes'
+    targetRevision: 0.25.1
+    helm:
+      releaseName: seichi-portal-meilisearch
+      values: |
+        image:
+          repository: getmeili/meilisearch
+          tag: "v1.36.0"
+        environment:
+          MEILI_ENV: production
+          MEILI_NO_ANALYTICS: "true"
+        persistence:
+          enabled: true
+          size: 10Gi
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+          limits:
+            cpu: "500m"
+            memory: "1Gi"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: seichi-minecraft
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/rabbitmq/credentials.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/rabbitmq/credentials.yaml
@@ -1,0 +1,11 @@
+apiVersion: "secretgenerator.mittwald.de/v1alpha1"
+kind: "StringSecret"
+metadata:
+  namespace: seichi-minecraft
+  name: seichi-portal-rabbitmq-credentials
+spec:
+  forceRegenerate: false
+  fields:
+    - fieldName: "password"
+      encoding: "hex"
+      length: "32"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/rabbitmq/definitions.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/rabbitmq/definitions.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: seichi-portal-rabbitmq-definitions
+  namespace: seichi-minecraft
+data:
+  definitions.json: |
+    {
+      "vhosts": [
+        {
+          "name": "/"
+        }
+      ],
+      "exchanges": [
+        {
+          "name": "seichi_portal",
+          "vhost": "/",
+          "type": "direct",
+          "durable": true
+        }
+      ],
+      "queues": [
+        {
+          "name": "seichi_portal",
+          "vhost": "/",
+          "durable": true,
+          "auto_delete": false,
+          "internal": false,
+          "arguments": {}
+        }
+      ],
+      "bindings": [
+        {
+          "source": "seichi_portal",
+          "vhost": "/",
+          "destination": "seichi_portal",
+          "destination_type": "queue",
+          "routing_key": "seichi_portal",
+          "arguments": {}
+        }
+      ]
+    }

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/rabbitmq/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/rabbitmq/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: seichi-portal-rabbitmq
+  namespace: seichi-minecraft
+  labels:
+    app: seichi-portal-rabbitmq
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: seichi-portal-rabbitmq
+  template:
+    metadata:
+      labels:
+        app: seichi-portal-rabbitmq
+    spec:
+      containers:
+        - name: rabbitmq
+          image: rabbitmq:4.2-management-alpine
+          env:
+            - name: RABBITMQ_DEFAULT_USER
+              value: seichi-portal
+            - name: RABBITMQ_DEFAULT_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: seichi-portal-rabbitmq-credentials
+                  key: password
+            - name: RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS
+              value: '-rabbitmq_management load_definitions "/etc/rabbitmq/definitions.json"'
+          ports:
+            - name: amqp
+              containerPort: 5672
+            - name: management
+              containerPort: 15672
+            - name: prometheus
+              containerPort: 15692
+          volumeMounts:
+            - name: definitions
+              mountPath: /etc/rabbitmq/definitions.json
+              subPath: definitions.json
+            - name: data
+              mountPath: /var/lib/rabbitmq
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          livenessProbe:
+            exec:
+              command:
+                - rabbitmq-diagnostics
+                - ping
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - rabbitmq-diagnostics
+                - ping
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 5
+      volumes:
+        - name: definitions
+          configMap:
+            name: seichi-portal-rabbitmq-definitions
+        - name: data
+          persistentVolumeClaim:
+            claimName: seichi-portal-rabbitmq-data

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/rabbitmq/pvc.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/rabbitmq/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: seichi-portal-rabbitmq-data
+  namespace: seichi-minecraft
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 8Gi

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/rabbitmq/service.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/rabbitmq/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: seichi-portal-rabbitmq
+  namespace: seichi-minecraft
+  labels:
+    app: seichi-portal-rabbitmq
+spec:
+  selector:
+    app: seichi-portal-rabbitmq
+  ports:
+    - name: amqp
+      port: 5672
+      targetPort: amqp
+    - name: management
+      port: 15672
+      targetPort: management
+    - name: prometheus
+      port: 15692
+      targetPort: prometheus

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
@@ -43,3 +43,22 @@ spec:
               value: "9000"
             - name: ENV_NAME
               value: production
+            - name: REDIS_HOST
+              value: seichi-portal-valkey
+            - name: REDIS_PORT
+              value: "6379"
+            - name: MEILISEARCH_HOST
+              value: http://seichi-portal-meilisearch:7700
+            - name: RABBITMQ_USER
+              value: seichi-portal
+            - name: RABBITMQ_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: seichi-portal-rabbitmq-credentials
+                  key: password
+            - name: RABBITMQ_HOST
+              value: seichi-portal-rabbitmq
+            - name: RABBITMQ_PORT
+              value: "5672"
+            - name: RABBITMQ_ROUTING_KEY
+              value: seichi_portal

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/valkey/seichi-portal-valkey.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/valkey/seichi-portal-valkey.yaml
@@ -1,0 +1,91 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: seichi-portal-valkey
+  namespace: argocd
+spec:
+  project: seichi-minecraft
+  source:
+    chart: valkey
+    repoURL: 'https://valkey-io.github.io/valkey-helm'
+    targetRevision: 0.9.3
+    helm:
+      releaseName: seichi-portal-valkey
+      values: |
+        image:
+          registry: "docker.io"
+          repository: valkey/valkey-bundle
+          tag: "9.0"
+        deploymentStrategy: Recreate
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "512Mi"
+        valkeyConfig: |
+          maxmemory 1024mb
+        dataStorage:
+          enabled: true
+          requestedSize: 8Gi
+        metrics:
+          enabled: true
+          exporter:
+            image:
+              registry: mirror.gcr.io
+              repository: oliver006/redis_exporter
+              tag: "v1.80.1"
+            resources:
+              requests:
+                cpu: "100m"
+                memory: "128Mi"
+              limits:
+                cpu: "150m"
+                memory: "192Mi"
+          serviceMonitor:
+            enabled: true
+            additionalLabels:
+              release: prometheus
+          prometheusRule:
+            enabled: true
+            extraLabels:
+              release: prometheus
+            rules:
+              - alert: ValkeyDown
+                expr: redis_up{service="{{ include "valkey.fullname" . }}-metrics"} == 0
+                for: 2m
+                labels:
+                  severity: error
+                annotations:
+                  summary: Valkey instance {{ "{{ $labels.instance }}" }} down
+                  description: Valkey instance {{ "{{ $labels.instance }}" }} is down
+              - alert: ValkeyMemoryHigh
+                expr: >
+                  redis_memory_used_bytes{service="{{ include "valkey.fullname" . }}-metrics"} * 100
+                  /
+                  redis_memory_max_bytes{service="{{ include "valkey.fullname" . }}-metrics"}
+                  > 90 <= 100
+                for: 2m
+                labels:
+                  severity: error
+                annotations:
+                  summary: Valkey instance {{ "{{ $labels.instance }}" }} is using too much memory
+                  description: |
+                    Valkey instance {{ "{{ $labels.instance }}" }} is using {{ "{{ $value }}" }}% of its available memory.
+              - alert: ValkeyKeyEviction
+                expr: |
+                  increase(redis_evicted_keys_total{service="{{ include "valkey.fullname" . }}-metrics"}[5m]) > 0
+                for: 1s
+                labels:
+                  severity: error
+                annotations:
+                  summary: Valkey instance {{ "{{ $labels.instance }}" }} has evicted keys
+                  description: |
+                    Valkey instance {{ "{{ $labels.instance }}" }} has evicted {{ "{{ $value }}" }} keys in the last 5 minutes.
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: seichi-minecraft
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true


### PR DESCRIPTION
seichi-portal-backend が起動時に MEILISEARCH_HOST の不足で panic していた問題に対応。 アプリが必要とする Valkey (セッション管理)、MeiliSearch (検索)、RabbitMQ (CDC メッセージング) を それぞれデプロイし、Deployment に環境変数を追加。

- Valkey: valkey-bundle 9.0 (ValkeyJSON モジュール付き) を Helm chart でデプロイ
- MeiliSearch: 公式 Helm chart v0.25.1 で v1.36.0 をデプロイ
- RabbitMQ: 公式イメージ 4.2-management-alpine を素のマニフェストでデプロイ
- seichi-portal-backend Deployment に REDIS_*, MEILISEARCH_*, RABBITMQ_* 環境変数を追加