### PR TITLE
fix: mcserverバックアップの Discord 失敗通知が発火しない問題を修正

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/cron-workflow.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/cron-workflow.yaml
@@ -14,6 +14,7 @@ spec:
     serviceAccountName: mcserver--backup-workflow-sa
     activeDeadlineSeconds: 14400 # 4時間でタイムアウト（image pullの失敗等での長時間ハングを防ぐ）
     entrypoint: run-mcserver-backups
+    onExit: notify-on-failure
 
     # ref: https://argo-workflows.readthedocs.io/en/latest/walk-through/loops/#withparam-example
     templates:
@@ -37,3 +38,34 @@ spec:
               - { "statefulset-name": "mcserver--s3", "coreprotect-db-name": "coreprotect__mc_s3", "persistent-volume-claim-name": "mcserver--s3-data-mcserver--s3-0" }
               - { "statefulset-name": "mcserver--s5", "coreprotect-db-name": "coreprotect__mc_s5", "persistent-volume-claim-name": "mcserver--s5-data-mcserver--s5-0" }
               - { "statefulset-name": "mcserver--s7", "coreprotect-db-name": "coreprotect__mc_s7", "persistent-volume-claim-name": "mcserver--s7-data-mcserver--s7-0" }
+
+      - name: notify-on-failure
+        steps:
+          - - name: send-failure-notification
+              template: send-discord-notification
+              when: "{{workflow.status}} != Succeeded"
+
+      - name: send-discord-notification
+        container:
+          image: curlimages/curl:8.18.0
+          env:
+            - name: DISCORD_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: backup-failure-notify-webhook
+                  key: DISCORD_WEBHOOK_URL
+          command: [sh, -ceu]
+          args:
+            - |
+              curl -fSs -X POST \
+                -H "Content-Type: application/json" \
+                --data "{
+                  \"content\": \"<@&532704116799963168>\",
+                  \"allowed_mentions\": {\"roles\": [\"532704116799963168\"]},
+                  \"embeds\": [{
+                    \"title\": \"mcserver バックアップ失敗\",
+                    \"description\": \"バックアップワークフローが失敗しました。ArgoWorkflows を確認してください。\",
+                    \"color\": 15548997
+                  }]
+                }" \
+                "${DISCORD_WEBHOOK_URL}"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/workflow-template.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/workflow-template.yaml
@@ -8,7 +8,6 @@ spec:
   ttlStrategy:
     secondsAfterCompletion: 86400
   activeDeadlineSeconds: 14400 # 4時間でタイムアウト（image pullの失敗等での長時間ハングを防ぐ）
-  onExit: notify-on-failure
   entrypoint: mcserver-backup-entrypoint
   arguments:
     # NOTE: Argo Workflows の Example やドキュメントには spec.arguments.parameters で指定する parameter には必ず value を指定しているように見えるが、
@@ -254,33 +253,3 @@ spec:
             --plaintext \
             --timeout 300
 
-    - name: notify-on-failure
-      steps:
-        - - name: send-failure-notification
-            template: send-discord-notification
-            when: "{{workflow.status}} != Succeeded"
-
-    - name: send-discord-notification
-      container:
-        image: curlimages/curl:8.18.0
-        env:
-          - name: DISCORD_WEBHOOK_URL
-            valueFrom:
-              secretKeyRef:
-                name: backup-failure-notify-webhook
-                key: DISCORD_WEBHOOK_URL
-        command: [sh, -ceu]
-        args:
-          - |
-            curl -fSs -X POST \
-              -H "Content-Type: application/json" \
-              --data "{
-                \"content\": \"<@&532704116799963168>\",
-                \"allowed_mentions\": {\"roles\": [\"532704116799963168\"]},
-                \"embeds\": [{
-                  \"title\": \"mcserver バックアップ失敗\",
-                  \"description\": \"バックアップワークフローが失敗しました。ArgoWorkflows を確認してください。\",
-                  \"color\": 15548997
-                }]
-              }" \
-              "${DISCORD_WEBHOOK_URL}"


### PR DESCRIPTION
## Summary
- バックアップワークフロー失敗時の Discord 通知が一度も発火していなかった問題を修正
- `onExit` と通知テンプレートを WorkflowTemplate から CronWorkflow に移動

## 原因
- CronWorkflow は `templateRef` で WorkflowTemplate の個別テンプレート（`mcserver-backup-entrypoint`）を参照している
- この場合、WorkflowTemplate の `spec.onExit` は CronWorkflow が生成する Workflow に**継承されない**
- そのため `notify-on-failure` テンプレートは死コードとなっており、ワークフロー失敗時にも通知が送信されていなかった
- 参考: `mariadb` バックアップは `workflowTemplateRef`（全体参照）を使っているため同様の問題はない

## 変更内容
- `cron-workflow.yaml`: `workflowSpec.onExit: notify-on-failure` を追加し、`notify-on-failure` / `send-discord-notification` テンプレートを移動
- `workflow-template.yaml`: 効果のなかった `onExit` と通知テンプレートを削除

## Test plan
- [ ] 次回のバックアップ CronWorkflow 実行時（毎日 4:00 JST）にワークフローが失敗した場合、Discord 通知が送信されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)