### PR TITLE
fix: trivy-action が修正パッチが存在しない脆弱性をスキャン結果から除外し、対応可能な脆弱性のみを報告するようにする

### DIFF
--- a/.github/workflows/build_mcserver_base_images.yaml
+++ b/.github/workflows/build_mcserver_base_images.yaml
@@ -107,6 +107,7 @@ jobs:
           image-ref: ${{ env.DOCKER_OUTPUT_IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: 'sarif'
           output: 'trivy-results.sarif'
+          ignore-unfixed: true
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/build_mcserver_images.yaml
+++ b/.github/workflows/build_mcserver_images.yaml
@@ -135,6 +135,7 @@ jobs:
           image-ref: ${{ matrix.image }}@${{ steps.build.outputs.digest }}
           format: 'sarif'
           output: 'trivy-results.sarif'
+          ignore-unfixed: true
 
       - if: always() && steps.should_build.outputs.should_build == 'true' && steps.build.outputs.digest != ''
         name: Upload Trivy scan results to GitHub Security tab

--- a/.github/workflows/mod_downloader.yaml
+++ b/.github/workflows/mod_downloader.yaml
@@ -93,6 +93,7 @@ jobs:
           image-ref: ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
           format: 'sarif'
           output: 'trivy-results.sarif'
+          ignore-unfixed: true
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/truenas_exporter.yaml
+++ b/.github/workflows/truenas_exporter.yaml
@@ -95,6 +95,7 @@ jobs:
           image-ref: ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
           format: 'sarif'
           output: 'trivy-results.sarif'
+          ignore-unfixed: true
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4


### PR DESCRIPTION
## Summary

- 4つのWorkflow（`build_mcserver_images.yaml`, `build_mcserver_base_images.yaml`, `mod_downloader.yaml`, `truenas_exporter.yaml`）の trivy-action に `ignore-unfixed: true` を追加
- 修正パッチが存在しない脆弱性をスキャン結果から除外し、対応可能な脆弱性のみを報告するようにする

## Test plan

- [ ] GitHub Security タブでスキャン結果が正常にアップロードされることを確認
- [ ] 修正されていない脆弱性がフィルタリングされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)