### PR TITLE
fix(garage-admin): Image Updater の戦略を digest に変更

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/garage-admin-image-updater.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/garage-admin-image-updater.yaml
@@ -11,12 +11,10 @@ spec:
     - namePattern: "garage-admin"
       images:
         - alias: frontend
-          imageName: ghcr.io/giganticminecraft/garage-admin-console-frontend
+          imageName: ghcr.io/giganticminecraft/garage-admin-console-frontend:latest
           commonUpdateSettings:
-            updateStrategy: latest
-            allowTags: "regexp:^sha-"
+            updateStrategy: digest
         - alias: backend
-          imageName: ghcr.io/giganticminecraft/garage-admin-console-backend
+          imageName: ghcr.io/giganticminecraft/garage-admin-console-backend:latest
           commonUpdateSettings:
-            updateStrategy: latest
-            allowTags: "regexp:^sha-"
+            updateStrategy: digest


### PR DESCRIPTION
latest タグの digest 変更を追跡する方式に変更。
全タグスキャンが不要になり効率的かつ正確。