### PR TITLE
refactor: Discord 通知テンプレートを ClusterWorkflowTemplate に共通化

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/backup-failure-notification/cluster-workflow-template.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/backup-failure-notification/cluster-workflow-template.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ClusterWorkflowTemplate
+metadata:
+  name: backup-failure-notification
+spec:
+  templates:
+    - name: send-discord-notification
+      inputs:
+        parameters:
+          - name: title
+      container:
+        image: curlimages/curl:8.18.0
+        env:
+          - name: DISCORD_WEBHOOK_URL
+            valueFrom:
+              secretKeyRef:
+                name: backup-failure-notify-webhook
+                key: DISCORD_WEBHOOK_URL
+        command: [sh, -ceu]
+        args:
+          - |
+            curl -fSs -X POST \
+              -H "Content-Type: application/json" \
+              --data "{
+                \"content\": \"<@&532704116799963168>\",
+                \"allowed_mentions\": {\"roles\": [\"532704116799963168\"]},
+                \"embeds\": [{
+                  \"title\": \"{{inputs.parameters.title}}\",
+                  \"description\": \"バックアップワークフロー \`{{workflow.name}}\` が失敗しました。ArgoWorkflows を確認してください。\",
+                  \"color\": 15548997
+                }]
+              }" \
+              "${DISCORD_WEBHOOK_URL}"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/argo-workflows-backup.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/argo-workflows-backup.yaml
@@ -134,33 +134,15 @@ spec:
     - name: notify-on-failure
       steps:
         - - name: send-failure-notification
-            template: send-discord-notification
+            templateRef:
+              name: backup-failure-notification
+              template: send-discord-notification
+              clusterScope: true
             when: "{{workflow.status}} != Succeeded"
-
-    - name: send-discord-notification
-      container:
-        image: curlimages/curl:8.18.0
-        env:
-          - name: DISCORD_WEBHOOK_URL
-            valueFrom:
-              secretKeyRef:
-                name: backup-failure-notify-webhook
-                key: DISCORD_WEBHOOK_URL
-        command: [sh, -ceu]
-        args:
-          - |
-            curl -fSs -X POST \
-              -H "Content-Type: application/json" \
-              --data-raw "{
-                \"content\": \"<@&532704116799963168>\",
-                \"allowed_mentions\": {\"roles\": [\"532704116799963168\"]},
-                \"embeds\": [{
-                  \"title\": \"garage バックアップ失敗\",
-                  \"description\": \"バックアップワークフローが失敗しました。ArgoWorkflows を確認してください。\",
-                  \"color\": 15548997
-                }]
-              }" \
-              "${DISCORD_WEBHOOK_URL}"
+            arguments:
+              parameters:
+                - name: title
+                  value: "garage バックアップ失敗"
 
   volumeClaimTemplates:
     - metadata:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/argo-workflows-backup-all-databases.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/argo-workflows-backup-all-databases.yaml
@@ -177,30 +177,12 @@ spec:
     - name: notify-on-failure
       steps:
         - - name: send-failure-notification
-            template: send-discord-notification
+            templateRef:
+              name: backup-failure-notification
+              template: send-discord-notification
+              clusterScope: true
             when: "{{workflow.status}} != Succeeded"
-
-    - name: send-discord-notification
-      container:
-        image: curlimages/curl:8.18.0
-        env:
-          - name: DISCORD_WEBHOOK_URL
-            valueFrom:
-              secretKeyRef:
-                name: backup-failure-notify-webhook
-                key: DISCORD_WEBHOOK_URL
-        command: [sh, -ceu]
-        args:
-          - |
-            curl -fSs -X POST \
-              -H "Content-Type: application/json" \
-              --data "{
-                \"content\": \"<@&532704116799963168>\",
-                \"allowed_mentions\": {\"roles\": [\"532704116799963168\"]},
-                \"embeds\": [{
-                  \"title\": \"mariadb バックアップ失敗\",
-                  \"description\": \"バックアップワークフローが失敗しました。ArgoWorkflows を確認してください。\",
-                  \"color\": 15548997
-                }]
-              }" \
-              "${DISCORD_WEBHOOK_URL}"
+            arguments:
+              parameters:
+                - name: title
+                  value: "mariadb バックアップ失敗"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/argo-workflows-backup.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/argo-workflows-backup.yaml
@@ -178,33 +178,15 @@ spec:
     - name: notify-on-failure
       steps:
         - - name: send-failure-notification
