### PR TITLE
fix(monitoring): Faro receiver の logs 出力先を loki.LogsReceiver 型に修正

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-k8s-monitoring.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-k8s-monitoring.yaml
@@ -96,7 +96,7 @@ spec:
               }
 
               output {
-                logs   = [otelcol.processor.attributes.localtempo.input]
+                logs   = [otelcol.receiver.loki.localtempo.receiver]
                 traces = [otelcol.processor.attributes.localtempo.input]
               }
             }


### PR DESCRIPTION
faro.receiver の output.logs は loki.LogsReceiver 型を期待するが、 otelcol.processor.attributes.localtempo.input は otelcol.Consumer 型のため 型不一致でクラッシュしていた。
チャートが生成する otelcol.receiver.loki.localtempo.receiver を使用することで loki.LogsReceiver → otelcol.Consumer のブリッジを経由させる。