### PR TITLE
fix: VolumeSnapshotClass の parameters に fsType を指定してチャートバグを回避

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/democratic-csi-sc-truenas-03.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/democratic-csi-sc-truenas-03.yaml
@@ -34,7 +34,11 @@ spec:
         volumeSnapshotClasses:
           - name: sc-truenas-03-iscsi-vsc
             deletionPolicy: Delete
-            parameters: {}
+            parameters:
+              # chart テンプレートが parameters キーを無条件でレンダリングするため、
+              # 空 map を渡すと parameters: null になりバリデーションエラーになる。
+              # 回避策として最低1エントリが必要。
+              fsType: ext4
   destination:
     server: https://kubernetes.default.svc
     namespace: democratic-csi


### PR DESCRIPTION
## Summary

- democratic-csi chart v0.15.1 のテンプレートが `parameters:` キーを無条件でレンダリングする
- 空 map (`parameters: {}`) を渡すと `parameters: null` になり Kubernetes バリデーションエラーになる
- 回避策として `fsType: ext4` を指定し、parameters フィールドが非 null オブジェクトになるようにする

## Test plan

- [ ] PR マージ後、ArgoCD で `democratic-csi-sc-truenas-03` Application が Synced/Healthy になることを確認
- [ ] `sc-truenas-03-iscsi-vsc` VolumeSnapshotClass が作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)