### PR TITLE
chore: mod-downloader イメージハッシュを sha-6f4c728 に更新

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-lobby/lobby-server.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-lobby/lobby-server.yaml
@@ -34,7 +34,7 @@ spec:
             - "-c"
             - 'wget -O /root/jmx-exporter-download/jmx-exporter-javaagent.jar "${JMX_EXPORTER_URL}"'
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-3445d77
+          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
@@ -43,7 +43,7 @@ spec:
             - "-c"
             - 'wget -O /root/jmx-exporter-download/jmx-exporter-javaagent.jar "${JMX_EXPORTER_URL}"'
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-3445d77
+          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       initContainers:
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-3445d77
+          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -42,7 +42,7 @@ spec:
             - name: mod-downloader-volume
               mountPath: /downloaded-plugins
         - name: seichiassist-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-3445d77
+          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -66,7 +66,7 @@ spec:
             - name: mod-downloader-volume
               mountPath: /downloaded-plugins
         - name: world-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-3445d77
+          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s2/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s2/stateful-set.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       initContainers:
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-3445d77
+          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -42,7 +42,7 @@ spec:
             - name: mod-downloader-volume
               mountPath: /downloaded-plugins
         - name: seichiassist-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-3445d77
+          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -66,7 +66,7 @@ spec:
             - name: mod-downloader-volume
               mountPath: /downloaded-plugins
         - name: world-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-3445d77
+          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--kagawa/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--kagawa/stateful-set.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       initContainers:
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-3445d77
+          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/stateful-set.yaml
@@ -22,7 +22,7 @@ spec:
         runAsUser: 1000
       initContainers:
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-3445d77
+          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--one-day-to-reset/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--one-day-to-reset/stateful-set.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       initContainers:
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-3445d77
+          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       initContainers:
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-3445d77
+          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -42,7 +42,7 @@ spec:
             - name: mod-downloader-volume
               mountPath: /downloaded-plugins
         - name: seichiassist-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-3445d77
+          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/stateful-set.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       initContainers:
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-3445d77
+          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -42,7 +42,7 @@ spec:
             - name: mod-downloader-volume
               mountPath: /downloaded-plugins
         - name: seichiassist-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-3445d77
+          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/stateful-set.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       initContainers:
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-3445d77
+          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -42,7 +42,7 @@ spec:
             - name: mod-downloader-volume
               mountPath: /downloaded-plugins
         - name: seichiassist-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-3445d77
+          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       initContainers:
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-3445d77
+          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -42,7 +42,7 @@ spec:
             - name: mod-downloader-volume
               mountPath: /downloaded-plugins
         - name: seichiassist-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-3445d77
+          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/stateful-set.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       initContainers:
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-3445d77
+          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -42,7 +42,7 @@ spec:
             - name: mod-downloader-volume
               mountPath: /downloaded-plugins
         - name: seichiassist-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-3445d77
+          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--votelistener/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--votelistener/stateful-set.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       initContainers:
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-3445d77
+          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -42,7 +42,7 @@ spec:
             - name: mod-downloader-volume
               mountPath: /downloaded-plugins
         - name: seichiassist-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-3445d77
+          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900


### PR DESCRIPTION
main マージ後に publish された正しいイメージタグに更新。
seichi-minecraft namespace でテスト済み (exitCode: 0)。