### PR TITLE
fix: democratic-csi driver 名を freenas-api-iscsi に修正

### DIFF
--- a/seichi-onp-k8s/cluster-boot-up/democratic-csi-sc-truenas-03.md
+++ b/seichi-onp-k8s/cluster-boot-up/democratic-csi-sc-truenas-03.md
@@ -67,7 +67,7 @@ TF_VAR_ONP_K8S_DEMOCRATIC_CSI_SC_TRUENAS_03_DRIVER_CONFIG
 **Secret の値:** 下記 YAML の `<TRUENAS_API_KEY>` を手順 1 で取得した値に置き換えたもの。
 
 ```yaml
-driver: freenas-scale-api-iscsi
+driver: freenas-api-iscsi
 httpConnection:
   protocol: https
   host: 192.168.16.234

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/democratic-csi-sc-truenas-03.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/democratic-csi-sc-truenas-03.yaml
@@ -20,7 +20,7 @@ spec:
           # NOTE: existingConfigSecret 使用時も driver フィールドの指定が必要
           # ref. https://github.com/democratic-csi/charts/blob/master/stable/democratic-csi/values.yaml
           config:
-            driver: freenas-scale-api-iscsi
+            driver: freenas-api-iscsi
 
         storageClasses:
           - name: sc-truenas-03-iscsi


### PR DESCRIPTION
## Summary

- `freenas-scale-api-iscsi` は democratic-csi に存在しない driver 名であることが判明
- TrueNAS SCALE の HTTP API ドライバの正しい名前は `freenas-api-iscsi`
- ArgoCD Application の Helm values と setup ドキュメントを修正

## Test plan

- [ ] PR マージ後、ArgoCD で `democratic-csi-sc-truenas-03` Application が Synced/Healthy になることを確認
- [x] GitHub Secret `TF_VAR_ONP_K8S_DEMOCRATIC_CSI_SC_TRUENAS_03_DRIVER_CONFIG` の `driver:` フィールドも `freenas-api-iscsi` に更新し terraform apply を実行
- [ ] `sc-truenas-03-iscsi` StorageClass が available になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)