### PR TITLE
fix: cluster-wide-apps プロジェクトに democratic-csi namespace を追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/projects.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/projects.yaml
@@ -43,6 +43,8 @@ spec:
       server: https://kubernetes.default.svc
     - namespace: "synology-csi"
       server: https://kubernetes.default.svc
+    - namespace: "democratic-csi"
+      server: https://kubernetes.default.svc
     - namespace: "mariadb-operator"
       server: https://kubernetes.default.svc
     - namespace: "cert-manager"


### PR DESCRIPTION
## 問題

#4414 で追加した `democratic-csi-sc-truenas-03` ArgoCD Application が以下のエラーで同期できない状態だった。

```
application destination server 'https://kubernetes.default.svc' and namespace 'democratic-csi'
do not match any of the allowed destinations in project 'cluster-wide-apps'
```

## 原因

`cluster-wide-apps` AppProject の `destinations` に `democratic-csi` namespace が未記載だった。

## 修正

`synology-csi` と同じ要領で `democratic-csi` namespace を destinations に追加。

## 確認事項

他の cluster namespace との照合も実施し、同様の記載漏れがないことを確認済み。