### PR TITLE
fix(monitoring): Faro receiver の logs 出力先を修正

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-k8s-monitoring.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-k8s-monitoring.yaml
@@ -103,7 +103,7 @@ spec:
               }
 
               output {
-                logs   = [otelcol.receiver.loki.localtempo.receiver]
+                logs   = [loki.write.localloki.receiver]
                 traces = [otelcol.processor.attributes.localtempo.input]
               }
             }


### PR DESCRIPTION
otelcol.receiver.loki.localtempo.receiver は存在しないコンポーネント だったため、Alloy の config reload が失敗し続けていた。
正しい loki.write.localloki.receiver に修正。