### PR TITLE
feat: right-size ArgoCD / Argo Workflows / Argo Events resources

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/argo-events.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/argo-events.yaml
@@ -13,6 +13,10 @@ spec:
       releaseName: argo-events
       values: |
         controller:
+          resources:
+            requests:
+              cpu: 15m
+              memory: 128Mi
           metrics:
             enabled: true
             serviceMonitor:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/argo-workflows.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/argo-workflows.yaml
@@ -13,6 +13,10 @@ spec:
       releaseName: argo-workflows
       values: |
         controller:
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
           metricsConfig:
             enabled: true
           serviceMonitor:
@@ -26,6 +30,10 @@ spec:
               ttlStrategy:
                 secondsAfterCompletion: 592200
         server:
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
           secure: true
           extraArgs:
             - --auth-mode=sso

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/argocd-helm-chart-values.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/argocd-helm-chart-values.yaml
@@ -18,8 +18,8 @@ server:
     targetMemoryUtilizationPercentage: 175
   resources:
     requests:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 50m
+      memory: 384Mi
   pdb:
     enabled: true
     minAvailable: 1
@@ -77,8 +77,8 @@ configs:
 controller:
   resources:
     requests:
-      cpu: 250m
-      memory: 768Mi
+      cpu: 600m
+      memory: 2Gi
   metrics:
     enabled: true
     serviceMonitor:
@@ -98,8 +98,8 @@ dex:
           key: client-secret
   resources:
     requests:
-      cpu: 50m
-      memory: 128Mi
+      cpu: 10m
+      memory: 384Mi
   metrics:
     enabled: true
     serviceMonitor:
@@ -115,8 +115,8 @@ dex:
 redis:
   resources:
     requests:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 15m
+      memory: 64Mi
   metrics:
     enabled: true
     serviceMonitor:
@@ -128,8 +128,8 @@ repoServer:
   replicaCount: 1
   resources:
     requests:
-      cpu: 500m
-      memory: 128Mi
+      cpu: 200m
+      memory: 256Mi
   metrics:
     enabled: true
     serviceMonitor:
@@ -141,8 +141,8 @@ applicationSet:
   replicaCount: 1
   resources:
     requests:
-      cpu: 500m
-      memory: 128Mi
+      cpu: 15m
+      memory: 384Mi
   metrics:
     enabled: true
     serviceMonitor:
@@ -153,8 +153,8 @@ applicationSet:
 notifications:
   resources:
     requests:
-      cpu: 100m
-      memory: 64Mi
+      cpu: 15m
+      memory: 192Mi
   metrics:
     enabled: true
     serviceMonitor:


### PR DESCRIPTION
## Summary

28日間ピーク実測値（1分解像度、3d/7d/14d/28d の最大値）をもとに、ArgoCD / Argo Workflows / Argo Events のリソースを適正化します。

### ArgoCD

| コンポーネント | リソース | 変更前 | 変更後 | 28日ピーク | 備考 |
|---|---|---|---|---|---|
| application-controller | CPU req | 250m | **600m** | 507m | UNDER だった |
| application-controller | MEM req | 768Mi | **2Gi** | 1.9Gi | UNDER だった |
| applicationset-controller | CPU req | 500m | **15m** | 9m | 56x over |
| applicationset-controller | MEM req | 128Mi | **384Mi** | 295Mi | UNDER だった |
| server | CPU req | 100m | **50m** | 46m | HPA あり（min 2, max 5） |
| server | MEM req | 128Mi | **384Mi** | 308Mi | UNDER だった |
| repo-server | CPU req | 500m | **200m** | 156m | 3x over |
| repo-server | MEM req | 128Mi | **256Mi** | 175Mi | UNDER だった |
| dex-server | CPU req | 50m | **10m** | 4m | 12x over |
| dex-server | MEM req | 128Mi | **384Mi** | 265Mi | UNDER だった |
| notifications | CPU req | 100m | **15m** | 6m | 17x over |
| notifications | MEM req | 64Mi | **192Mi** | 146Mi | UNDER だった |
| redis | CPU req | 100m | **15m** | 6m | 17x over |
| redis | MEM req | 128Mi | **64Mi** | 45Mi | over |

### Argo Workflows（リソース未設定 → 新規追加）

| コンポーネント | CPU req | MEM req | 28日ピーク |
|---|---|---|---|
| controller | 10m | 64Mi | 4m / 46Mi |
| server | 10m | 64Mi | 3m / 56Mi |

### Argo Events（リソース未設定 → 新規追加）

| コンポーネント | CPU req | MEM req | 28日ピーク |
|---|---|---|---|
| controller-manager | 15m | 128Mi | 12m / 117Mi |

### バックアップタスク
MariaDB Operator による backup Job はリソース未設定で、ピーク CPU 85m / MEM 28Mi 程度。MariaDB Operator 側の設定が必要なため、別途対応とします。

## Test plan
- [ ] ArgoCD の各コンポーネントが正常に起動することを確認（特に application-controller）
- [ ] ArgoCD UI にアクセスでき、Application の Sync が正常に動作することを確認
- [ ] Argo Workflows の Workflow 実行が正常に動作することを確認
- [ ] Argo Events の EventSource / Sensor が正常に動作することを確認
- [ ] HPA による server の自動スケーリングが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)