### PR TITLE
fix(garage-admin): readinessProbe を追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/garage-admin/deployment-api.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/garage-admin/deployment-api.yaml
@@ -80,6 +80,11 @@ spec:
               port: 8080
             failureThreshold: 6
             periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 8080
+            periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /api/health

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/garage-admin/deployment-ui.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/garage-admin/deployment-ui.yaml
@@ -37,6 +37,10 @@ spec:
               port: 80
             failureThreshold: 6
             periodSeconds: 5
+          readinessProbe:
+            tcpSocket:
+              port: 80
+            periodSeconds: 5
           livenessProbe:
             tcpSocket:
               port: 80


### PR DESCRIPTION
起動完了前にトラフィックが流れるのを防ぐため、
UI/API 両方に readinessProbe を追加。