### PR TITLE
fix: Cilium BPF マップの mapDynamicSizeRatio を削減

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/cilium.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/cilium.yaml
@@ -32,7 +32,7 @@ spec:
           masquerade: true
           distributedLRU:
             enabled: true
-          mapDynamicSizeRatio: 0.0080
+          mapDynamicSizeRatio: 0.0025
         bandwidthManager:
           enabled: true
           bbr: true


### PR DESCRIPTION
## Summary
- Cilium の `bpf.mapDynamicSizeRatio` を `0.008` から `0.0025` に変更
- Worker ノード (88GiB) で BPF マップが約 1.3GiB 消費しているが、実際の map pressure は最大 2.3% と大幅に余裕がある
- この変更により Worker ノードあたり約 900MiB、クラスタ全体で約 2.7GiB のメモリを節約

## 調査結果

### 変更前の状態 (ratio: 0.008)

| ノード | メモリ | BPF マップ仮想メモリ | Max pressure |
|--------|--------|---------------------|--------------|
| Worker (88GiB) | 1.3 GiB | ~1.34 GiB | 2.3% |
| CP (16GiB) | 228 MiB | ~228 MiB | < 1% |

### 変更後の見込み (ratio: 0.0025)

| ノード | BPF マップ仮想メモリ |
|--------|---------------------|
| Worker (88GiB) | ~420 MiB |
| CP (16GiB) | ~71 MiB |

## Test plan
- [ ] ArgoCD sync で cilium DaemonSet が rolling restart されることを確認
- [ ] `cilium_bpf_maps_virtual_memory_max_bytes` メトリクスで削減を確認
- [ ] `cilium_bpf_map_pressure` が異常に上がっていないことを確認
- [ ] `cilium status` で全コンポーネントが正常であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)