### PR TITLE
feat(monitoring): k8s-monitoring の Alloy に Faro receiver を追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-k8s-monitoring.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-k8s-monitoring.yaml
@@ -84,11 +84,31 @@ spec:
 
         alloy-receiver:
           enabled: true
+          extraConfig: |-
+            faro.receiver "default" {
+              server {
+                listen_address = "0.0.0.0"
+                listen_port    = 12347
+
+                cors_allowed_origins = ["https://garage-admin.onp.admin.seichi.click"]
+
+                max_allowed_payload_size = "10MiB"
+              }
+
+              output {
+                logs   = [otelcol.processor.k8sattributes.default.input]
+                traces = [otelcol.processor.k8sattributes.default.input]
+              }
+            }
           alloy:
             extraPorts:
               - name: otlp-http
                 port: 4318
                 targetPort: 4318
+                protocol: TCP
+              - name: faro
+                port: 12347
+                targetPort: 12347
                 protocol: TCP
 
         alloy-profiles:


### PR DESCRIPTION
garage-admin-console のフロントエンドテレメトリを受信するため、
alloy-receiver に faro.receiver を port 12347 で追加