### PR TITLE
fix: Loki の max_line_size を 1MB に増やして audit log ドロップを回避

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/loki.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/loki.yaml
@@ -49,6 +49,11 @@ spec:
             volume_enabled: true
             ingestion_rate_mb: 8
             ingestion_burst_size_mb: 16
+            # Kubernetes audit log の RequestResponse エントリは
+            # デフォルト 256KB を超えることがある (observed: ~490KB)。
+            # 超過時はドロップではなく切り詰めにして可観測性を維持する。
+            max_line_size: 1MB
+            max_line_size_truncate: true
           ruler:
             enable_api: true
 


### PR DESCRIPTION
## Summary

- Loki の `limits_config.max_line_size` を 1MB に引き上げ (デフォルト 256KB)
- 併せて `max_line_size_truncate: true` を設定し、超過時はドロップではなく切り詰めに

## Context

直前にマージされた #4843 で audit log の Loki 転送を開始したところ、`alloy-logs` で以下のエラーが発生していることを確認:

\`\`\`
level=error msg="final error sending batch, no retries left, dropping data"
error="server returned HTTP status 400 Bad Request (400):
max entry size '262144' bytes exceeded for stream ...
while adding an entry with length '489940' bytes"
\`\`\`

Kubernetes audit log の \`level=RequestResponse\` のイベント (RBAC 変更、Pod spec 作成など) は request body / response body を含むため、256KB を超えることがある。

## Test plan

- [ ] Loki の StatefulSet が再起動し、\`/etc/loki/config/config.yaml\` に新しい limit が反映されていることを確認
- [ ] alloy-logs のログから \`max entry size\` エラーが消えることを確認
- [ ] Grafana Explore で \`{source="k8s-audit", level="RequestResponse"}\` が結果を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)