### PR TITLE
fix: gate Trivy/SARIF upload on digest for Go image workflows

### DIFF
--- a/.github/workflows/mod_downloader.yaml
+++ b/.github/workflows/mod_downloader.yaml
@@ -87,6 +87,7 @@ jobs:
             ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
 
       - name: Run Trivy vulnerability scanner
+        if: steps.build.outputs.digest != ''
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
@@ -95,6 +96,6 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
-        if: always()
+        if: always() && steps.build.outputs.digest != ''
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/truenas_exporter.yaml
+++ b/.github/workflows/truenas_exporter.yaml
@@ -89,6 +89,7 @@ jobs:
             ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
 
       - name: Run Trivy vulnerability scanner
+        if: steps.build.outputs.digest != ''
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
@@ -97,6 +98,6 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
-        if: always()
+        if: always() && steps.build.outputs.digest != ''
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## Summary
- `truenas_exporter.yaml` と `mod_downloader.yaml` の Trivy スキャン / SARIF アップロードに `steps.build.outputs.digest != ''` の guard を追加
- 非 main ブランチではイメージが push されないため Trivy がリモートイメージを pull できず、SARIF ファイルが生成されない → `upload-sarif` が `Path does not exist: trivy-results.sarif` で失敗していた
- `build_mcserver_base_images.yaml` / `build_mcserver_images.yaml` は #4570 で修正済み

## Test plan
- [ ] 非 main ブランチの PR で Trivy/SARIF ステップがスキップされ CI が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)