### PR TITLE
feat: バックアップワークフロー用のArgoCDアカウントを追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/argocd-helm-chart-values.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/argocd-helm-chart-values.yaml
@@ -58,6 +58,7 @@ configs:
           secretEnv: ARGO_WORKFLOWS_SSO_CLIENT_SECRET
     admin.enabled: false
     accounts.mcp-service: apiKey
+    accounts.backup-workflow: apiKey
   rbac:
     create: true
     # policy.csv is an file containing user-defined RBAC policies and role definitions (optional).
@@ -69,6 +70,8 @@ configs:
     policy.csv: |
       g, GiganticMinecraft:admin-team, role:admin
       g, mcp-service, role:readonly
+      p, backup-workflow, applications, sync, seichi-minecraft/*, allow
+      p, backup-workflow, applications, get, seichi-minecraft/*, allow
     # policy.default is the name of the default role which Argo CD will falls back to, when
     # authorizing API requests (optional). If omitted or empty, users may be still be able to login,
     # but will see no apps, projects, etc...


### PR DESCRIPTION
## Summary

ref #3278

バックアップワークフローから `argocd app sync` を実行するための ArgoCD アカウントを追加する。

- `backup-workflow` アカウント（apiKey認証）を追加
- `seichi-minecraft/*` アプリに対する `sync` / `get` 権限の RBAC ポリシーを追加

### マージ後に必要な作業

1. ArgoCD のトークンを生成:
   ```bash
   argocd login argocd.onp-k8s.admin.seichi.click --grpc-web --sso
   argocd account generate-token --account backup-workflow
   ```
2. GitHub Actions Secrets に登録:
   ```bash
   gh secret set TF_VAR_ARGOCD_BACKUP_WORKFLOW_AUTH_TOKEN --repo GiganticMinecraft/seichi_infra
   ```
3. 上記完了後、後続の PR（ワークフロー変更 + Terraform Secret 定義）をマージ可能になる

## Test plan

- [ ] ArgoCD Helm chart の apply で `backup-workflow` アカウントが作成されることを確認
- [ ] `argocd account generate-token --account backup-workflow` でトークンが生成できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)