### PR TITLE
feat: bugsink本体とdsn-reverse-proxyにprobeを追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/bugsink/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/bugsink/deployment.yaml
@@ -71,6 +71,24 @@ spec:
             # https://github.com/bugsink/bugsink/blob/bddc2e8f640e82b7d1f861f1b8b363535d8a22a1/bugsink/conf_templates/singleserver.py.template#L41
             - name: TIME_ZONE
               value: "Asia/Tokyo"
+          startupProbe:
+            httpGet:
+              path: /
+              port: 9000
+            failureThreshold: 30
+            periodSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 9000
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 9000
+            periodSeconds: 5
+            failureThreshold: 3
           resources:
             limits:
               cpu: 100m

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/bugsink/dsn-reverse-proxy.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/bugsink/dsn-reverse-proxy.yaml
@@ -31,6 +31,16 @@ spec:
       containers:
         - name: nginx
           image: nginx:1.29.6
+          livenessProbe:
+            tcpSocket:
+              port: 80
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: 80
+            periodSeconds: 5
+            failureThreshold: 3
           volumeMounts:
             - name: conf
               mountPath: /etc/nginx/conf.d/proxy.conf


### PR DESCRIPTION
## Summary
- bugsink 本体に startupProbe / livenessProbe / readinessProbe を追加（HTTP GET `:9000`）
- dsn-reverse-proxy (nginx) に livenessProbe / readinessProbe を追加（TCP `:80`）

起動後にハングしても Kubernetes が切り離せない状態を防止します。

## Test plan
- [ ] bugsink Pod が正常に起動し、probe が PASS することを確認
- [ ] dsn-reverse-proxy Pod が正常に起動し、probe が PASS することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)