### PR TITLE
fix: ArgoCD diff CIのコメント文言を差分とエラーで出し分ける

### DIFF
--- a/.github/workflows/argocd_diff.yaml
+++ b/.github/workflows/argocd_diff.yaml
@@ -83,6 +83,7 @@ jobs:
           PR_HEAD_SHA="${{ github.event.pull_request.head.sha }}"
 
           has_diff=false
+          has_error=false
           touch /tmp/argocd-diff-output.md
 
           while IFS= read -r app; do
@@ -112,7 +113,7 @@ jobs:
               echo "</details>" >> /tmp/argocd-diff-output.md
               echo "" >> /tmp/argocd-diff-output.md
             elif [ ${exit_code} -ge 2 ]; then
-              has_diff=true
+              has_error=true
               echo "<details>" >> /tmp/argocd-diff-output.md
               printf '<summary>⚠️ %s (error)</summary>\n\n' "${app}" >> /tmp/argocd-diff-output.md
               echo '```' >> /tmp/argocd-diff-output.md
@@ -124,20 +125,32 @@ jobs:
           done < /tmp/affected-apps.txt
 
           echo "has_diff=${has_diff}" >> "$GITHUB_OUTPUT"
+          echo "has_error=${has_error}" >> "$GITHUB_OUTPUT"
 
       - name: Build comment body
-        if: steps.argocd-diff.outputs.has_diff == 'true'
+        if: steps.argocd-diff.outputs.has_diff == 'true' || steps.argocd-diff.outputs.has_error == 'true'
         run: |
+          has_diff="${{ steps.argocd-diff.outputs.has_diff }}"
+          has_error="${{ steps.argocd-diff.outputs.has_error }}"
+
+          if [ "${has_diff}" = "true" ] && [ "${has_error}" = "true" ]; then
+            description="以下の差分・エラーが検出されました。"
+          elif [ "${has_error}" = "true" ]; then
+            description="以下のエラーが検出されました。"
+          else
+            description="以下の差分が検出されました。"
+          fi
+
           {
             echo "## ArgoCD Diff Result"
             echo ""
-            echo '`argocd app diff --revision ${{ github.event.pull_request.head.sha }}` の結果、以下の差分・エラーが検出されました。'
+            printf '`argocd app diff --revision %s` の結果、%s\n' "${{ github.event.pull_request.head.sha }}" "${description}"
             echo ""
             cat /tmp/argocd-diff-output.md
           } > /tmp/argocd-comment.md
 
       - name: Comment on Pull Request
-        if: steps.argocd-diff.outputs.has_diff == 'true'
+        if: steps.argocd-diff.outputs.has_diff == 'true' || steps.argocd-diff.outputs.has_error == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -158,7 +171,7 @@ jobs:
           fi
 
       - name: Remove comment if no diff
-        if: steps.argocd-diff.outputs.has_diff == 'false' || steps.find-apps.outputs.has_apps == 'false'
+        if: (steps.argocd-diff.outputs.has_diff != 'true' && steps.argocd-diff.outputs.has_error != 'true') || steps.find-apps.outputs.has_apps == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary
- `argocd app diff` の結果をPRコメントする際、差分のみ・エラーのみ・両方の3パターンでヘッダー文言を出し分けるように修正
- 既存の `has_diff` フラグ1つで差分・エラー両方を管理していたのを、`has_diff`（差分）と `has_error`（エラー）に分離

## Test plan
- [ ] 差分のみのPRで「以下の差分が検出されました。」と表示されること
- [ ] エラーのみの場合に「以下のエラーが検出されました。」と表示されること
- [ ] 差分とエラーが混在する場合に「以下の差分・エラーが検出されました。」と表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)