### PR TITLE
perf: mariadb に jemalloc を LD_PRELOAD して RSS 膨張を抑制

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
@@ -35,6 +35,7 @@ spec:
     innodb_io_capacity_max = 3000
     max_allowed_packet = 256M
     performance_schema=on
+    performance_schema_instrument='memory/%=ON'
     max-connections=400
     join_buffer_size=256K
 

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
@@ -49,6 +49,12 @@ spec:
   env:
     - name: TZ
       value: SYSTEM
+    # glibc malloc は thread-per-connection ワークロードで arena 断片化を起こし、
+    # buffer pool (8G) を大きく超えて RSS が膨れ上がる。
+    # 公式 image に同梱されている jemalloc に切り替えて RSS を抑える。
+    # 実測では RSS が limit (16Gi) の 96% 超まで張り付いていた。
+    - name: LD_PRELOAD
+      value: /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
   podSecurityContext:
     runAsUser: 0


### PR DESCRIPTION
## Summary

`seichi-minecraft/mariadb-0` の container working set が limit (16 GiB) の **96.6%** まで張り付いており、OOMKill 寸前の状態。原因は glibc malloc が thread-per-connection モデルで多数の arena を作り、その free list を kernel に返さず抱え込むことによる断片化と推測される。

- `innodb_buffer_pool_size = 8G` に対して container RSS が **14.2 GB**
- MariaDB 自己申告 (`mysql_global_status_memory_used`) は **8.4 GB**
- **差分 5.8 GB 分が perf_schema にも buffer pool にも現れない** → glibc arena 由来が濃厚

公式 `mariadb:11.8` image には `libjemalloc2 5.3.0` が既にバンドル済みで、`LD_PRELOAD` 経由で切り替えるだけで良い。

## Changes

- `seichi-minecraft/mariadb` の `spec.env` に `LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2` を追加
- `myCnf` に `performance_schema_instrument='memory/%=ON'` を追加
  - MariaDB はデフォルトで `memory/innodb/*` や `memory/sql/*` の instrument が OFF のため、`performance_schema.memory_summary_global_by_event_name` に内訳が一切出ない
  - jemalloc で解決しなかった場合に即座に原因切り分けするために必要
  - オーバーヘッド +30-70MB（16GiB に対して誤差）

## Verification (事前テスト済み)

default namespace の検証 Pod で、`docker-registry1.mariadb.com/library/mariadb:11.8` に対して 2 つの env / cnf 両方を適用し：

- `SHOW GLOBAL VARIABLES LIKE 'version_malloc_library'` → `jemalloc 5.3.0-0-g54eaed1d8b56b1aa528be3bdd1877e59c56fa90c`
- `performance_schema.setup_instruments` で `memory/innodb` 68/68、`memory/sql` 94/94、`memory/*` 合計 269/269 が ENABLED
- `memory_summary_global_by_event_name` に `memory/innodb`, `memory/sql` カテゴリが即現れることを確認

## Test plan

- [ ] ArgoCD sync 後、`kubectl rollout restart statefulset/mariadb -n seichi-minecraft` で Pod 再作成（`updateStrategy.autoUpdateDataPlane: false` のため手動）
- [ ] Pod 起動待ち（buffer pool warmup 含め 1 分程度）
- [ ] jemalloc 確認: `SHOW GLOBAL VARIABLES LIKE 'version_malloc_library';` → `jemalloc 5.3.0-...`
- [ ] memory instrument 確認: `performance_schema.memory_summary_global_by_event_name` に `memory/innodb/buf_buf_pool` などが現れる
- [ ] 24h 経過後に Grafana で `container_memory_working_set_bytes{pod="mariadb-0"}` の推移を観察
- [ ] MariaDB Overview の `Memory Limit Usage %` が 80% 未満に収まっていることを確認
- [ ] `mysql_global_status_innodb_buffer_pool_bytes_data` や queries/sec に異常退行がないことを確認

改善が不十分だった場合：
- `Internal Memory Breakdown` パネルの Top を見て真犯人を特定
- 必要に応じて `env` を revert / `MALLOC_ARENA_MAX=2` への差し替えを検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)