### PR TITLE
fix: デバッグ用 MariaDB のサーバー ID マイグレーションを SeichiAssist の設定値と合わせる

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/mariadb/mariadb.yaml
@@ -162,8 +162,7 @@ spec:
               set -eu
               cat > /docker-entrypoint-initdb.d/40-debug-server-migrations.sql << 'EOSQL'
               USE seichiassist;
-              UPDATE item_migration_in_server_world_levels SET server_id = 'deb-s1' WHERE server_id = 's1';
-              UPDATE item_migration_in_server_world_levels SET server_id = 'deb-s2' WHERE server_id = 's2';
+              UPDATE item_migration_in_server_world_levels SET server_id = '{{ .Values.SeichiAssistPullRequestNumber }}' WHERE server_id = 's1';
               EOSQL
           volumeMounts:
             - mountPath: /docker-entrypoint-initdb.d


### PR DESCRIPTION
## Summary

- `item_migration_in_server_world_levels` のサーバー ID 書き換えで、ハードコードされていた `deb-s1` / `deb-s2` を `CFG_REPLACEMENT__SEICHIASSIST_SERVER_ID` と同じ `{{ .Values.SeichiAssistPullRequestNumber }}` に修正
- 存在しない debug-s2 に対応する不要な行を削除

## Background

`mariadb.yaml` の `add-debug-migrations` initContainer で実行される SQL は、`item_migration_in_server_world_levels` テーブルのサーバー ID を本番用の `s1` からデバッグ用の値に書き換えるものです。
しかし従来は `deb-s1` とハードコードされており、実際に SeichiAssist に設定される `CFG_REPLACEMENT__SEICHIASSIST_SERVER_ID`（= PR 番号）と一致していませんでした。

## Test plan

- [ ] PR デバッグ環境を起動し、SeichiAssist のアイテムマイグレーションが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)