### PR TITLE
feat: kubechecks 用 ArgoCD アカウント追加と API トークン設定

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/argocd-helm-chart-values.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/argocd-helm-chart-values.yaml
@@ -59,6 +59,7 @@ configs:
     admin.enabled: false
     accounts.mcp-service: apiKey
     accounts.backup-workflow: apiKey
+    accounts.kubechecks: apiKey
   rbac:
     create: true
     # policy.csv is an file containing user-defined RBAC policies and role definitions (optional).
@@ -70,6 +71,7 @@ configs:
     policy.csv: |
       g, GiganticMinecraft:admin-team, role:admin
       g, mcp-service, role:readonly
+      g, kubechecks, role:readonly
       p, backup-workflow, applications, sync, seichi-minecraft/*, allow
       p, backup-workflow, applications, get, seichi-minecraft/*, allow
     # policy.default is the name of the default role which Argo CD will falls back to, when

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -212,6 +212,12 @@ variable "onp_k8s_kubechecks_github_app_pem" {
   sensitive   = true
 }
 
+variable "onp_k8s_kubechecks_argocd_api_token" {
+  description = "ArgoCD API token for the kubechecks account"
+  type        = string
+  sensitive   = true
+}
+
 #endregion
 
 #region on-premise Grafana to GitHub integration

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -216,6 +216,7 @@ variable "onp_k8s_kubechecks_argocd_api_token" {
   description = "ArgoCD API token for the kubechecks account"
   type        = string
   sensitive   = true
+  default     = ""
 }
 
 #endregion

--- a/terraform/onp_cluster_secrets.tf
+++ b/terraform/onp_cluster_secrets.tf
@@ -341,6 +341,7 @@ resource "kubernetes_secret" "onp_kubechecks_github_app_secret" {
     KUBECHECKS_GITHUB_APP_ID          = var.onp_k8s_kubechecks_github_app_id
     KUBECHECKS_GITHUB_INSTALLATION_ID = var.onp_k8s_kubechecks_github_app_installation_id
     KUBECHECKS_GITHUB_PRIVATE_KEY     = var.onp_k8s_kubechecks_github_app_pem
+    KUBECHECKS_ARGOCD_API_TOKEN       = var.onp_k8s_kubechecks_argocd_api_token
   }
 
   type = "Opaque"


### PR DESCRIPTION
## Summary
- ArgoCD に `kubechecks` アカウント (`apiKey`, `role:readonly`) を追加
- Terraform に ArgoCD API トークン用の変数 (`onp_k8s_kubechecks_argocd_api_token`) と Secret を追加

## Follow-up (マージ後)
1. Terraform apply で ArgoCD Helm values が反映され、kubechecks アカウントが作成される
2. `argocd account generate-token --account kubechecks` でトークンを発行
3. `gh secret set TF_VAR_ONP_K8S_KUBECHECKS_ARGOCD_API_TOKEN --repo GiganticMinecraft/seichi_infra --body "<token>"` で登録
4. 再度 Terraform apply で kubechecks Pod に Secret が反映される

🤖 Generated with [Claude Code](https://claude.com/claude-code)