### PR TITLE
fix: OTEL エンドポイントを k8s-monitoring-alloy-receiver に修正

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-admin/deployment-api.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-admin/deployment-api.yaml
@@ -36,7 +36,7 @@ spec:
             - name: GITHUB_TEAM_SLUG
               value: "onp-admin-grafana"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: "http://alloy.monitoring.svc.cluster.local:4318"
+              value: "http://k8s-monitoring-alloy-receiver.monitoring.svc.cluster.local:4318"
             - name: GARAGE_ADMIN_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
alloy.monitoring.svc.cluster.local は存在しないため、
k8s-monitoring-alloy-receiver.monitoring.svc.cluster.local:4318 に修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)