### PR TITLE
fix(monitoring): OTLP exporter の TLS を無効化して平文 gRPC で Tempo に接続

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-k8s-monitoring.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-k8s-monitoring.yaml
@@ -31,6 +31,8 @@ spec:
           - name: localTempo
             type: otlp
             url: http://tempo:4317
+            tls:
+              insecure: true
             metrics:
               enabled: true
             logs:


### PR DESCRIPTION
otelcol.exporter.otlp はデフォルトで TLS を有効にするため、
平文の Tempo gRPC エンドポイント (4317) への接続で
"tls: first record does not look like a TLS handshake" エラーが発生していた。

tls.insecure: true を追加して平文 gRPC 接続を有効化。