### PR TITLE
fix: Garage の blockSize を 64MiB に変更

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/garage.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/garage.yaml
@@ -16,7 +16,7 @@ spec:
       values: |
         garage:
           dbEngine: "lmdb"
-          blockSize: "1048576"
+          blockSize: "67108864" # 64MiB
           replicationFactor: "2"
           consistencyMode: "consistent"
           compressionLevel: "1"


### PR DESCRIPTION
デバッグサーバーの構築で発生している、ワールドデータ / SQL dump のダウンロードに時間がかかるので