### PR TITLE
fix(monitoring): k8s-monitoring の OTLP destination URL を gRPC エンドポイントに修正

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-k8s-monitoring.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-k8s-monitoring.yaml
@@ -30,7 +30,7 @@ spec:
 
           - name: localTempo
             type: otlp
-            url: http://tempo:4318/v1/traces
+            url: http://tempo:4317
             metrics:
               enabled: true
             logs:


### PR DESCRIPTION
otelcol.exporter.otlp は gRPC を使用するため、URL にパスを含めると
"lookup tcp/4318/v1/traces: unknown port" エラーで全トレースの エクスポートが失敗していた。

これにより Faro (ブラウザ) からの root span が Tempo に到達せず、
Explore Traces で "root span not yet received" と表示されていた。

URL を http://tempo:4317 (gRPC OTLP ポート) に修正。