### PR TITLE
fix(monitoring): Tempo の metrics-generator を有効化して TraceQL メトリクスクエリを修正

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-tempo.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-tempo.yaml
@@ -16,6 +16,17 @@ spec:
     targetRevision: 1.24.4
     helm:
       values: |
+        tempo:
+          metricsGenerator:
+            enabled: true
+            remoteWriteUrl: "http://prometheus-kube-prometheus-prometheus.monitoring:9090/api/v1/write"
+          overrides:
+            defaults:
+              metrics_generator:
+                processors:
+                  - local-blocks
+                  - service-graphs
+                  - span-metrics
         persistence:
           enabled: true
           accessModes:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
@@ -170,6 +170,7 @@ spec:
               release: prometheus
           prometheusSpec:
             enableOTLPReceiver: true
+            enableRemoteWriteReceiver: true
             thanos:
               objectStorageConfig:
                 existingSecret:


### PR DESCRIPTION
Explore Traces で TraceQL の rate() クエリ実行時に
"error finding generators: empty ring" エラーが発生していた問題を修正。

- Tempo に metricsGenerator を有効化し local-blocks, service-graphs, span-metrics プロセッサを設定
- Prometheus に enableRemoteWriteReceiver を追加して metrics-generator からの remote write を受付可能にする