### PR TITLE
feat: Cilium policyAuditMode有効化 + Hubble NetworkPolicy計画ダッシュボード追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/cilium.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/cilium.yaml
@@ -12,6 +12,7 @@ spec:
     helm:
       releaseName: cilium
       values: |
+        policyAuditMode: true
         kubeProxyReplacement: true
         k8sServiceHost: 192.168.32.100 # modify it if necessary
         k8sServicePort: 8443

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/hubble-network-policy-dashboard/grafana-dashboard.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/hubble-network-policy-dashboard/grafana-dashboard.yaml
@@ -1,0 +1,337 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hubble-network-policy-dashboard
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+  annotations:
+    grafana_folder: "Cilium"
+data:
+  hubble-network-policy-planning.json: |
+    {
+      "uid": "hubble-network-policy-planning",
+      "title": "Hubble NetworkPolicy Planning",
+      "description": "NetworkPolicy導入計画のための通信フロー分析ダッシュボード。Hubble policy verdicts、drop理由、DNS問い合わせを可視化し、必要な許可ルールを特定する。",
+      "tags": ["cilium", "hubble", "network-policy"],
+      "timezone": "browser",
+      "schemaVersion": 39,
+      "version": 1,
+      "refresh": "30s",
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "templating": {
+        "list": [
+          {
+            "name": "source_namespace",
+            "type": "query",
+            "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+            "query": "label_values(hubble_policy_verdicts_total, source_namespace)",
+            "includeAll": true,
+            "allValue": ".*",
+            "current": { "text": "All", "value": "$__all" },
+            "refresh": 2,
+            "sort": 1
+          },
+          {
+            "name": "destination_namespace",
+            "type": "query",
+            "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+            "query": "label_values(hubble_policy_verdicts_total, destination_namespace)",
+            "includeAll": true,
+            "allValue": ".*",
+            "current": { "text": "All", "value": "$__all" },
+            "refresh": 2,
+            "sort": 1
+          }
+        ]
+      },
+      "panels": [
+        {
+          "id": 1,
+          "title": "Policy Audit: Denied Flows (policyAuditMode)",
+          "description": "policyAuditMode有効時に、実際にポリシーで拒否されるはずのフローを表示。このパネルにデータが表示される場合、対応するallowルールが必要。",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 },
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "drawStyle": "bars",
+                "fillOpacity": 80,
+                "stacking": { "mode": "normal" }
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "sum by (source, source_namespace, destination, destination_namespace) (rate(hubble_policy_verdicts_total{action=~\"denied|audit-denied\", source_namespace=~\"$source_namespace\", destination_namespace=~\"$destination_namespace\"}[$__rate_interval]))",
+              "legendFormat": "{{source_namespace}}/{{source}} → {{destination_namespace}}/{{destination}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "title": "Namespace間 通信マトリクス (Forwarded)",
+          "description": "ポリシーにより許可されたフローのnamespace間マトリクス。NetworkPolicy設計時の通信要件把握に使用。",
+          "type": "table",
+          "gridPos": { "h": 10, "w": 12, "x": 0, "y": 8 },
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "options": {
+            "sortBy": [{ "displayName": "Value", "desc": true }]
+          },
+          "targets": [
+            {
+              "expr": "topk(30, sum by (source_namespace, destination_namespace) (rate(hubble_policy_verdicts_total{action=\"forwarded\"}[$__rate_interval])))",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": { "Time": true },
+                "renameByName": {
+                  "source_namespace": "Source Namespace",
+                  "destination_namespace": "Destination Namespace",
+                  "Value": "Rate (ops)"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "title": "Workload間 通信マトリクス (Forwarded)",
+          "description": "ポリシーにより許可されたフローのワークロード単位の詳細。source/destinationにはワークロード名またはCilium identity が入る。",
+          "type": "table",
+          "gridPos": { "h": 10, "w": 12, "x": 12, "y": 8 },
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "fieldConfig": {
+            "defaults": {
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "options": {
+            "sortBy": [{ "displayName": "Value", "desc": true }]
+          },
+          "targets": [
+            {
+              "expr": "topk(30, sum by (source, source_namespace, destination, destination_namespace) (rate(hubble_policy_verdicts_total{action=\"forwarded\", source_namespace=~\"$source_namespace\", destination_namespace=~\"$destination_namespace\"}[$__rate_interval])))",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": { "Time": true },
+                "renameByName": {
+                  "source": "Source",
+                  "source_namespace": "Src NS",
+                  "destination": "Destination",
+                  "destination_namespace": "Dst NS",
+                  "Value": "Rate (ops)"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": 4,
+          "title": "Policy Verdicts by Action",
+          "description": "ポリシー判定結果の時系列。forwarded/denied/audit-deniedの割合を監視。policyAuditMode有効時はaudit-deniedが出現する。",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 18 },
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 30,
+                "stacking": { "mode": "normal" }
+              },
+              "unit": "ops"
+            },
+            "overrides": [
+              {
+                "matcher": { "id": "byRegexp", "options": ".*denied.*" },
+                "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "expr": "sum by (action) (rate(hubble_policy_verdicts_total[$__rate_interval]))",
+              "legendFormat": "{{action}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 5,
+          "title": "Drop Reasons",
+          "description": "パケットドロップの理由別レート。POLICY_DENIEDが出現した場合、NetworkPolicyによる意図しないブロックの可能性がある。",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 18 },
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "drawStyle": "bars",
+                "fillOpacity": 80,
+                "stacking": { "mode": "normal" }
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "sum by (reason) (rate(hubble_drop_total[$__rate_interval]))",
+              "legendFormat": "{{reason}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 6,
+          "title": "Flow Overview by Verdict",
+          "description": "全フローのverdict別レート。FORWARDED/DROPPED/TRACED/TRANSLATEDの全体傾向。",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 26 },
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "sum by (subtype, verdict) (rate(hubble_flows_processed_total[$__rate_interval]))",
+              "legendFormat": "{{subtype}} / {{verdict}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 7,
+          "title": "DNS Queries (Egress先の特定用)",
+          "description": "DNS問い合わせの宛先ドメイン別レート。Egress NetworkPolicy設計時にFQDNベースのルール作成に使用。データが無い場合、Hubble DNS metricsの設定を確認。",
+          "type": "timeseries",
+          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 26 },
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": {
+                "drawStyle": "bars",
+                "fillOpacity": 80,
+                "stacking": { "mode": "normal" }
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "topk(15, sum by (query) (rate(hubble_dns_queries_total[$__rate_interval])))",
+              "legendFormat": "{{query}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 8,
+          "title": "Policy Verdicts by Direction",
+          "description": "ingress/egressのポリシー判定レート。",
+          "type": "piechart",
+          "gridPos": { "h": 8, "w": 8, "x": 0, "y": 34 },
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "targets": [
+            {
+              "expr": "sum by (direction, action) (increase(hubble_policy_verdicts_total[$__rate_interval]))",
+              "legendFormat": "{{direction}} / {{action}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 9,
+          "title": "Policy Match Type",
+          "description": "ポリシーマッチの種類 (l3-only, l4-only, all, none)。noneはポリシーにマッチしなかった通信で、audit-deniedの候補。",
+          "type": "piechart",
+          "gridPos": { "h": 8, "w": 8, "x": 8, "y": 34 },
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "targets": [
+            {
+              "expr": "sum by (match) (increase(hubble_policy_verdicts_total[$__rate_interval]))",
+              "legendFormat": "{{match}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 10,
+          "title": "Top Dropped Flows by Source/Destination",
+          "description": "ドロップされたフローのsource/destination別Top。ドロップ元・先の特定に使用。",
+          "type": "table",
+          "gridPos": { "h": 8, "w": 8, "x": 16, "y": 34 },
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "fieldConfig": {
+            "defaults": { "unit": "short" },
+            "overrides": []
+          },
+          "options": {
+            "sortBy": [{ "displayName": "Value", "desc": true }]
+          },
+          "targets": [
+            {
+              "expr": "topk(20, sum by (source, destination, reason) (increase(hubble_drop_total[$__rate_interval])))",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": { "Time": true },
+                "renameByName": {
+                  "source": "Source",
+                  "destination": "Destination",
+                  "reason": "Reason",
+                  "Value": "Count"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/hubble-network-policy-dashboard/grafana-dashboard.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/hubble-network-policy-dashboard/grafana-dashboard.yaml
@@ -27,7 +27,7 @@ data:
           {
             "name": "source_namespace",
             "type": "query",
-            "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+            "datasource": { "type": "prometheus" },
             "query": "label_values(hubble_policy_verdicts_total, source_namespace)",
             "includeAll": true,
             "allValue": ".*",
@@ -38,7 +38,7 @@ data:
           {
             "name": "destination_namespace",
             "type": "query",
-            "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+            "datasource": { "type": "prometheus" },
             "query": "label_values(hubble_policy_verdicts_total, destination_namespace)",
             "includeAll": true,
             "allValue": ".*",
@@ -55,7 +55,7 @@ data:
           "description": "policyAuditMode有効時に、実際にポリシーで拒否されるはずのフローを表示。このパネルにデータが表示される場合、対応するallowルールが必要。",
           "type": "timeseries",
           "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 },
-          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "datasource": { "type": "prometheus" },
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "palette-classic" },
@@ -82,7 +82,7 @@ data:
           "description": "ポリシーにより許可されたフローのnamespace間マトリクス。NetworkPolicy設計時の通信要件把握に使用。",
           "type": "table",
           "gridPos": { "h": 10, "w": 12, "x": 0, "y": 8 },
-          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "datasource": { "type": "prometheus" },
           "fieldConfig": {
             "defaults": {
               "unit": "ops"
@@ -94,7 +94,7 @@ data:
           },
           "targets": [
             {
-              "expr": "topk(30, sum by (source_namespace, destination_namespace) (rate(hubble_policy_verdicts_total{action=\"forwarded\"}[$__rate_interval])))",
+              "expr": "topk(30, sum by (source_namespace, destination_namespace) (rate(hubble_policy_verdicts_total{action=\"forwarded\", source_namespace=~\"$source_namespace\", destination_namespace=~\"$destination_namespace\"}[$__rate_interval])))",
               "format": "table",
               "instant": true,
               "refId": "A"
@@ -120,7 +120,7 @@ data:
           "description": "ポリシーにより許可されたフローのワークロード単位の詳細。source/destinationにはワークロード名またはCilium identity が入る。",
           "type": "table",
           "gridPos": { "h": 10, "w": 12, "x": 12, "y": 8 },
-          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "datasource": { "type": "prometheus" },
           "fieldConfig": {
             "defaults": {
               "unit": "ops"
@@ -160,7 +160,7 @@ data:
           "description": "ポリシー判定結果の時系列。forwarded/denied/audit-deniedの割合を監視。policyAuditMode有効時はaudit-deniedが出現する。",
           "type": "timeseries",
           "gridPos": { "h": 8, "w": 12, "x": 0, "y": 18 },
-          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "datasource": { "type": "prometheus" },
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "palette-classic" },
@@ -192,7 +192,7 @@ data:
           "description": "パケットドロップの理由別レート。POLICY_DENIEDが出現した場合、NetworkPolicyによる意図しないブロックの可能性がある。",
           "type": "timeseries",
           "gridPos": { "h": 8, "w": 12, "x": 12, "y": 18 },
-          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "datasource": { "type": "prometheus" },
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "palette-classic" },
@@ -219,7 +219,7 @@ data:
           "description": "全フローのverdict別レート。FORWARDED/DROPPED/TRACED/TRANSLATEDの全体傾向。",
           "type": "timeseries",
           "gridPos": { "h": 8, "w": 12, "x": 0, "y": 26 },
-          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "datasource": { "type": "prometheus" },
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "palette-classic" },
@@ -245,7 +245,7 @@ data:
           "description": "DNS問い合わせの宛先ドメイン別レート。Egress NetworkPolicy設計時にFQDNベースのルール作成に使用。データが無い場合、Hubble DNS metricsの設定を確認。",
           "type": "timeseries",
           "gridPos": { "h": 8, "w": 12, "x": 12, "y": 26 },
-          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "datasource": { "type": "prometheus" },
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "palette-classic" },
@@ -272,10 +272,10 @@ data:
           "description": "ingress/egressのポリシー判定レート。",
           "type": "piechart",
           "gridPos": { "h": 8, "w": 8, "x": 0, "y": 34 },
-          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "datasource": { "type": "prometheus" },
           "targets": [
             {
-              "expr": "sum by (direction, action) (increase(hubble_policy_verdicts_total[$__rate_interval]))",
+              "expr": "sum by (direction, action) (increase(hubble_policy_verdicts_total{source_namespace=~\"$source_namespace\", destination_namespace=~\"$destination_namespace\"}[$__rate_interval]))",
               "legendFormat": "{{direction}} / {{action}}",
               "refId": "A"
             }
@@ -287,10 +287,10 @@ data:
           "description": "ポリシーマッチの種類 (l3-only, l4-only, all, none)。noneはポリシーにマッチしなかった通信で、audit-deniedの候補。",
           "type": "piechart",
           "gridPos": { "h": 8, "w": 8, "x": 8, "y": 34 },
-          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "datasource": { "type": "prometheus" },
           "targets": [
             {
-              "expr": "sum by (match) (increase(hubble_policy_verdicts_total[$__rate_interval]))",
+              "expr": "sum by (match) (increase(hubble_policy_verdicts_total{source_namespace=~\"$source_namespace\", destination_namespace=~\"$destination_namespace\"}[$__rate_interval]))",
               "legendFormat": "{{match}}",
               "refId": "A"
             }
@@ -302,7 +302,7 @@ data:
           "description": "ドロップされたフローのsource/destination別Top。ドロップ元・先の特定に使用。",
           "type": "table",
           "gridPos": { "h": 8, "w": 8, "x": 16, "y": 34 },
-          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "datasource": { "type": "prometheus" },
           "fieldConfig": {
             "defaults": { "unit": "short" },
             "overrides": []


### PR DESCRIPTION
## Summary

Kubescapeスキャンで検出されたNetworkPolicy未設定(244リソース, C-0260)への対応準備として、通信フローの観測基盤を整備する。

- **Cilium `policyAuditMode: true`**: ポリシー違反をドロップせずにログとして記録するモード。既存の通信を止めることなく、どのフローがポリシーにマッチしないかを安全に把握できる
- **Hubble NetworkPolicy Planning ダッシュボード**: Grafanaに以下のパネルを追加
  - Policy Audit: Denied Flows — audit-deniedフローの可視化（allowルール作成の根拠）
  - Namespace間通信マトリクス — source/destination namespace別のforwardedフロー一覧
  - Workload間通信マトリクス — ワークロード単位の通信詳細
  - Policy Verdicts by Action — forwarded/denied/audit-deniedの時系列推移
  - Drop Reasons — パケットドロップ理由の分布
  - Flow Overview — 全フローのverdict別レート
  - DNS Queries — egress先特定用のDNS問い合わせ一覧
  - Policy Match Type / Direction — ポリシーマッチ種別と方向の内訳

### 想定する運用フロー

1. このPRをマージして `policyAuditMode` を有効化
2. Hubble UI (`hubble-ui.onp-k8s.admin.seichi.click`) とGrafanaダッシュボードで通信フローを1-2週間観測
3. 観測結果を元にnamespace単位でCiliumNetworkPolicyを段階的に作成
4. audit-deniedが0になったことを確認後、`policyAuditMode` を `false` に変更してenforce

### メトリクス実在確認済み

Grafana MCP経由で以下のメトリクスにデータが存在することを確認:
- `hubble_policy_verdicts_total` (action, source_namespace, destination_namespace, source, destination, direction, match)
- `hubble_drop_total` (reason, source, destination)
- `hubble_flows_processed_total` (subtype, verdict)
- `hubble_dns_queries_total` (定義あり、現在データなし — policyAuditMode有効化後に蓄積される見込み)

## Test plan

- [ ] ArgoCD syncが正常に完了すること
- [ ] Cilium agentが `policyAuditMode: true` で動作していることを `cilium status` で確認
- [ ] Grafanaの「Cilium」フォルダに「Hubble NetworkPolicy Planning」ダッシュボードが表示されること
- [ ] 既存のbungeecord CiliumNetworkPolicyのトラフィックがダッシュボードに表示されること
- [ ] 既存サービスへの影響がないこと（policyAuditModeはドロップしない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)