### PR TITLE
feat: バックアップワークフローのスケールアップをArgoCD Syncに置き換え

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/workflow-template.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/workflow-template.yaml
@@ -86,8 +86,8 @@ spec:
             dependencies:
               - wait-for-scale-to-0
 
-          - name: patch-statefulset-to-1
-            template: patch-statefulset-to-1
+          - name: argocd-sync
+            template: argocd-sync
             inputs:
               parameters:
                 - name: statefulset-name
@@ -98,18 +98,6 @@ spec:
             dependencies:
               - run-backup
               - delete-coreprotect-db
-
-          - name: wait-for-scale-to-1
-            template: wait-for-scale-to-1
-            inputs:
-              parameters:
-                - name: statefulset-name
-            arguments:
-              parameters:
-                - name: statefulset-name
-                  value: "{{inputs.parameters.statefulset-name}}"
-            dependencies:
-              - patch-statefulset-to-1
 
     - name: check-maintenance-mode
       script:
@@ -256,31 +244,26 @@ spec:
           mariadb -hmariadb -ucoreprotect -p"${COREPROTECT_DB_USER_PASSWORD}" -Nse 'SHOW TABLES' -D {{inputs.parameters.coreprotect-db-name}} | 
             while read table; do mariadb -hmariadb -ucoreprotect -p"${COREPROTECT_DB_USER_PASSWORD}" -e "TRUNCATE TABLE $table" -D {{inputs.parameters.coreprotect-db-name}}; done
 
-    - name: patch-statefulset-to-1
+    - name: argocd-sync
       inputs:
         parameters:
           - name: statefulset-name
+      activeDeadlineSeconds: 300 # 5分でタイムアウト
       script:
-        image: alpine/kubectl:1.35.2
+        image: quay.io/argoproj/argocd:v2.14.11
         command: ["/bin/sh", "-c"]
+        env:
+          - name: ARGOCD_SERVER
+            value: "argocd-server.argocd.svc.cluster.local"
+          - name: ARGOCD_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: argocd-auth-token
+                key: token
         source: |
-          kubectl patch statefulset {{inputs.parameters.statefulset-name}} -n seichi-minecraft --type='merge' -p '{"spec": {"replicas": 1}}'
-
-    - name: wait-for-scale-to-1
-      inputs:
-        parameters:
-          - name: statefulset-name
-      activeDeadlineSeconds: 300 # 5分待っても上がってこない場合は諦める
-      script:
-        image: alpine/kubectl:1.35.2
-        command: ["/bin/sh", "-c"]
-        source: |
-          echo "Waiting for StatefulSet to scale up..."
-          while [ "$(kubectl get statefulset {{inputs.parameters.statefulset-name}} -n seichi-minecraft -o jsonpath='{.status.availableReplicas}')" != "1" ]; do
-            echo "Still scaling up..."
-            sleep 5
-          done
-          echo "Scale-up confirmed!"
+          argocd app sync "seichi-minecraft-{{inputs.parameters.statefulset-name}}" \
+            --plaintext \
+            --timeout 300
 
     - name: notify-on-failure
       steps:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -505,6 +505,16 @@ variable "cloudflare_pages__seichi_portal__next_public_ms_app_client_id" {
 
 #endregion
 
+# region ArgoCD backup-workflow account token
+
+variable "argocd_backup_workflow_auth_token" {
+  description = "ArgoCD auth token for the backup-workflow account, used to sync apps after backup"
+  type        = string
+  sensitive   = true
+}
+
+# endregion
+
 # region env variables for ArgoEvents
 
 variable "argo_events_github_access_token" {

--- a/terraform/onp_cluster_minecraft_secrets.tf
+++ b/terraform/onp_cluster_minecraft_secrets.tf
@@ -299,6 +299,21 @@ resource "kubernetes_secret" "backup_failure_notify_webhook" {
   type = "Opaque"
 }
 
+resource "kubernetes_secret" "argocd_backup_workflow_auth_token" {
+  depends_on = [kubernetes_namespace.onp_seichi_minecraft]
+
+  metadata {
+    name      = "argocd-auth-token"
+    namespace = "seichi-minecraft"
+  }
+
+  data = {
+    token = var.argocd_backup_workflow_auth_token
+  }
+
+  type = "Opaque"
+}
+
 # pbs-credentials: seichi-minecraft に配置し、seichi-debug-minecraft と garage に複製
 resource "kubernetes_secret" "pbs_credentials" {
   depends_on = [kubernetes_namespace.onp_seichi_minecraft]


### PR DESCRIPTION
## Summary

closes #3278
depends on #4621

- バックアップ後の StatefulSet replicas 復帰を `kubectl patch` から `argocd app sync` に変更
- 認証トークン用の Kubernetes Secret を Terraform で管理

### 背景

現在のバックアップワークフロー（午前4時）では `kubectl patch` で replicas を 0→1 に戻しているが、ArgoCD から見るとgit状態と異なる方法で変更されたドリフトとして検出され、SyncWindow（午前7時〜8時）で再度 Sync → 不要な再起動が発生していた。

`argocd app sync` でgitの状態に同期させることで、Sync後にドリフトがなくなり、7時台の再起動を防止できる。

### 前提

- #4621 のマージ後、以下を実施してからマージすること:
  1. `argocd account generate-token --account backup-workflow` でトークン生成
  2. `gh secret set TF_VAR_ARGOCD_BACKUP_WORKFLOW_AUTH_TOKEN` で GitHub Secrets に登録

## Test plan

- [ ] `terraform plan` が成功することを確認
- [ ] バックアップワークフローを手動実行して `argocd app sync` が成功することを確認
- [ ] 翌日の SyncWindow（7時台）で不要な再起動が発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)