### PR TITLE
fix: bugsinkのenv設定バグ修正と設定追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/bugsink/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/bugsink/deployment.yaml
@@ -52,8 +52,16 @@ spec:
               value: "9000"
             - name: DATABASE_URL
               value: mysql://bugsink:$(MYSQL_PASSWORD)@mariadb/bugsink
-            - value: SINGLE_TEAM
-              name: "True"
+            - name: SINGLE_TEAM
+              value: "True"
+            - name: SINGLE_USER
+              value: "True"
+            - name: USER_REGISTRATION
+              value: "CB_NOBODY"
+            - name: PHONEHOME
+              value: "False"
+            - name: USE_X_REAL_IP
+              value: "True"
             - name: BEHIND_HTTPS_PROXY
               value: "True"
             - name: BASE_URL

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/bugsink/dsn-reverse-proxy.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/bugsink/dsn-reverse-proxy.yaml
@@ -49,6 +49,11 @@ data:
   proxy.conf: |
     server_names_hash_bucket_size 128;
 
+    map $http_cf_connecting_ip $real_client_ip {
+      default $http_cf_connecting_ip;
+      ""      $remote_addr;
+    }
+
     server {
       listen 80;
       server_name bugsink-dsn.onp-k8s.admin.seichi.click;
@@ -60,7 +65,7 @@ data:
         proxy_request_buffering off;
 
         proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Real-IP $real_client_ip;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
       }


### PR DESCRIPTION
## Summary
- `SINGLE_TEAM` の `name` / `value` が逆になっていたバグを修正（`True=SINGLE_TEAM` という無関係な環境変数になっていた）
- 以下の設定を追加:
  - `SINGLE_USER=True`: シングルユーザーモード有効化
  - `USER_REGISTRATION=CB_NOBODY`: ユーザー登録を無効化
  - `PHONEHOME=False`: 使用統計の送信を無効化
  - `USE_X_REAL_IP=True`: クライアントIPの正しい取得
- dsn-reverse-proxy の nginx で `CF-Connecting-IP` ヘッダーから `X-Real-IP` を設定するように変更（Cloudflare Tunnel 非経由時は `$remote_addr` にフォールバック）

## Test plan
- [ ] bugsink Pod が正常に起動することを確認
- [ ] bugsink の管理画面でシングルユーザーモードが有効になっていることを確認
- [ ] DSN エンドポイントへの POST でクライアント IP が正しく記録されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)