### PR TITLE
fix: argocd-sync の接続フラグを --plaintext から --insecure に変更

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/workflow-template.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/workflow-template.yaml
@@ -251,7 +251,7 @@ spec:
                 key: token
         source: |
           argocd app sync "seichi-minecraft-{{inputs.parameters.statefulset-name}}" \
-            --plaintext \
+            --insecure \
             --timeout 300
 
     - name: notify-on-failure


### PR DESCRIPTION
## Summary
- バックアップワークフローの `argocd-sync` ステップが全サーバーで5分タイムアウト失敗していた問題を修正
- ArgoCD CLI の接続フラグを `--plaintext` から `--insecure` に変更

## 原因
- `1f606ef42` (3/15) で ArgoCD CLI イメージが v2.14.11 → v3.3.3 にメジャーアップデートされた
- ArgoCD v3 の CLI では `--plaintext`（plain gRPC over HTTP）が TLS モードのサーバーに対してハングするようになった
- ArgoCD サーバーは `server.insecure` 未設定（TLS 有効）のため、HTTP リクエストが HTTPS に 307 リダイレクトされ gRPC 接続が確立できない状態だった
- 結果、全リトライが `Pod was active on the node longer than the specified deadline` (exit code 143) で失敗

## 修正内容
- `--plaintext`（HTTP接続）→ `--insecure`（HTTPS + 自己署名証明書検証スキップ）に変更
- クラスタ内通信のため `--insecure` が適切

## Test plan
- [x] クラスタ内でデバッグ Pod を起動し `argocd app list --insecure` での正常動作を確認済み
- [ ] 次回バックアップ CronWorkflow（毎日 4:00 JST）実行時に argocd-sync ステップが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)