### PR TITLE
fix: KyvernoのverifyImagesにmutateDigest: falseを設定

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cloudflared-tunnel-exits/http-exits.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cloudflared-tunnel-exits/http-exits.yaml
@@ -115,8 +115,6 @@ spec:
     metadata:
       name: "cloudflared-tunnel-http-exit--{{name}}"
       namespace: argocd
-      annotations:
-        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     spec:
       project: cloudflared-tunnel-exits
       source:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cloudflared-tunnel-exits/https-exits.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cloudflared-tunnel-exits/https-exits.yaml
@@ -51,8 +51,6 @@ spec:
     metadata:
       name: "cloudflared-tunnel-https-exit--{{name}}"
       namespace: argocd
-      annotations:
-        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     spec:
       project: cloudflared-tunnel-exits
       source:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cloudflared-tunnel-exits/tcp-exits.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cloudflared-tunnel-exits/tcp-exits.yaml
@@ -30,8 +30,6 @@ spec:
     metadata:
       name: "cloudflared-tunnel-tcp-exit--{{name}}"
       namespace: argocd
-      annotations:
-        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     spec:
       project: cloudflared-tunnel-exits
       source:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/kyverno-policies/verify-image-signatures.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/kyverno-policies/verify-image-signatures.yaml
@@ -19,7 +19,8 @@ spec:
               kinds:
                 - Pod
       verifyImages:
-        - imageReferences:
+        - mutateDigest: false
+          imageReferences:
             - "ghcr.io/giganticminecraft/*"
           attestors:
             - entries:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/apps.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/apps.yaml
@@ -15,8 +15,6 @@ spec:
       # 各Application が argocd namespace に配置されるため prefix した方が安全
       name: "cluster-wide-apps-{{path.basenameNormalized}}"
       namespace: argocd
-      annotations:
-        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     spec:
       project: cluster-wide-apps
       source:
@@ -68,8 +66,6 @@ spec:
       # 各Application が argocd namespace に配置されるため prefix した方が安全
       name: "seichi-debug-gateway-{{path.basenameNormalized}}"
       namespace: argocd
-      annotations:
-        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     spec:
       project: seichi-debug-gateway
       source:
@@ -111,8 +107,6 @@ spec:
       # 各Application が argocd namespace に配置されるため prefix した方が安全
       name: "seichi-gateway-{{path.basenameNormalized}}"
       namespace: argocd
-      annotations:
-        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     spec:
       project: seichi-gateway
       source:
@@ -142,8 +136,6 @@ kind: Application
 metadata:
   name: app-of-cloudflared-tunnel-exits
   namespace: argocd
-  annotations:
-    argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
 spec:
   project: cloudflared-tunnel-exits
   source:
@@ -184,8 +176,6 @@ spec:
       # 各Application が argocd namespace に配置されるため prefix した方が安全
       name: "seichi-minecraft-{{path.basenameNormalized}}"
       namespace: argocd
-      annotations:
-        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     spec:
       project: seichi-minecraft
       source:
@@ -226,8 +216,6 @@ spec:
       # 各Application が argocd namespace に配置されるため prefix した方が安全
       name: "seichi-debug-minecraft-{{path.basenameNormalized}}"
       namespace: argocd
-      annotations:
-        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     spec:
       project: seichi-debug-minecraft
       source:


### PR DESCRIPTION
## Summary

Kyverno の `verify-ghcr-image-signatures` ポリシーで2つの問題を解消する。

### 問題1: ClusterPolicy の sync 失敗（1215回リトライ中）

Kyverno のバリデーションルールにより `validationFailureAction: Audit` の場合 `mutateDigest: true`（デフォルト）が拒否されるようになった:

```
admission webhook "validate-policy.kyverno.svc" denied the request:
mutateDigest must be set to false for 'Audit' failure action
```

### 問題2: イメージダイジェスト付与による OutOfSync

`mutateDigest: true` により Kyverno が admission 時にイメージ参照にダイジェストを付与し、ArgoCD が常に OutOfSync と判定していた。

### 対処

- `mutateDigest: false` を設定 → 両方の問題を根本解決
- #4625 で追加した `IncludeMutationWebhook=true` annotation は不要になったため削除

## Test plan

- [ ] `cluster-wide-apps-kyverno-policies` が Synced になることを確認
- [ ] cloudflared-tunnel 系アプリが OutOfSync にならないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)