### PR TITLE
fix: bugsinkのprobeにHostヘッダーを追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/bugsink/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/bugsink/deployment.yaml
@@ -75,18 +75,27 @@ spec:
             httpGet:
               path: /
               port: 9000
+              httpHeaders:
+                - name: Host
+                  value: bugsink.seichi-minecraft
             failureThreshold: 60
             periodSeconds: 5
           livenessProbe:
             httpGet:
               path: /
               port: 9000
+              httpHeaders:
+                - name: Host
+                  value: bugsink.seichi-minecraft
             periodSeconds: 10
             failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /
               port: 9000
+              httpHeaders:
+                - name: Host
+                  value: bugsink.seichi-minecraft
             periodSeconds: 5
             failureThreshold: 3
           resources:


### PR DESCRIPTION
## Summary
- kube-probe が Pod IP で直接アクセスするため、Django の `ALLOWED_HOSTS` チェックで 400 が返り probe が通過できなかった
- 全 probe の `httpGet` に `Host: bugsink.seichi-minecraft` ヘッダーを追加して解消

## Test plan
- [ ] bugsink Pod が startup probe を通過して Ready になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)