### PR TITLE
fix: meilisearch master keyをTerraform管理に移行しOutOfSyncを解消

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/meilisearch/meilisearch.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/meilisearch/meilisearch.yaml
@@ -15,6 +15,8 @@ spec:
         image:
           repository: getmeili/meilisearch
           tag: "v1.36.0"
+        auth:
+          existingMasterKeySecret: seichi-portal-meilisearch-master-key
         environment:
           MEILI_ENV: production
           MEILI_NO_ANALYTICS: "true"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
@@ -49,6 +49,11 @@ spec:
               value: "6379"
             - name: MEILISEARCH_HOST
               value: http://seichi-portal-meilisearch:7700
+            - name: MEILISEARCH_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: seichi-portal-meilisearch-master-key
+                  key: MEILI_MASTER_KEY
             - name: RABBITMQ_USER
               value: seichi-portal
             - name: RABBITMQ_PASSWORD

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -559,6 +559,16 @@ variable "proxmox_backup_client__fingerprint" {
 
 # endregion
 
+#region meilisearch secrets
+
+variable "meilisearch__master_key" {
+  description = "Meilisearch master key for seichi-portal-meilisearch"
+  type        = string
+  sensitive   = true
+}
+
+#endregion
+
 #region tailscale-approval-bot secrets
 
 variable "tailscale_approval_bot__tailnet" {

--- a/terraform/onp_cluster_minecraft_secrets.tf
+++ b/terraform/onp_cluster_minecraft_secrets.tf
@@ -265,6 +265,21 @@ resource "kubernetes_secret" "onp_minecraft_debug_mariadb_root_password" {
 }
 
 
+resource "kubernetes_secret" "seichi_portal_meilisearch_master_key" {
+  depends_on = [kubernetes_namespace.onp_seichi_minecraft]
+
+  metadata {
+    name      = "seichi-portal-meilisearch-master-key"
+    namespace = "seichi-minecraft"
+  }
+
+  data = {
+    MEILI_MASTER_KEY = var.meilisearch__master_key
+  }
+
+  type = "Opaque"
+}
+
 resource "kubernetes_secret" "tailscale_approval_bot_secrets" {
   depends_on = [kubernetes_namespace.onp_seichi_minecraft]
 


### PR DESCRIPTION
## Summary
- Helm chartがSync毎にランダムなmaster keyを生成するため、ArgoCD上でSecretが常にOutOfSyncになっていた
- master keyをTerraform (GitHub Actions Secret `TF_VAR_MEILISEARCH__MASTER_KEY`) で管理する形に変更
- Helm chartの `auth.existingMasterKeySecret` で Terraform が作成したSecretを参照
- `seichi-portal-backend` に `MEILISEARCH_API_KEY` 環境変数を追加し、認証付きでMeilisearchに接続

## 変更ファイル
- `terraform/main.tf` — `meilisearch__master_key` variable 追加
- `terraform/onp_cluster_minecraft_secrets.tf` — `seichi-portal-meilisearch-master-key` Secret リソース追加
- `meilisearch/meilisearch.yaml` — `auth.existingMasterKeySecret` 設定
- `seichi-portal-backend/deployment.yaml` — `MEILISEARCH_API_KEY` 環境変数追加

## 前提
- [x] GitHub Actions Secret `TF_VAR_MEILISEARCH__MASTER_KEY` を登録済み

## Test plan
- [ ] Terraform plan で Secret リソースの作成が確認できること
- [ ] ArgoCD Sync 後、`seichi-portal-meilisearch-master-key` Secret が OutOfSync にならないこと
- [ ] seichi-portal-backend が Meilisearch に正常に接続できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)