### PR TITLE
fix(haproxy): kube-apiserver バックエンドのヘルスチェックを L7 に変更

### DIFF
--- a/seichi-onp-k8s/cluster-boot-up/scripts/nodes/k8s-node-setup.sh
+++ b/seichi-onp-k8s/cluster-boot-up/scripts/nodes/k8s-node-setup.sh
@@ -211,7 +211,6 @@ global
     user haproxy
     group haproxy
     daemon
-    ssl-server-verify none
 defaults
     log     global
     mode    http
@@ -241,9 +240,9 @@ backend k8s-api
     http-check expect status 200
     balance roundrobin
     default-server inter 5s downinter 2s rise 2 fall 3 slowstart 60s maxconn 250 maxqueue 256 weight 100
-    server k8s-api-1 ${NODE_IPS[0]}:6443 check
-    server k8s-api-2 ${NODE_IPS[1]}:6443 check
-    server k8s-api-3 ${NODE_IPS[2]}:6443 check
+    server k8s-api-1 ${NODE_IPS[0]}:6443 check verify required ca-file /etc/kubernetes/pki/ca.crt
+    server k8s-api-2 ${NODE_IPS[1]}:6443 check verify required ca-file /etc/kubernetes/pki/ca.crt
+    server k8s-api-3 ${NODE_IPS[2]}:6443 check verify required ca-file /etc/kubernetes/pki/ca.crt
 EOF
 
 # Install Keepalived

--- a/seichi-onp-k8s/cluster-boot-up/scripts/nodes/k8s-node-setup.sh
+++ b/seichi-onp-k8s/cluster-boot-up/scripts/nodes/k8s-node-setup.sh
@@ -211,6 +211,7 @@ global
     user haproxy
     group haproxy
     daemon
+    ssl-server-verify none
 defaults
     log     global
     mode    http
@@ -234,9 +235,12 @@ frontend k8s-api
 backend k8s-api
     mode tcp
     option tcplog
-    option tcp-check
+    option httpchk
+    http-check connect ssl alpn h2,http/1.1
+    http-check send meth GET uri /readyz ver HTTP/1.1 hdr Host kubernetes
+    http-check expect status 200
     balance roundrobin
-    default-server inter 10s downinter 5s rise 2 fall 2 slowstart 60s maxconn 250 maxqueue 256 weight 100
+    default-server inter 5s downinter 2s rise 2 fall 3 slowstart 60s maxconn 250 maxqueue 256 weight 100
     server k8s-api-1 ${NODE_IPS[0]}:6443 check
     server k8s-api-2 ${NODE_IPS[1]}:6443 check
     server k8s-api-3 ${NODE_IPS[2]}:6443 check


### PR DESCRIPTION
## Summary
- HAProxy の kube-apiserver バックエンドヘルスチェックを TCP (L4) から HTTPS `/readyz` (L7) に変更
- 応答不能な apiserver backend を 15 秒 (fall 3 × inter 5s) で自動切り離し
- ヘルスチェック時の TLS 証明書を kubernetes 内部 CA (`/etc/kubernetes/pki/ca.crt`) で検証

## Background
2026-04-15 に cp-1 で containerd v2.2.2 のデッドロックが発生し、kube-apiserver が応答不能になった。
しかし TCP ポート 6443 は開いたままだったため、L4 ヘルスチェックが通過し続け、
HAProxy が cp-1 にトラフィックを送り続けた結果、VIP 経由の kubectl リクエストのうち3分の1がタイムアウトした。

## 変更内容
| 項目 | Before | After |
|---|---|---|
| ヘルスチェック方式 | `option tcp-check` (L4) | `option httpchk` + HTTPS GET `/readyz` (L7) |
| TLS 検証 | なし | `verify required ca-file /etc/kubernetes/pki/ca.crt` |
| チェック間隔 | `inter 10s` | `inter 5s` |
| DOWN 判定 | `fall 2` (20s) | `fall 3` (15s) |
| DOWN 時チェック間隔 | `downinter 5s` | `downinter 2s` |

## 適用状況
- [x] cp-1, cp-2, cp-3 のライブ環境に適用済み・reload 済み
- [x] 全 backend が `L7OK / check_code=200` で UP を確認

## Test plan
- [x] `haproxy -c` で構文チェック通過 (3 台)
- [x] `systemctl reload haproxy` 後に kubectl が正常動作
- [x] `show stat` で全 backend が `L7OK` / `check_code=200` を確認
- [x] CA 検証が有効であることを確認 (`ssl-server-verify none` は不使用)

🤖 Generated with [Claude Code](https://claude.com/claude-code)