### PR TITLE
mariadb バックアップの S3 オブジェクトローテーションを追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/argo-workflows-backup-all-databases.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/argo-workflows-backup-all-databases.yaml
@@ -191,20 +191,28 @@ spec:
           S3_REGION="seichi-cloud"
           BUCKET="mariadb-backups"
 
-          KEYS=$(aws --endpoint-url "$S3_ENDPOINT" --region "$S3_REGION" \
+          OBJECTS_TO_DELETE=$(aws --endpoint-url "$S3_ENDPOINT" --region "$S3_REGION" \
             s3api list-objects-v2 --bucket "$BUCKET" \
-            --query "Contents[?starts_with(Key, 'database--') && LastModified<'${CUTOFF}'].Key" \
-            --output text)
+            --query "Contents[?starts_with(Key, 'database--') && LastModified<'${CUTOFF}'].{Key: Key}" \
+            --output json)
 
-          if [ "$KEYS" = "None" ] || [ -z "$KEYS" ]; then
-            echo "削除対象のオブジェクトはありません"
-          else
-            echo "$KEYS" | tr '\t' '\n' | while read -r KEY; do
-              [ -z "$KEY" ] && continue
-              echo "削除: s3://${BUCKET}/${KEY}"
+          if [ "$OBJECTS_TO_DELETE" = "null" ]; then
+            OBJECTS_TO_DELETE="[]"
+          fi
+
+          COUNT=$(echo "$OBJECTS_TO_DELETE" | jq 'length')
+          if [ "$COUNT" -gt 0 ]; then
+            echo "削除対象: ${COUNT}件"
+            echo "$OBJECTS_TO_DELETE" | jq -r '.[].Key'
+
+            echo "$OBJECTS_TO_DELETE" | jq -c '. as $in | range(0; length; 1000) | $in[.:. + 1000]' | while read -r BATCH; do
+              DELETE_PAYLOAD="{\"Objects\": ${BATCH}, \"Quiet\": false}"
               aws --endpoint-url "$S3_ENDPOINT" --region "$S3_REGION" \
-                s3 rm "s3://${BUCKET}/${KEY}"
+                s3api delete-objects --bucket "$BUCKET" --delete "$DELETE_PAYLOAD"
             done
+            echo "${COUNT}件のオブジェクトを削除しました"
+          else
+            echo "削除対象のオブジェクトはありません"
           fi
 
           echo "=== S3クリーンアップ完了 ==="


### PR DESCRIPTION
## Summary

- mariadb バックアップワークフローの `cleanup-old-backups` は Kubernetes Backup CR のみ削除し、S3 上の `.sql` ファイルを削除していなかった
- mariadb-backups バケットに約30日分・**171.2 GiB** のデータが蓄積し、garage-to-pbs バックアップの PVC 容量不足 (200Gi) の主因となっていた
- S3 の `LastModified` メタデータを使い、保持期間 (3日) を超過した `database--` プレフィックスのオブジェクトを削除する `cleanup-old-s3-objects` テンプレートを追加
- 既存の Backup CR クリーンアップと並列実行される

## 変更内容

- `cleanup-old-s3-objects` テンプレートを新規追加
  - JMESPath の `starts_with` + `LastModified` 比較で対象オブジェクトをフィルタ（ファイル名パースに依存しない堅牢な方式）
  - `database--` プレフィックスのみ対象（手動アップロード等は除外）
  - 空バケット / 0件時のハンドリング済み
- `default` ステップの最終ステップで `cleanup-old-backups` と並列実行

## 期待される効果

ローテーション適用後、mariadb-backups バケットは約 **20 GiB**（3日分）まで縮小する見込み。これにより garage-to-pbs バックアップの PVC 容量問題も大幅に緩和される。

Closes #4672

## Test plan

- [ ] ワークフローをマニュアル実行し、`cleanup-old-s3-objects` ステップが正常に完了することを確認
- [ ] S3 バケット内の古いオブジェクト（3日超過分）が削除されていることを確認
- [ ] 直近3日分のオブジェクトが保持されていることを確認
- [ ] 空バケットの場合にステップが失敗しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)