### PR TITLE
feat(garage): OpenTelemetry トレーシングを有効化

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/garage.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/garage.yaml
@@ -73,6 +73,8 @@ spec:
                 release: prometheus
               interval: 30s
               scrapeTimeout: 10s
+          tracing:
+            sink: "http://k8s-monitoring-alloy-receiver.monitoring.svc.cluster.local:4317"
   destination:
     server: https://kubernetes.default.svc
     namespace: garage


### PR DESCRIPTION
Garage の trace_sink を Alloy OTLP レシーバーに設定し、
S3 API リクエストのトレースを Tempo に送信できるようにする。