### PR TITLE
update(garage-admin): フロントエンドイメージを sha-af22c9a に更新

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-admin/deployment-ui.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-admin/deployment-ui.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: garage-admin-ui
-          image: ghcr.io/giganticminecraft/garage-admin-console-frontend:sha-2123fe9
+          image: ghcr.io/giganticminecraft/garage-admin-console-frontend:sha-af22c9a
           ports:
             - containerPort: 80
           resources:


### PR DESCRIPTION
Workers ページの回復済みエラー表示改善を含むイメージに更新。