-            template: send-discord-notification
+            templateRef:
+              name: backup-failure-notification
+              template: send-discord-notification
+              clusterScope: true
             when: "{{workflow.status}} != Succeeded"
-
-    - name: send-discord-notification
-      container:
-        image: curlimages/curl:8.18.0
-        env:
-          - name: DISCORD_WEBHOOK_URL
-            valueFrom:
-              secretKeyRef:
-                name: backup-failure-notify-webhook
-                key: DISCORD_WEBHOOK_URL
-        command: [sh, -ceu]
-        args:
-          - |
-            curl -fSs -X POST \
-              -H "Content-Type: application/json" \
-              --data-raw "{
-                \"content\": \"<@&532704116799963168>\",
-                \"allowed_mentions\": {\"roles\": [\"532704116799963168\"]},
-                \"embeds\": [{
-                  \"title\": \"mcserver--lobby バックアップ失敗\",
-                  \"description\": \"バックアップワークフローが失敗しました。ArgoWorkflows を確認してください。\",
-                  \"color\": 15548997
-                }]
-              }" \
-              "${DISCORD_WEBHOOK_URL}"
+            arguments:
+              parameters:
+                - name: title
+                  value: "mcserver--lobby バックアップ失敗"
 
   volumes:
     - name: backup-target-volume

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/cron-workflow.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/cron-workflow.yaml
@@ -42,30 +42,12 @@ spec:
       - name: notify-on-failure
         steps:
           - - name: send-failure-notification
-              template: send-discord-notification
+              templateRef:
+                name: backup-failure-notification
+                template: send-discord-notification
+                clusterScope: true
               when: "{{workflow.status}} != Succeeded"
-
-      - name: send-discord-notification
-        container:
-          image: curlimages/curl:8.18.0
-          env:
-            - name: DISCORD_WEBHOOK_URL
-              valueFrom:
-                secretKeyRef:
-                  name: backup-failure-notify-webhook
-                  key: DISCORD_WEBHOOK_URL
-          command: [sh, -ceu]
-          args:
-            - |
-              curl -fSs -X POST \
-                -H "Content-Type: application/json" \
-                --data "{
-                  \"content\": \"<@&532704116799963168>\",
-                  \"allowed_mentions\": {\"roles\": [\"532704116799963168\"]},
-                  \"embeds\": [{
-                    \"title\": \"mcserver バックアップ失敗\",
-                    \"description\": \"バックアップワークフローが失敗しました。ArgoWorkflows を確認してください。\",
-                    \"color\": 15548997
-                  }]
-                }" \
-                "${DISCORD_WEBHOOK_URL}"
+              arguments:
+                parameters:
+                  - name: title
+                    value: "mcserver バックアップ失敗"


### PR DESCRIPTION
## Summary
- 各バックアップワークフローに重複していた `send-discord-notification` テンプレートを `ClusterWorkflowTemplate` (`backup-failure-notification`) に抽出
- 各ワークフローから `templateRef` + `clusterScope: true` で参照するように変更
- 通知タイトルは `title` パラメータで個別に指定可能
- `cluster-wide-apps` の ApplicationSet により自動的に ArgoCD で管理される

## Test plan
- [ ] ClusterWorkflowTemplate がクラスタに正しくデプロイされることを確認
- [ ] 各バックアップワークフローを手動トリガーし、失敗時に正しいタイトルで Discord 通知が届くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)