### PR TITLE
fix: trivy-action のバージョンを master から v0.35.0 に固定

### DIFF
--- a/.github/workflows/build_mcserver_base_images.yaml
+++ b/.github/workflows/build_mcserver_base_images.yaml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         if: steps.build.outputs.digest != ''
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: ${{ env.DOCKER_OUTPUT_IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: 'sarif'

--- a/.github/workflows/build_mcserver_images.yaml
+++ b/.github/workflows/build_mcserver_images.yaml
@@ -130,7 +130,7 @@ jobs:
 
       - if: steps.should_build.outputs.should_build == 'true' && steps.build.outputs.digest != ''
         name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: ${{ matrix.image }}@${{ steps.build.outputs.digest }}
           format: 'sarif'

--- a/.github/workflows/mod_downloader.yaml
+++ b/.github/workflows/mod_downloader.yaml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         if: steps.build.outputs.digest != ''
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
           format: 'sarif'

--- a/.github/workflows/truenas_exporter.yaml
+++ b/.github/workflows/truenas_exporter.yaml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         if: steps.build.outputs.digest != ''
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
           format: 'sarif'


### PR DESCRIPTION
## 概要

- 4つのワークフローで `aquasecurity/trivy-action@master` を `aquasecurity/trivy-action@v0.35.0` に固定

## 変更理由

`master` ブランチを直接参照すると、上流の変更により予期せず動作が変わるリスクがある。特定バージョンに固定することで安定性とセキュリティを向上させる。

## 変更ファイル

- `.github/workflows/build_mcserver_base_images.yaml`
- `.github/workflows/build_mcserver_images.yaml`
- `.github/workflows/mod_downloader.yaml`
- `.github/workflows/truenas_exporter.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)