### PR TITLE
fix(garage-admin): ImageUpdater CRD を追加して自動イメージ更新を有効化

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/garage-admin-image-updater.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/garage-admin-image-updater.yaml
@@ -1,0 +1,21 @@
+apiVersion: argocd-image-updater.argoproj.io/v1alpha1
+kind: ImageUpdater
+metadata:
+  name: garage-admin
+  namespace: argocd
+spec:
+  writeBackConfig:
+    method: argocd
+  applicationRefs:
+    - namePattern: "garage-admin"
+      images:
+        - alias: frontend
+          imageName: ghcr.io/giganticminecraft/garage-admin-console-frontend
+          commonUpdateSettings:
+            updateStrategy: latest
+            allowTags: "regexp:^sha-"
+        - alias: backend
+          imageName: ghcr.io/giganticminecraft/garage-admin-console-backend
+          commonUpdateSettings:
+            updateStrategy: latest
+            allowTags: "regexp:^sha-"


### PR DESCRIPTION
v1.1.0 ではアノテーションベースから CRD ベースに変更されたため、
ImageUpdater CR を作成。app-of-other-apps 経由で argocd namespace にデプロイ。