### PR TITLE
fix: bugsinkのstartupProbe猶予時間を拡大

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/bugsink/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/bugsink/deployment.yaml
@@ -75,8 +75,8 @@ spec:
             httpGet:
               path: /
               port: 9000
-            failureThreshold: 30
-            periodSeconds: 2
+            failureThreshold: 60
+            periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
## Summary
- bugsink の startupProbe が 60秒（30回×2秒）でタイムアウトし、再起動ループに陥っていた
- 起動時の `bugsink-manage check --deploy` やDBマイグレーションが完了する前にkillされていた
- 猶予を 300秒（60回×5秒）に拡大

## Test plan
- [ ] bugsink Pod が startup probe を通過して Ready になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)