### PR TITLE
feat: Kubernetes API server の audit log を Loki に収集

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-k8s-monitoring.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-k8s-monitoring.yaml
@@ -116,6 +116,50 @@ spec:
             presets: [singleton]
           alloy-logs:
             presets: [daemonset, filesystem-log-reader]
+            # k8s-monitoring Helm chart は alloy-logs 以外の任意名 collector を
+            # サポートしないため、audit log 収集を alloy-logs に同居させている。
+            # /var/log/kubernetes/audit/ は CP ノードにしか存在しないので、
+            # worker の alloy-logs では local.file_match が空 targets を返し、
+            # 実質的に CP ノードのみで audit log が収集される。
+            extraConfig: |-
+              local.file_match "k8s_audit" {
+                path_targets = [{
+                  __path__ = "/var/log/kubernetes/audit/audit*.log",
+                  job      = "integrations/kubernetes/audit",
+                  instance = sys.env("HOSTNAME"),
+                  cluster  = "seichi-cloud",
+                }]
+              }
+
+              loki.source.file "k8s_audit" {
+                targets       = local.file_match.k8s_audit.targets
+                forward_to    = [loki.process.k8s_audit.receiver]
+                tail_from_end = true
+              }
+
+              loki.process "k8s_audit" {
+                // audit イベントは 1 行 1 JSON。
+                // user.username や objectRef.resource/namespace をラベル化すると
+                // カーディナリティが爆発して Loki が劣化するので、
+                // 低カーディナリティな level のみラベル化し、他は log 本文の JSON で検索する
+                // (Grafana Explore では `| json | user_username="..."` で絞り込める)
+                stage.json {
+                  expressions = {
+                    audit_level = "level",
+                  }
+                }
+                stage.labels {
+                  values = {
+                    level = "audit_level",
+                  }
+                }
+                stage.static_labels {
+                  values = {
+                    source = "k8s-audit",
+                  }
+                }
+                forward_to = [loki.write.localloki.receiver]
+              }
           alloy-receiver:
             presets: [deployment]
             extraConfig: |-


### PR DESCRIPTION
## Summary

- CP ノードで有効化した kube-apiserver の audit log (`/var/log/kubernetes/audit/audit*.log`) を既存の `alloy-logs` DaemonSet から tail して Loki に転送する
- 検索用ラベルは `level` のみ。user/resource/namespace などは高カーディナリティのためラベル化せず、Grafana Explore 上で `| json | user_username="..."` で絞り込む
- `source=k8s-audit` の静的ラベルで他のログストリームと区別

## Context

クラスターの監査ログは現時点で CP ノード (`seichi-onp-k8s-cp-1/2/3`) 上で有効化済み:

- `kubeadm-config` ConfigMap の `apiServer.extraArgs` に `audit-policy-file` / `audit-log-path` などを追加
- 各 CP ノードに `/etc/kubernetes/audit/policy.yaml` を配置 (secrets は metadata, RBAC 変更と pod exec/attach は RequestResponse レベルで記録、events や lease 更新などのノイズは除外)
- `kubeadm upgrade apply` / `kubeadm upgrade node` で static pod マニフェストを再生成

この PR はログをクラスター外からクエリ可能にするための最後のピース。

## なぜ CP 限定の DaemonSet を別建てしなかったか

k8s-monitoring Helm chart は固定の 5 種類のコレクター (`alloy-metrics`, `alloy-logs`, `alloy-receiver`, `alloy-singleton`, `alloy-profiles`) のみサポートしており、任意名の追加 collector は立てられない。

代わりに既存 `alloy-logs` の `extraConfig` に同居させ、worker ノードでは `/var/log/kubernetes/audit/` が存在しないので `local.file_match` が空 targets を返し実質 no-op になる運用にしている。厳密な nodeSelector 分離は ClusterRole 追加や Downward API + relabel のコスト対効果が悪いと判断した。

## Test plan

- [ ] ArgoCD が `k8s-monitoring` Application を自動 sync して `k8s-monitoring-alloy-logs` DaemonSet の ConfigMap が更新されることを確認
- [ ] alloy-logs Pod が再起動して新しい config を読み込んでいることを確認 (`kubectl logs -n monitoring k8s-monitoring-alloy-logs-<cp-pod>`)
- [ ] Grafana Explore で `{source="k8s-audit"}` クエリが結果を返すことを確認
- [ ] `{source="k8s-audit", level="RequestResponse"} | json | objectRef_resource="secrets"` で Secret アクセスが記録されていることを確認
- [ ] worker ノードの alloy-logs では k8s_audit component が空 targets を報告していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)