### PR TITLE
feat: enable Goldilocks on key namespaces

### DIFF
--- a/terraform/onp_cluster_namespaces.tf
+++ b/terraform/onp_cluster_namespaces.tf
@@ -13,12 +13,18 @@ resource "kubernetes_namespace" "onp_seichi_debug_minecraft" {
 resource "kubernetes_namespace" "onp_seichi_gateway" {
   metadata {
     name = "seichi-gateway"
+    labels = {
+      "goldilocks.fairwinds.com/enabled" = "true"
+    }
   }
 }
 
 resource "kubernetes_namespace" "onp_seichi_minecraft" {
   metadata {
     name = "seichi-minecraft"
+    labels = {
+      "goldilocks.fairwinds.com/enabled" = "true"
+    }
   }
 }
 
@@ -37,6 +43,9 @@ resource "kubernetes_namespace" "onp_argo" {
 resource "kubernetes_namespace" "onp_monitoring" {
   metadata {
     name = "monitoring"
+    labels = {
+      "goldilocks.fairwinds.com/enabled" = "true"
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- `seichi-minecraft`、`monitoring`、`seichi-gateway` namespace に `goldilocks.fairwinds.com/enabled: "true"` ラベルを追加
- Terraform で宣言的に管理し、Goldilocks が自動的に VPA リソースを作成してリソース推薦値を収集開始する

## Test plan
- [ ] `terraform plan` で3つの namespace に label 追加のみの差分であることを確認
- [ ] apply 後、`kubectl get vpa -n seichi-minecraft` 等で VPA リソースが自動作成されることを確認
- [ ] Goldilocks ダッシュボードに対象 namespace の推薦値が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)