### PR TITLE
feat: garage-admin-console K8s マニフェスト + Cloudflare Tunnel + Terraform…

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cloudflared-tunnel-exits/http-exits.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cloudflared-tunnel-exits/http-exits.yaml
@@ -101,6 +101,11 @@ spec:
             external-hostname: bugsink-dsn.onp-k8s.admin.seichi.click
             internal-authority: "bugsink-dsn-proxy.seichi-minecraft:80"
 
+          # Garage Admin Console (GitHub OAuth 認証付き)
+          - name: garage-admin
+            external-hostname: garage-admin.onp.admin.seichi.click
+            internal-authority: "garage-admin-ui.cluster-wide-apps:80"
+
   template:
     metadata:
       name: "cloudflared-tunnel-http-exit--{{name}}"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-admin/deployment-api.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-admin/deployment-api.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: garage-admin-api
+  labels:
+    app: garage-admin-api
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  revisionHistoryLimit: 0
+  selector:
+    matchLabels:
+      app: garage-admin-api
+  template:
+    metadata:
+      labels:
+        app: garage-admin-api
+    spec:
+      containers:
+        - name: garage-admin-api
+          image: ghcr.io/giganticminecraft/garage-admin-console-backend:latest
+          ports:
+            - containerPort: 8080
+          env:
+            - name: GARAGE_ADMIN_ENDPOINT
+              value: "http://garage.garage.svc.cluster.local:3903"
+            - name: GARAGE_S3_ENDPOINT
+              value: "http://garage.garage.svc.cluster.local:3900"
+            - name: GARAGE_S3_REGION
+              value: "seichi-cloud"
+            - name: BASE_URL
+              value: "https://garage-admin.onp.admin.seichi.click"
+            - name: GITHUB_ORG
+              value: "GiganticMinecraft"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://alloy.monitoring.svc.cluster.local:4318"
+            - name: GARAGE_ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: garage-admin-token
+                  key: GARAGE_ADMIN_TOKEN
+            - name: GITHUB_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: garage-admin-github-oauth
+                  key: GITHUB_CLIENT_ID
+            - name: GITHUB_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: garage-admin-github-oauth
+                  key: GITHUB_CLIENT_SECRET
+            - name: SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: garage-admin-github-oauth
+                  key: SESSION_SECRET
+            - name: GARAGE_S3_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: garage-admin-s3
+                  key: AWS_ACCESS_KEY_ID
+            - name: GARAGE_S3_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: garage-admin-s3
+                  key: AWS_SECRET_ACCESS_KEY
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          startupProbe:
+            httpGet:
+              path: /api/health
+              port: 8080
+            failureThreshold: 6
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 8080
+            periodSeconds: 30

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-admin/deployment-ui.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-admin/deployment-ui.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: garage-admin-ui
+  labels:
+    app: garage-admin-ui
+spec:
+  replicas: 1
+  revisionHistoryLimit: 0
+  selector:
+    matchLabels:
+      app: garage-admin-ui
+  template:
+    metadata:
+      labels:
+        app: garage-admin-ui
+    spec:
+      containers:
+        - name: garage-admin-ui
+          image: ghcr.io/giganticminecraft/garage-admin-console-frontend:latest
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          startupProbe:
+            tcpSocket:
+              port: 80
+            failureThreshold: 6
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: 80
+            periodSeconds: 30

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-admin/kustomization.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-admin/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment-api.yaml
+  - deployment-ui.yaml
+  - service-api.yaml
+  - service-ui.yaml

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-admin/service-api.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-admin/service-api.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: garage-admin-api
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: garage-admin-api

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-admin/service-ui.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-admin/service-ui.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: garage-admin-ui
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 80
+  selector:
+    app: garage-admin-ui

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -293,6 +293,46 @@ variable "garage_backup_secret_access_key" {
 
 #endregion
 
+#region Garage Admin Console secrets
+
+variable "garage_admin_github_client_id" {
+  description = "GitHub OAuth Client ID for Garage Admin Console"
+  type        = string
+  sensitive   = true
+}
+
+variable "garage_admin_github_client_secret" {
+  description = "GitHub OAuth Client Secret for Garage Admin Console"
+  type        = string
+  sensitive   = true
+}
+
+variable "garage_admin_session_secret" {
+  description = "Session cookie encryption key for Garage Admin Console"
+  type        = string
+  sensitive   = true
+}
+
+variable "garage_admin_api_token" {
+  description = "Garage Admin API bearer token for Garage Admin Console"
+  type        = string
+  sensitive   = true
+}
+
+variable "garage_admin_s3_access_key_id" {
+  description = "Garage S3 access key ID for Garage Admin Console (object browse/upload/download)"
+  type        = string
+  sensitive   = true
+}
+
+variable "garage_admin_s3_secret_access_key" {
+  description = "Garage S3 secret access key for Garage Admin Console"
+  type        = string
+  sensitive   = true
+}
+
+#endregion
+
 #region seichi-debug-minecraft secrets
 
 variable "minecraft__debug_s1_seichiassist_webhook_url" {

--- a/terraform/onp_cluster_secrets.tf
+++ b/terraform/onp_cluster_secrets.tf
@@ -234,6 +234,49 @@ resource "kubernetes_secret" "garage_backup_s3_credentials" {
   type = "Opaque"
 }
 
+# Garage Admin Console secrets
+resource "kubernetes_secret" "garage_admin_github_oauth" {
+  metadata {
+    name      = "garage-admin-github-oauth"
+    namespace = "cluster-wide-apps"
+  }
+
+  data = {
+    "GITHUB_CLIENT_ID"     = var.garage_admin_github_client_id
+    "GITHUB_CLIENT_SECRET" = var.garage_admin_github_client_secret
+    "SESSION_SECRET"       = var.garage_admin_session_secret
+  }
+
+  type = "Opaque"
+}
+
+resource "kubernetes_secret" "garage_admin_token" {
+  metadata {
+    name      = "garage-admin-token"
+    namespace = "cluster-wide-apps"
+  }
+
+  data = {
+    "GARAGE_ADMIN_TOKEN" = var.garage_admin_api_token
+  }
+
+  type = "Opaque"
+}
+
+resource "kubernetes_secret" "garage_admin_s3" {
+  metadata {
+    name      = "garage-admin-s3"
+    namespace = "cluster-wide-apps"
+  }
+
+  data = {
+    "AWS_ACCESS_KEY_ID"     = var.garage_admin_s3_access_key_id
+    "AWS_SECRET_ACCESS_KEY" = var.garage_admin_s3_secret_access_key
+  }
+
+  type = "Opaque"
+}
+
 resource "random_password" "minecraft__prod_mariadb_monitoring_password" {
   length  = 16
   special = false // MariaDBのパスワードがぶっ壊れて困るので記号を含めない


### PR DESCRIPTION
… Secrets

- Deployment/Service (API + UI) を cluster-wide-apps/garage-admin/ に追加
- Cloudflare Tunnel exit で garage-admin.onp.admin.seichi.click を公開
- Terraform で GitHub OAuth, Admin Token, S3 credentials の Secret を管理