### PR TITLE
cleanup: mariadb-operator v26移行完了に伴いautoUpdateDataPlaneを無効化

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mariadb/mariadb.yaml
@@ -158,7 +158,7 @@ spec:
     timeoutSeconds: 5
 
   updateStrategy:
-    autoUpdateDataPlane: true
+    autoUpdateDataPlane: false
     type: ReplicasFirstPrimaryLast
 
   metrics:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
@@ -79,7 +79,7 @@ spec:
     timeoutSeconds: 5
 
   updateStrategy:
-    autoUpdateDataPlane: true
+    autoUpdateDataPlane: false
     type: ReplicasFirstPrimaryLast
 
   metrics:


### PR DESCRIPTION
## Summary
- mariadb-operator v26 へのアップグレードが完了したため、`autoUpdateDataPlane` を `false` に戻す
- #4614 → #4585 の手順3（後続PRで `autoUpdateDataPlane: false` に戻す）に該当

## Test plan
- [ ] ArgoCD Sync 後、MariaDB Pod が正常に動作していることを確認
- [ ] MariaDB への接続が正常であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)