### PR TITLE
fix: remediate critical/high CVEs in container images

### DIFF
--- a/.github/workflows/build_mcserver_base_images.yaml
+++ b/.github/workflows/build_mcserver_base_images.yaml
@@ -38,13 +38,13 @@ jobs:
           #     各サーバーの基底イメージ指定は
           #     java_version_component_in_tag + digest pinning で行うこととしている。
           - mcserver_base_image_tag: java8-jdk
-            mcserver_base_image_digest: "sha256:15ebec91af95ee112d804677158ad8b52e96488b6937886a23e7d35b0a48bfdf"
+            mcserver_base_image_digest: "sha256:3f3fb125b37c8b1e1f0fcf81a01a8ccc1eb9d7dd307ac3b78ff67191ae00a12c"
             java_version_component_in_tag: java8-jdk
           - mcserver_base_image_tag: java17
-            mcserver_base_image_digest: "sha256:212e5a654b6e868cb757a9fd4e891ac848bd5ff084d74053d35391d46941777a"
+            mcserver_base_image_digest: "sha256:0186d4ba0894b9dfb7865e6ec2f1f1a2271523704af72266b8d1b920d07ce7ff"
             java_version_component_in_tag: java17-jdk
           - mcserver_base_image_tag: java21-jdk
-            mcserver_base_image_digest: "sha256:58b3dd1b46e1c21411d280a293c9b35abe5b956ca8cb54aa5a5a6f1d7a0af559"
+            mcserver_base_image_digest: "sha256:de368ea0708dee40e11d81fd8e19c9ec51a3568e9a7e6abd3e8599b64dd316a6"
             java_version_component_in_tag: java21-jdk
 
     steps:

--- a/docker-images/mod-downloader/Dockerfile
+++ b/docker-images/mod-downloader/Dockerfile
@@ -13,12 +13,13 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=bind,target=. \
     CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build -buildvcs=false -ldflags="-s -w" -trimpath -o /mod-downloader
 
-FROM debian:trixie-slim
+FROM scratch
 
 LABEL org.opencontainers.image.authors="outductor <inductor.kela+seichi@gmail.com>"
 LABEL org.opencontainers.image.url="https://github.com/GiganticMinecraft/seichi_infra"
 LABEL org.opencontainers.image.source="https://github.com/GiganticMinecraft/seichi_infra/blob/main/docker-images/mod-downloader/Dockerfile"
 
+COPY --link --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --link --from=builder /mod-downloader /bin/
 ENV S3_ENDPOINT=""
 ENV S3_ACCESS_KEY=""

--- a/docker-images/truenas-exporter/Dockerfile
+++ b/docker-images/truenas-exporter/Dockerfile
@@ -13,12 +13,13 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=bind,target=. \
     CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build -buildvcs=false -ldflags="-s -w" -trimpath -o /truenas-exporter
 
-FROM debian:trixie-slim
+FROM scratch
 
 LABEL org.opencontainers.image.authors="outductor <inductor.kela+seichi@gmail.com>"
 LABEL org.opencontainers.image.url="https://github.com/GiganticMinecraft/seichi_infra"
 LABEL org.opencontainers.image.source="https://github.com/GiganticMinecraft/seichi_infra/blob/main/docker-images/truenas-exporter/Dockerfile"
 
+COPY --link --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --link --from=builder /truenas-exporter /bin/
 ENV TRUENAS_HOST=""
 ENV TRUENAS_PORT="443"


### PR DESCRIPTION
## Summary

- **mod-downloader / truenas-exporter**: ランタイムベースを `debian:trixie-slim` → `scratch` に変更し、glibc の CVE-2026-0861 (HIGH) を排除。両バイナリは `CGO_ENABLED=0` で静的リンクされているため glibc は不要。HTTPS 接続用の CA 証明書はビルダーステージからコピー。
- **itzg/minecraft-server**: java8-jdk, java17, java21-jdk 全ての digest を最新に更新し、Go stdlib (CVE-2025-68121 CRITICAL 等) や OpenSSL/expat 等の脆弱性に対応。

## Addressed CVEs

| Severity | CVE | Component | Fix |
|----------|-----|-----------|-----|
| CRITICAL | CVE-2025-68121 | Go stdlib in rcon-cli, gosu, easy-add | upstream digest update |
| CRITICAL | CVE-2022-36944 | scala-library in mc-image-helper | upstream digest update (may remain if upstream hasn't updated) |
| HIGH | CVE-2026-0861 | glibc in mod-downloader, truenas-exporter | switch to scratch base |
| HIGH | CVE-2025-61726/61728/61729/58183/47907 | Go stdlib in rcon-cli, gosu, easy-add | upstream digest update |
| HIGH | CVE-2023-0286, CVE-2022-0778 | OpenSSL in base image | upstream digest update |
| HIGH | CVE-2022-24407 | cyrus-sasl in base image | upstream digest update |
| HIGH | CVE-2022-25235/25236 | expat in base image | upstream digest update |
| HIGH | CVE-2023-44487 | HTTP/2 in base image | upstream digest update |
| HIGH | GHSA-72hv-8253-57qq | jackson-core in mc-image-helper | upstream digest update |
| HIGH | CVE-2022-41404 | ini4j in mc-image-helper | upstream digest update |

## Notes

- mc-image-helper 内の scala-library (CVE-2022-36944) や jackson-core 等は itzg/minecraft-server 上流に依存するため、上流で更新されていなければアラートが残る可能性あり。その場合は上流へ issue/PR を検討。
- `scratch` ベースに変更した2つのイメージはイメージサイズも大幅に削減される副次効果あり。

## Test plan

- [ ] mod-downloader イメージがビルドでき、S3 からの mod ダウンロードが正常に動作すること
- [ ] truenas-exporter イメージがビルドでき、TrueNAS への HTTPS 接続と Prometheus メトリクス公開が正常に動作すること
- [ ] 3つの Java バリアント (java8-jdk, java17, java21-jdk) の base image がビルドできること
- [ ] Trivy スキャンで Critical/High アラートが減少していること

🤖 Generated with [Claude Code](https://claude.com/claude-code)