### PR TITLE
feat: mariadb-operator v26向けデータプレーン自動更新を有効化

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mariadb/mariadb.yaml
@@ -158,6 +158,7 @@ spec:
     timeoutSeconds: 5
 
   updateStrategy:
+    autoUpdateDataPlane: true
     type: ReplicasFirstPrimaryLast
 
   metrics:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
@@ -79,6 +79,7 @@ spec:
     timeoutSeconds: 5
 
   updateStrategy:
+    autoUpdateDataPlane: true
     type: ReplicasFirstPrimaryLast
 
   metrics:


### PR DESCRIPTION
## Summary
- mariadb-operator v26 へのアップグレードに備え、MariaDB CR に `updateStrategy.autoUpdateDataPlane: true` を設定
- 対象: `seichi-minecraft` / `seichi-debug-minecraft` の両 MariaDB リソース
- [アップグレードガイド](https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_26.3.0.md) に従い、オペレータ更新前にデータプレーン（init container / agent sidecar）の自動更新を有効にする必要がある

## 手順
1. **このPRをマージ＆Sync** → データプレーン自動更新が有効になる
2. **#4585 をマージ＆Sync** → mariadb-operator が v26 に更新され、データプレーンも v26 に自動更新される
3. **後続PRで `autoUpdateDataPlane: false` に戻す**

## Test plan
- [ ] ArgoCD Sync 後、MariaDB Pod の init container / agent sidecar が正常に動作していることを確認
- [ ] MariaDB への接続が正常であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)