### PR TITLE
feat: PRテンプレートのデバッグ環境を固定デバッグサーバーと統一する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
@@ -62,23 +62,57 @@ spec:
             - name: BUCKET_PREFIX_NAME
               value: deb-1-18-2
             - name: DOWNLOAD_TARGET_DIR_PATH
-              value: /plugins
+              value: /downloaded-plugins
           volumeMounts:
             - name: mod-downloader-volume
-              mountPath: /plugins
-        # FIXME: ワールドデータを取得する際に 404 エラーが発生するため、一旦コメントアウト
-        # - name: world-downloader
-        #   image: busybox:1.36.1
-        #   env:
-        #     - name: WORLD_URL # S1からインポートしてきたワールドデータ
-        #       value: "http://garage.garage.svc.cluster.local:3900/seichi-plugins/world-data/s1/world_2.tar.gz"
-        #   volumeMounts:
-        #     - name: world-download-volume
-        #       mountPath: /data
-        #   command:
-        #     - "sh"
-        #     - "-c"
-        #     - 'echo "start downloading world data" && wget -qO- "${WORLD_URL}" | tar -xz -C /data && echo "successfully imported world data"'
+              mountPath: /downloaded-plugins
+        - name: world-downloader
+          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          env:
+            - name: S3_ENDPOINT
+              value: garage.garage.svc.cluster.local:3900
+            - name: S3_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: garage-s3-credentials
+                  key: AWS_ACCESS_KEY_ID
+            - name: S3_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: garage-s3-credentials
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: BUCKET_NAME
+              value: mc-worlds
+            - name: BUCKET_PREFIX_NAME
+              value: s1
+            - name: DOWNLOAD_TARGET_DIR_PATH
+              value: /downloaded-worlds
+          volumeMounts:
+            - name: world-download-volume
+              mountPath: /downloaded-worlds
+        - name: world-extractor
+          image: alpine:3.23
+          command:
+            - "sh"
+            - "-ce"
+            - |
+              apk add --no-cache zstd
+              echo "Extracting world data..."
+              for f in /downloaded-worlds/*.tar.zst; do
+                [ -e "${f}" ] || { echo "No tar.zst files found"; exit 1; }
+                BASENAME=$(basename "${f}" .tar.zst)
+                mkdir -p "/downloaded-worlds/${BASENAME}"
+                echo "Extracting: ${f} -> /downloaded-worlds/${BASENAME}"
+                unzstd -c "${f}" | tar -xf - -C "/downloaded-worlds/${BASENAME}"
+              done
+              chown -R 1000:1000 /downloaded-worlds/
+              echo "Cleaning up tar.zst files..."
+              rm -f /downloaded-worlds/*.tar.zst
+              echo "World data extraction complete."
+              ls -la /downloaded-worlds/
+          volumeMounts:
+            - name: world-download-volume
+              mountPath: /downloaded-worlds
       containers:
         - resources:
             requests:
@@ -103,6 +137,11 @@ spec:
             - name: MODS
               value: >-
                 https://github.com/GiganticMinecraft/SeichiAssist/releases/download/pr-{{ .Values.SeichiAssistPullRequestNumber }}-{{ .Values.PullRequestBranchHeadSHA }}/SeichiAssist.jar,
+
+            - name: COPY_PLUGINS_SRC
+              value: |-
+                /downloaded-plugins
+                /plugins
 
             - name: JVM_OPTS
               # ワールドマイグレーションをするとメモリリークが発生するため、Papermc公式が推奨しているJVM Optionを追加する
@@ -165,31 +204,46 @@ spec:
             # MCIDで指定しても、当該プレイヤーがまだログインしたことがない判定だからか追加できないので、UUIDを指定している。
             - name: RCON_CMDS_STARTUP
               value: |-
-                mv create world_SW NORMAL
-                mv create world_SW_2 NORMAL
-                mv create world_SW_nether NETHER
-                mv create world_SW_the_end END
+                mv import world_SW NORMAL
+                mv import world_SW_2 NORMAL
+                mv import world_SW_3 NORMAL
+                mv import world_SW_4 NORMAL
+                mv import world_SW_nether NETHER
+                mv import world_SW_the_end END
                 gamerule keepInventory true
                 mv gamerule keepInventory true world_SW
                 mv gamerule keepInventory true world_SW_2
+                mv gamerule keepInventory true world_SW_3
+                mv gamerule keepInventory true world_SW_4
                 mv gamerule keepInventory true world_SW_nether
                 mv gamerule keepInventory true world_SW_the_end
                 mv gamerule disableRaids true world_2
                 mv gamerule disableRaids true world_SW
                 mv gamerule disableRaids true world_SW_2
+                mv gamerule disableRaids true world_SW_3
+                mv gamerule disableRaids true world_SW_4
                 mv gamerule disableRaids true world_SW_nether
                 mv gamerule disableRaids true world_SW_the_end
                 mv gamerule doInsomnia false world_2
                 mv gamerule doInsomnia false world_SW
                 mv gamerule doInsomnia false world_SW_2
+                mv gamerule doInsomnia false world_SW_3
+                mv gamerule doInsomnia false world_SW_4
                 mv gamerule doInsomnia false world_SW_nether
                 mv gamerule doInsomnia false world_SW_the_end
                 mvm set difficulty peaceful world_2
-                rg addmember -w world_2 __global__ b66cc3f6-a045-42ad-b4b8-320f20caf140
-                rg flag -w world_2 __global__ build -g members allow
                 rg addmember -w world_SW_2 __global__ b66cc3f6-a045-42ad-b4b8-320f20caf140
                 rg flag -w world_SW_2 __global__ build -g members allow
+                rg addmember -w world_SW_2 __global__ b66cc3f6-a045-42ad-b4b8-320f20caf140
+                rg flag -w world_SW_2 __global__ build -g members allow
+                rg addmember -w world_SW_4 __global__ b66cc3f6-a045-42ad-b4b8-320f20caf140
+                rg flag -w world_SW_4 __global__ build -g members allow
+                rg flag -w world_SW __global__ deny-spawn PHANTOM
+                rg flag -w world_SW_2 __global__ deny-spawn PHANTOM
+                rg flag -w world_SW_3 __global__ deny-spawn PHANTOM
+                rg flag -w world_SW_4 __global__ deny-spawn PHANTOM
                 rg flag -w world_SW_the_end __global__ deny-spawn ENDER_DRAGON
+                mv reload
 
           image: ghcr.io/giganticminecraft/seichi_minecraft_server_debug_base_1_18_2:sha-b6ee419
           name: minecraft
@@ -611,7 +665,7 @@ spec:
               subPath: config.yml
 
             - name: mod-downloader-volume
-              mountPath: /plugins
+              mountPath: /downloaded-plugins
 
             - name: world-download-volume
               mountPath: /data

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/mariadb/mariadb.yaml
@@ -75,33 +75,91 @@ spec:
         - name: mariadb-config
           mountPath: /etc/mysql/conf.d
       initContainers:
-      - name: init-0
-        image: docker-registry1.mariadb.com/library/mariadb:11.8
-        imagePullPolicy: IfNotPresent
-        resources:
-          requests:
-            cpu: 2
-            memory: 2Gi
+      - name: fetch-latest-mariadb-backups
+        image: amazon/aws-cli:latest
+        command:
+          - sh
+          - -c
+        args:
+          - |
+            set -eu
+
+            export AWS_ACCESS_KEY_ID="${S3_ACCESS_KEY}"
+            export AWS_SECRET_ACCESS_KEY="${S3_SECRET_KEY}"
+            S3_OPTS="--endpoint-url ${S3_ENDPOINT} --region seichi-cloud"
+
+            copy_latest_sql() {
+              prefix="$1"
+              output_file="$2"
+              latest_key=""
+              latest_filename=""
+
+              for object_key in $(aws s3 ls ${S3_OPTS} "s3://${BUCKET_NAME}/${prefix}/" | awk '{print $NF}'); do
+                case "${object_key}" in
+                  backup.????-??-??T??:??:??Z.sql)
+                    if [ -z "${latest_filename}" ] || [ "${object_key}" \> "${latest_filename}" ]; then
+                      latest_filename="${object_key}"
+                      latest_key="${prefix}/${object_key}"
+                    fi
+                    ;;
+                esac
+              done
+
+              if [ -z "${latest_key}" ]; then
+                echo "No backup SQL file found for prefix: ${prefix}" >&2
+                exit 1
+              fi
+
+              aws s3 cp ${S3_OPTS} "s3://${BUCKET_NAME}/${latest_key}" "/docker-entrypoint-initdb.d/${output_file}"
+            }
+
+            copy_latest_sql database--flyway 10-flyway.sql
+            copy_latest_sql database--seichiassist 20-seichiassist.sql
+            copy_latest_sql database--luckperms 30-luckperms.sql
         env:
-        - name: DB_PASSWORD
+        - name: S3_ENDPOINT
+          value: http://garage.garage.svc.cluster.local:3900
+        - name: S3_ACCESS_KEY
           valueFrom:
             secretKeyRef:
-              key: prod-mariadb-password
-              name: mariadb-pr-review-password
+              name: garage-s3-credentials
+              key: AWS_ACCESS_KEY_ID
+        - name: S3_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: garage-s3-credentials
+              key: AWS_SECRET_ACCESS_KEY
+        - name: BUCKET_NAME
+          value: mariadb-backups
+        volumeMounts:
+        - mountPath: /docker-entrypoint-initdb.d
+          name: sqldump-volume
+      - name: fix-sql-dump-permissions
+        image: busybox:1.37.0
         args:
         - sh
         - -c
         - |
-          mariadb-dump -upr-review -p${DB_PASSWORD} -hmariadb.seichi-minecraft.svc.cluster.local --ssl=0 --databases flyway_managed_schema seichiassist --ignore-table=seichiassist.mine_stack > /docker-entrypoint-initdb.d/seichiassist.sql
-          mariadb-dump -upr-review -p${DB_PASSWORD} -hmariadb.seichi-minecraft.svc.cluster.local --ssl=0 seichiassist mine_stack --where 'amount != 0' >> /docker-entrypoint-initdb.d/seichiassist.sql
-
-          echo 'CREATE DATABASE IF NOT EXISTS litebans;' > /docker-entrypoint-initdb.d/litebans.sql
-          mariadb-dump -upr-review -p${DB_PASSWORD} -hmariadb.seichi-minecraft.svc.cluster.local --ssl=0 --no-create-db --databases litebans_gigantic_prod \
-            --ignore-table=litebans_gigantic_prod.litebans_config \
-            --ignore-table=litebans_gigantic_prod.litebans_servers \
-            --ignore-table=litebans_gigantic_prod.litebans_sync \
-            --ignore-table=litebans_gigantic_prod.litebans_warnings >> /docker-entrypoint-initdb.d/litebans.sql
-          sed -i 's/^USE `litebans_gigantic_prod`;/USE `litebans`;/' /docker-entrypoint-initdb.d/litebans.sql
+          set -eu
+          if [ -d /docker-entrypoint-initdb.d ]; then
+            find /docker-entrypoint-initdb.d -type d -exec chmod 755 {} +
+            find /docker-entrypoint-initdb.d -type f -exec chmod 644 {} +
+          fi
+        volumeMounts:
+        - mountPath: /docker-entrypoint-initdb.d
+          name: sqldump-volume
+      - name: add-debug-migrations
+        image: busybox:1.37.0
+        args:
+        - sh
+        - -c
+        - |
+          set -eu
+          cat > /docker-entrypoint-initdb.d/40-debug-server-migrations.sql << 'EOSQL'
+          USE seichiassist;
+          UPDATE item_migration_in_server_world_levels SET server_id = 'deb-s1' WHERE server_id = 's1';
+          UPDATE item_migration_in_server_world_levels SET server_id = 'deb-s2' WHERE server_id = 's2';
+          EOSQL
         volumeMounts:
         - mountPath: /docker-entrypoint-initdb.d
           name: sqldump-volume
@@ -114,7 +172,7 @@ spec:
         - |
           echo 'CREATE DATABASE IF NOT EXISTS luckperms;' > /docker-entrypoint-initdb.d/create-db.sql
           echo 'CREATE DATABASE IF NOT EXISTS coreprotect__mc_lobby;' >> /docker-entrypoint-initdb.d/create-db.sql
-          echo 'CREATE DATABASE IF NOT EXISTS coreprotect__mc_s1;' >> /docker-entrypoint-initdb.d/create-db.sql
+          echo 'CREATE DATABASE IF NOT EXISTS coreprotect__mc_debug_s1;' >> /docker-entrypoint-initdb.d/create-db.sql
         volumeMounts:
         - mountPath: /docker-entrypoint-initdb.d
           name: sqldump-volume


### PR DESCRIPTION
- seichiassist.yaml:
  - mod-downloaderのmountPathを/plugins→/downloaded-pluginsに変更
  - world-downloader/world-extractorのinitContainerを追加（Garage S3 mc-worldsからtar.zstでダウンロード・展開）
  - COPY_PLUGINS_SRC環境変数を追加（/downloaded-pluginsと/pluginsをマージ）
  - RCON_CMDS_STARTUPをmv create→mv importに変更し、world_SW_3/world_SW_4を追加

- mariadb.yaml:
  - init-0（本番DB直接dump）を削除し、以下に置き換え:
    - fetch-latest-mariadb-backups: Garage S3 mariadb-backupsから最新バックアップを取得
    - fix-sql-dump-permissions: chmod で権限修正
    - add-debug-migrations: server_idをdeb-s1/deb-s2に変換するSQLを追加
  - coreprotect__mc_s1→coreprotect__mc_debug_s1に変更
  - prod-mariadb-password参照を削除し、garage-s3-credentialsを参照