### PR TITLE
feat: bugsinkのデプロイ戦略をRollingUpdateに変更

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/bugsink/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/bugsink/deployment.yaml
@@ -99,6 +99,6 @@ spec:
               memory: 500Mi
               ephemeral-storage: 500Mi
   strategy:
-    type: Recreate
+    type: RollingUpdate
   revisionHistoryLimit: 10
   progressDeadlineSeconds: 600


### PR DESCRIPTION
## Summary
- bugsink の Deployment strategy を `Recreate` から `RollingUpdate` に変更
- DB が MariaDB に移行済みのため、同時に複数 Pod が起動しても問題なく、Recreate によるダウンタイムは不要
- 前の PR で追加した readinessProbe により、新 Pod が Ready になってから旧 Pod が落ちる

## Test plan
- [ ] デプロイ時にダウンタイムなく Pod が入れ替わることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)