### PR TITLE
feat: Prometheus に Thanos sidecar を追加し Garage で長期メトリクス保存

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
@@ -162,8 +162,19 @@ spec:
                   secureJsonData:
                     password: ${MARIADB_MONITORING_PASSWORD}
         prometheus:
+          thanosService:
+            enabled: true
+          thanosServiceMonitor:
+            enabled: true
+            labels:
+              release: prometheus
           prometheusSpec:
             enableOTLPReceiver: true
+            thanos:
+              objectStorageConfig:
+                existingSecret:
+                  name: garage-thanos-credentials
+                  key: objstore.yml
             storageSpec:
               volumeClaimTemplate:
                 spec:

--- a/terraform/onp_cluster_secrets.tf
+++ b/terraform/onp_cluster_secrets.tf
@@ -230,8 +230,21 @@ resource "kubernetes_secret" "garage_thanos_credentials" {
   }
 
   data = {
-    "AWS_ACCESS_KEY_ID"     = var.garage_thanos_access_key_id
-    "AWS_SECRET_ACCESS_KEY" = var.garage_thanos_secret_access_key
+    # Thanos sidecar は objstore.yml キーで S3 設定を読み込む
+    "objstore.yml" = yamlencode({
+      type = "S3"
+      config = {
+        bucket       = "thanos"
+        endpoint     = "garage.garage.svc.cluster.local:3900"
+        region       = "seichi-cloud"
+        access_key   = var.garage_thanos_access_key_id
+        secret_key   = var.garage_thanos_secret_access_key
+        insecure     = true
+        http_config  = {
+          idle_conn_timeout = "90s"
+        }
+      }
+    })
   }
 
   type = "Opaque"


### PR DESCRIPTION
Summary

- kube-prometheus-stack に Thanos sidecar を有効化
- Garage の thanos バケットをオブジェクトストレージバックエンドとして設定
- garage-thanos-credentials Secret を Thanos が要求する objstore.yml 形式に変更

Test plan

- Terraform plan で Secret の更新が正しいこと
- Prometheus Pod に thanos-sidecar コンテナが追加されること
- thanos バケットにデータがアップロードされること