### PR TITLE
feat(monitoring): garage-admin-console に OTel ログ/メトリクス相関を追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-k8s-monitoring.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-k8s-monitoring.yaml
@@ -34,9 +34,9 @@ spec:
             tls:
               insecure: true
             metrics:
-              enabled: true
+              enabled: false
             logs:
-              enabled: true
+              enabled: false
             traces:
               enabled: true
 

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-admin/deployment-api.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-admin/deployment-api.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: garage-admin-api
-          image: ghcr.io/giganticminecraft/garage-admin-console-backend:sha-1886b35
+          image: ghcr.io/giganticminecraft/garage-admin-console-backend:sha-a7b56f5
           ports:
             - containerPort: 8080
           env:


### PR DESCRIPTION
localTempo の metrics/logs 出力を無効化し（Tempo はトレース専用）、
バックエンドイメージを sha-a7b56f5 に更新（trace_id 付きログ + Go runtime メトリクス対応）。