### PR TITLE
fix: KyvernoのverifyImagesによるOutOfSyncを解消

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cloudflared-tunnel-exits/http-exits.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cloudflared-tunnel-exits/http-exits.yaml
@@ -115,6 +115,8 @@ spec:
     metadata:
       name: "cloudflared-tunnel-http-exit--{{name}}"
       namespace: argocd
+      annotations:
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     spec:
       project: cloudflared-tunnel-exits
       source:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cloudflared-tunnel-exits/https-exits.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cloudflared-tunnel-exits/https-exits.yaml
@@ -51,6 +51,8 @@ spec:
     metadata:
       name: "cloudflared-tunnel-https-exit--{{name}}"
       namespace: argocd
+      annotations:
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     spec:
       project: cloudflared-tunnel-exits
       source:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cloudflared-tunnel-exits/tcp-exits.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cloudflared-tunnel-exits/tcp-exits.yaml
@@ -30,6 +30,8 @@ spec:
     metadata:
       name: "cloudflared-tunnel-tcp-exit--{{name}}"
       namespace: argocd
+      annotations:
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     spec:
       project: cloudflared-tunnel-exits
       source:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/apps.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/apps.yaml
@@ -15,6 +15,8 @@ spec:
       # 各Application が argocd namespace に配置されるため prefix した方が安全
       name: "cluster-wide-apps-{{path.basenameNormalized}}"
       namespace: argocd
+      annotations:
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     spec:
       project: cluster-wide-apps
       source:
@@ -66,6 +68,8 @@ spec:
       # 各Application が argocd namespace に配置されるため prefix した方が安全
       name: "seichi-debug-gateway-{{path.basenameNormalized}}"
       namespace: argocd
+      annotations:
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     spec:
       project: seichi-debug-gateway
       source:
@@ -107,6 +111,8 @@ spec:
       # 各Application が argocd namespace に配置されるため prefix した方が安全
       name: "seichi-gateway-{{path.basenameNormalized}}"
       namespace: argocd
+      annotations:
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     spec:
       project: seichi-gateway
       source:
@@ -136,6 +142,8 @@ kind: Application
 metadata:
   name: app-of-cloudflared-tunnel-exits
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
 spec:
   project: cloudflared-tunnel-exits
   source:
@@ -176,6 +184,8 @@ spec:
       # 各Application が argocd namespace に配置されるため prefix した方が安全
       name: "seichi-minecraft-{{path.basenameNormalized}}"
       namespace: argocd
+      annotations:
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     spec:
       project: seichi-minecraft
       source:
@@ -216,6 +226,8 @@ spec:
       # 各Application が argocd namespace に配置されるため prefix した方が安全
       name: "seichi-debug-minecraft-{{path.basenameNormalized}}"
       namespace: argocd
+      annotations:
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     spec:
       project: seichi-debug-minecraft
       source:


### PR DESCRIPTION
## Summary

Kyverno の `verify-ghcr-image-signatures` ポリシーが admission 時にイメージ参照にダイジェストを付与（mutate）するため、ArgoCD が git の状態（タグのみ）とライブ状態（タグ+ダイジェスト）の差分を検出し、常に OutOfSync と判定していた。

### 対処

全 ApplicationSet テンプレートに以下のアノテーションを追加:

```
argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
```

これにより diff 計算時に Kubernetes API サーバーで dry-run が行われ、Kyverno の mutating webhook による変更が含まれた状態で比較されるため、OutOfSync が解消される。

### 変更対象

- `apps.yaml`: cluster-wide-apps, seichi-minecraft, seichi-debug-minecraft, seichi-debug-gateway, seichi-gateway, app-of-cloudflared-tunnel-exits
- `http-exits.yaml`, `https-exits.yaml`, `tcp-exits.yaml`: cloudflared-tunnel の各 ApplicationSet テンプレート

## Test plan

- [ ] マージ後、cloudflared-tunnel 系アプリが Synced になることを確認
- [ ] `ghcr.io/giganticminecraft/*` イメージを使う他のアプリも OutOfSync にならないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)