### PR TITLE
fix: ArgoCD Image Updater が 1.0.0 タグの digest を追跡するよう修正

### DIFF
--- a/.github/workflows/build_mcserver_images.yaml
+++ b/.github/workflows/build_mcserver_images.yaml
@@ -105,7 +105,6 @@ jobs:
           tags: |
             type=sha,prefix=sha-,suffix=,format=short
             type=raw,value=${{ matrix.image_ver }}
-            type=raw,value=latest
 
       - if: steps.should_build.outputs.should_build == 'true'
         name: Build (and push if on main)

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/mcserver--lobby-image-updater.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/mcserver--lobby-image-updater.yaml
@@ -11,6 +11,6 @@ spec:
     - namePattern: "seichi-minecraft-mcserver--lobby"
       images:
         - alias: minecraft
-          imageName: ghcr.io/giganticminecraft/seichi_minecraft_server_production_lobby:latest
+          imageName: ghcr.io/giganticminecraft/seichi_minecraft_server_production_lobby:1.0.0
           commonUpdateSettings:
             updateStrategy: digest

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/stateful-set.yaml
@@ -164,7 +164,7 @@ spec:
             - name: REMOVE_OLD_MODS
               value: "TRUE"
 
-          image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_lobby:latest
+          image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_lobby:1.0.0@sha256:14636d2d0f89a497a5ea9d8f241454ce647d78eb86849112e25dd5a8c885ca4b
           name: minecraft
           ports:
             - containerPort: 25565


### PR DESCRIPTION
## 概要

`mcserver-lobby` が `latest` タグのイメージ取得失敗でサーバー起動できない問題を修正します。

## 問題の原因

PR #4608 で ArgoCD Image Updater 導入時に `latest` タグへ変更されたが、CI ワークフローは対象 Dockerfile に変更がない場合ビルドをスキップする仕組みのため、`latest` タグが ghcr に実際には push されていなかった。

## 変更内容

- `stateful-set.yaml`: イメージタグを `latest` → `1.0.0@sha256:14636d2d...` に戻す
- `mcserver--lobby-image-updater.yaml`: ArgoCD Image Updater の追跡タグを `latest` → `1.0.0` に変更（digest 更新戦略は維持）
- `build_mcserver_images.yaml`: 不要となった `latest` タグの push を削除

`1.0.0` タグは SHA digest が変わる形で継続更新されているため、ArgoCD Image Updater による自動 digest 追跡が正常に機能します。

## Test plan

- [ ] `mcserver-lobby` Pod が正常に起動することを確認
- [ ] 次回 lobby イメージビルド時に ArgoCD Image Updater が `1.0.0` タグの digest を更新することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)