### PR TITLE
fix: Discord通知にGitHubリリースノートのHTMLコメントが混入する問題を修正

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/sensor.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/sensor.yaml
@@ -248,6 +248,9 @@ spec:
                           {{workflow.parameters.release-body}}
                           __RELEASE_BODY_BOUNDARY__
 
+                          # HTML コメント行を除去 (GitHub 自動生成リリースノートの先頭コメント)
+                          sed -i '/^<!--.*-->$/d' /tmp/release-body.txt
+
                           # Discord embed description の 4096 文字制限に対応
                           body=$(head -c 4000 /tmp/release-body.txt)
                           if [ "$(wc -c < /tmp/release-body.txt)" -gt 4000 ]; then


### PR DESCRIPTION
## 概要
- GitHub の自動生成リリースノートには先頭に `<!-- Release notes generated using configuration in .github/release.yml at master -->` という HTML コメントが付与される
- このコメントが `send-discord-embed-for-master` テンプレートを通じて Discord の embed description にそのまま含まれてしまっていた
- `release-body.txt` 書き出し直後に `sed -i '/^<!--.*-->$/d'` を追加し、HTML コメント単独行を除去するよう修正した

## テスト計画
- [ ] sensor.yaml を apply 後、SeichiAssist の master ブランチに対してテスト用リリースを発行し、Discord 通知に HTML コメントが含まれないことを確認する
- [ ] または、手動で `release-body` に HTML コメントを含む文字列を渡した Workflow を作成して動作確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)