### PR TITLE
feat: add VPA, Goldilocks, and OpenCost

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/goldilocks.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/goldilocks.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: goldilocks
+  namespace: argocd
+spec:
+  project: cluster-wide-apps
+  source:
+    chart: goldilocks
+    repoURL: https://charts.fairwinds.com/stable
+    targetRevision: 10.3.0
+    helm:
+      releaseName: goldilocks
+      values: |
+        vpa:
+          enabled: false
+        dashboard:
+          enabled: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: goldilocks
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/opencost.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/opencost.yaml
@@ -1,0 +1,32 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: opencost
+  namespace: argocd
+spec:
+  project: cluster-wide-apps
+  source:
+    chart: opencost
+    repoURL: https://opencost.github.io/opencost-helm-chart
+    targetRevision: 2.5.11
+    helm:
+      releaseName: opencost
+      values: |
+        opencost:
+          prometheus:
+            internal:
+              serviceName: prometheus-kube-prometheus-prometheus
+              namespaceName: monitoring
+              port: 9090
+          ui:
+            enabled: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: opencost
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/vpa.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/vpa.yaml
@@ -1,0 +1,32 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vpa
+  namespace: argocd
+spec:
+  project: cluster-wide-apps
+  source:
+    chart: vpa
+    repoURL: https://charts.fairwinds.com/stable
+    targetRevision: 4.10.2
+    helm:
+      releaseName: vpa
+      values: |
+        recommender:
+          enabled: true
+        updater:
+          enabled: false
+        admissionController:
+          enabled: false
+        metrics-server:
+          enabled: false
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: vpa
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/projects.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/projects.yaml
@@ -64,6 +64,12 @@ spec:
       server: https://kubernetes.default.svc
     - namespace: "kyverno"
       server: https://kubernetes.default.svc
+    - namespace: "vpa"
+      server: https://kubernetes.default.svc
+    - namespace: "goldilocks"
+      server: https://kubernetes.default.svc
+    - namespace: "opencost"
+      server: https://kubernetes.default.svc
   clusterResourceWhitelist:
     - group: "*"
       kind: "*"


### PR DESCRIPTION
## Summary
- **VPA (Recommender only)**: Pod の requests/limits の適正値を推薦。Updater / Admission Controller は無効化し、GitOps との競合を防止
- **Goldilocks**: namespace 単位で VPA の推薦値をダッシュボードで可視化。対象 namespace に `goldilocks.fairwinds.com/enabled=true` ラベルを付与して利用
- **OpenCost**: クラスタ全体のリソース配分を可視化。既存の Prometheus (`monitoring` namespace) を参照

Descheduler の最適化に向けて、まずリソース配分の現状を把握するための基盤を整備します。

## Test plan
- [ ] ArgoCD で 3 つの Application が Healthy / Synced になることを確認
- [ ] VPA Recommender Pod が起動し、VPA リソースの recommendations が生成されることを確認
- [ ] `kubectl label ns seichi-minecraft goldilocks.fairwinds.com/enabled=true` 後、Goldilocks ダッシュボードに推薦値が表示されることを確認
- [ ] OpenCost UI でノード・namespace 単位のリソース配分が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)