### PR TITLE
fix: Argo Workflows Full CRDスキーマに準拠するようマニフェストを修正

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/cron-workflow.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/cron-workflow.yaml
@@ -37,5 +37,5 @@ spec:
               - { "statefulset-name": "mcserver--s3", "coreprotect-db-name": "coreprotect__mc_s3", "persistent-volume-claim-name": "mcserver--s3-data-mcserver--s3-0" }
               - { "statefulset-name": "mcserver--s5", "coreprotect-db-name": "coreprotect__mc_s5", "persistent-volume-claim-name": "mcserver--s5-data-mcserver--s5-0" }
               - { "statefulset-name": "mcserver--s7", "coreprotect-db-name": "coreprotect__mc_s7", "persistent-volume-claim-name": "mcserver--s7-data-mcserver--s7-0" }
-  retryStrategy:
-    limit: 3
+    retryStrategy:
+      limit: 3

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/workflow-template.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/workflow-template.yaml
@@ -37,9 +37,6 @@ spec:
 
           - name: patch-statefulset-to-0
             template: patch-statefulset-to-0
-            inputs:
-              parameters:
-                - name: statefulset-name
             arguments:
               parameters:
                 - name: statefulset-name
@@ -49,9 +46,6 @@ spec:
 
           - name: wait-for-scale-to-0
             template: wait-for-scale-to-0
-            inputs:
-              parameters:
-                - name: statefulset-name             
             arguments:
               parameters:
                 - name: statefulset-name
@@ -61,10 +55,6 @@ spec:
 
           - name: run-backup
             template: run-backup
-            inputs:
-              parameters:
-                - name: statefulset-name        
-                - name: persistent-volume-claim-name
             arguments:
               parameters:
                 - name: statefulset-name
@@ -76,9 +66,6 @@ spec:
 
           - name: delete-coreprotect-db
             template: delete-coreprotect-db
-            inputs:
-              parameters:
-                - name: coreprotect-db-name
             arguments:
               parameters:
                 - name: coreprotect-db-name
@@ -88,9 +75,6 @@ spec:
 
           - name: argocd-sync
             template: argocd-sync
-            inputs:
-              parameters:
-                - name: statefulset-name
             arguments:
               parameters:
                 - name: statefulset-name
@@ -158,7 +142,7 @@ spec:
           persistentVolumeClaim:
             claimName: "{{inputs.parameters.persistent-volume-claim-name}}"
         - name: pbs-tmpfs
-      emptyDir: {}
+          emptyDir: {}
       script:
         image: mirror.gcr.io/debian:13
         command: ["/bin/sh", "-c"]


### PR DESCRIPTION
## Summary

Argo Workflows Helm chart 1.0.2 (appVersion v4.0.2) で Full CRD がデフォルトになったが、ArgoCD は Helm hook を実行しないため Minimal CRD のままだった。手動で Full CRD を適用したところ、SSA のスキーマ検証で既存マニフェストの不正フィールドが検出されたため修正。

### 修正内容

- **`cron-workflow.yaml`**: `retryStrategy` が `spec` 直下にあったのを `spec.workflowSpec` 配下に移動
- **`workflow-template.yaml`**: DAG タスクの不正な `inputs` フィールドを削除（`arguments` のみが正しい）
- **`workflow-template.yaml`**: `emptyDir` のインデント修正（`volumes` の子要素に）

### 背景

- Minimal CRD では `x-kubernetes-preserve-unknown-fields` によりスキーマ検証がスキップされるため、これらの不正フィールドでも動作していた
- Full CRD + SSA ではスキーマ検証が行われるため `field not declared in schema` エラーが発生
- `seichi-minecraft-workflows` が 3/12 から 2000回以上リトライし続けていた原因

### 事前作業（実施済み）

```bash
kubectl apply --server-side --force-conflicts \
  -k "https://github.com/argoproj/argo-workflows/manifests/base/crds/full?ref=v4.0.2"
kubectl rollout restart statefulset argocd-application-controller -n argocd
```

## Test plan

- [ ] ArgoCD で `seichi-minecraft-workflows` が Synced になることを確認
- [ ] バックアップの CronWorkflow が正常にスケジュールされていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)