### PR TITLE
fix: mcserverバックアップの重複スナップショットを修正

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/cron-workflow.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/cron-workflow.yaml
@@ -37,5 +37,3 @@ spec:
               - { "statefulset-name": "mcserver--s3", "coreprotect-db-name": "coreprotect__mc_s3", "persistent-volume-claim-name": "mcserver--s3-data-mcserver--s3-0" }
               - { "statefulset-name": "mcserver--s5", "coreprotect-db-name": "coreprotect__mc_s5", "persistent-volume-claim-name": "mcserver--s5-data-mcserver--s5-0" }
               - { "statefulset-name": "mcserver--s7", "coreprotect-db-name": "coreprotect__mc_s7", "persistent-volume-claim-name": "mcserver--s7-data-mcserver--s7-0" }
-    retryStrategy:
-      limit: 3

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/workflow-template.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/workflow-template.yaml
@@ -232,6 +232,11 @@ spec:
       inputs:
         parameters:
           - name: statefulset-name
+      retryStrategy:
+        limit: 3
+        backoff:
+          duration: "30s"
+          factor: 2
       activeDeadlineSeconds: 300 # 5分でタイムアウト
       script:
         image: quay.io/argoproj/argocd:v3.3.4


### PR DESCRIPTION
## Summary
- `workflowSpec.retryStrategy` がワークフロー内の全ノードに適用されていたため、`run-backup`（PBSスナップショット作成）がリトライのたびに再実行され、1日のバックアップでサーバーあたり最大14回の重複スナップショットが作成されていた
- `workflowSpec.retryStrategy` を削除し、冪等な `argocd-sync` テンプレートにのみ `retryStrategy`（backoff付き）を設定

## 背景
2026-03-18 の `backup--mcservers` ワークフローで確認した実行回数:

| サーバー | run-backup実行回数 |
|---------|-------------------|
| mcserver--s1 | 14 |
| mcserver--s2 | 16 |
| mcserver--s3 | 14 |
| mcserver--s5 | 14 |
| mcserver--s7 | 14 |

ワークフロー全体は `retry exceeded workflow deadline` で失敗していた。

## Test plan
- [ ] 次回の日次バックアップ（04:00 JST）で各サーバーの `run-backup` が1回だけ実行されることを確認
- [ ] `argocd-sync` が失敗した場合にリトライされることを確認
- [ ] PBSのスナップショット数が1日1つになっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)