### PR TITLE
fix(garage-admin): ImageUpdater CR に spec.namespace を追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/garage-admin-image-updater.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/garage-admin-image-updater.yaml
@@ -4,6 +4,7 @@ metadata:
   name: garage-admin
   namespace: argocd
 spec:
+  namespace: argocd
   writeBackConfig:
     method: argocd
   applicationRefs:


### PR DESCRIPTION
ImageUpdater CRD の必須フィールド spec.namespace を指定し、
Application を探す namespace を argocd に設定。