### PR TITLE
fix: K8sノードのDNS設定を廃止済み192.168.100.1からsc-dns01/02に変更

### DIFF
--- a/seichi-onp-k8s/cluster-boot-up/snippets/seichi-onp-k8s-cp-1-network.yaml
+++ b/seichi-onp-k8s/cluster-boot-up/snippets/seichi-onp-k8s-cp-1-network.yaml
@@ -21,6 +21,7 @@ config:
       netmask: '255.255.255.0'
   - type: nameserver
     address:
-    - '192.168.100.1'
+    - '10.123.0.195'
+    - '10.123.0.196'
     search:
     - 'local'

--- a/seichi-onp-k8s/cluster-boot-up/snippets/seichi-onp-k8s-cp-2-network.yaml
+++ b/seichi-onp-k8s/cluster-boot-up/snippets/seichi-onp-k8s-cp-2-network.yaml
@@ -21,6 +21,7 @@ config:
       netmask: '255.255.255.0'
   - type: nameserver
     address:
-    - '192.168.100.1'
+    - '10.123.0.195'
+    - '10.123.0.196'
     search:
     - 'local'

--- a/seichi-onp-k8s/cluster-boot-up/snippets/seichi-onp-k8s-cp-3-network.yaml
+++ b/seichi-onp-k8s/cluster-boot-up/snippets/seichi-onp-k8s-cp-3-network.yaml
@@ -21,6 +21,7 @@ config:
       netmask: '255.255.255.0'
   - type: nameserver
     address:
-    - '192.168.100.1'
+    - '10.123.0.195'
+    - '10.123.0.196'
     search:
     - 'local'

--- a/seichi-onp-k8s/cluster-boot-up/snippets/seichi-onp-k8s-wk-1-network.yaml
+++ b/seichi-onp-k8s/cluster-boot-up/snippets/seichi-onp-k8s-wk-1-network.yaml
@@ -21,6 +21,7 @@ config:
       netmask: '255.255.255.0'
   - type: nameserver
     address:
-    - '192.168.100.1'
+    - '10.123.0.195'
+    - '10.123.0.196'
     search:
     - 'local'

--- a/seichi-onp-k8s/cluster-boot-up/snippets/seichi-onp-k8s-wk-2-network.yaml
+++ b/seichi-onp-k8s/cluster-boot-up/snippets/seichi-onp-k8s-wk-2-network.yaml
@@ -21,6 +21,7 @@ config:
       netmask: '255.255.255.0'
   - type: nameserver
     address:
-    - '192.168.100.1'
+    - '10.123.0.195'
+    - '10.123.0.196'
     search:
     - 'local'

--- a/seichi-onp-k8s/cluster-boot-up/snippets/seichi-onp-k8s-wk-3-network.yaml
+++ b/seichi-onp-k8s/cluster-boot-up/snippets/seichi-onp-k8s-wk-3-network.yaml
@@ -21,6 +21,7 @@ config:
       netmask: '255.255.255.0'
   - type: nameserver
     address:
-    - '192.168.100.1'
+    - '10.123.0.195'
+    - '10.123.0.196'
     search:
     - 'local'


### PR DESCRIPTION
## Summary
- K8s全ノード(CP×3, WK×3)のnetwork snippetsで、DNSサーバーとして参照していた `192.168.100.1` を削除
- 代わりに `sc-dns01` (10.123.0.195) と `sc-dns02` (10.123.0.196) を設定
- `192.168.100.1` は既に存在しないサーバーのため

## 変更対象ファイル
- `seichi-onp-k8s/cluster-boot-up/snippets/seichi-onp-k8s-cp-{1,2,3}-network.yaml`
- `seichi-onp-k8s/cluster-boot-up/snippets/seichi-onp-k8s-wk-{1,2,3}-network.yaml`

## Test plan
- [ ] K8sノードからsc-dns01/02への名前解決が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)