### PR TITLE
feat: mariadb の slow log を sidecar 経由で pod stdout 化

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
@@ -61,24 +61,34 @@ spec:
   # stdout に流すための emptyDir。mariadb-operator は spec.volumes / spec.volumeMounts を
   # primary container と sidecar container の両方に自動伝播するため、sidecar 側で
   # 同じ mountPath を書くと "must be unique" エラーになる。
+  # sizeLimit: MariaDB slow log は自動ローテーションされない。実測 ~230 KB/h なので
+  # 500Mi = ~3 ヶ月分。想定外の増加でノードの ephemeral storage を巻き込む前に
+  # Pod が eviction される上限として設定する。
   volumes:
     - name: slow-log
-      emptyDir: {}
+      emptyDir:
+        sizeLimit: 500Mi
   volumeMounts:
     - name: slow-log
       mountPath: /var/log/mysql
 
   sidecarContainers:
     # MariaDB は slow log を stdout に書けない (MDEV-26625、/dev/stderr は権限降格後に open 不可)
-    # ため、ファイル → 共有 emptyDir → sidecar tail -F → stdout という経路で
+    # ため、ファイル → 共有 emptyDir → sidecar tail → stdout という経路で
     # kubelet の pod log 回収経路に乗せ、Alloy が拾えるようにする。
+    #
+    # tail はデフォルトの末尾から開始 ("-n +1" を付けない)。sidecar 再起動時に
+    # 既存 slow log を先頭から再送してしまうと Loki 側で重複ストリームになり、
+    # loki_process_custom_mariadb_slow_query_seconds_* の累積値が歪む。
+    # 初回起動時の数百 ms 分の slow log は失うが、mariadb 起動直後の
+    # ウォームアップクエリは運用上重要ではないのでそのトレードオフを受け入れる。
     - name: slow-log-tailer
       image: busybox:1.37.0
       command: ["/bin/sh", "-c"]
       args:
         - |
           until [ -f /var/log/mysql/mysql-slow.log ]; do sleep 1; done
-          exec tail -n +1 -F /var/log/mysql/mysql-slow.log
+          exec tail -F /var/log/mysql/mysql-slow.log
       resources:
         requests:
           cpu: 10m

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
@@ -57,6 +57,36 @@ spec:
     - name: LD_PRELOAD
       value: /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
+  # slow log をファイル (/var/log/mysql/mysql-slow.log) から sidecar 経由で
+  # stdout に流すための emptyDir。mariadb-operator は spec.volumes / spec.volumeMounts を
+  # primary container と sidecar container の両方に自動伝播するため、sidecar 側で
+  # 同じ mountPath を書くと "must be unique" エラーになる。
+  volumes:
+    - name: slow-log
+      emptyDir: {}
+  volumeMounts:
+    - name: slow-log
+      mountPath: /var/log/mysql
+
+  sidecarContainers:
+    # MariaDB は slow log を stdout に書けない (MDEV-26625、/dev/stderr は権限降格後に open 不可)
+    # ため、ファイル → 共有 emptyDir → sidecar tail -F → stdout という経路で
+    # kubelet の pod log 回収経路に乗せ、Alloy が拾えるようにする。
+    - name: slow-log-tailer
+      image: busybox:1.37.0
+      command: ["/bin/sh", "-c"]
+      args:
+        - |
+          until [ -f /var/log/mysql/mysql-slow.log ]; do sleep 1; done
+          exec tail -n +1 -F /var/log/mysql/mysql-slow.log
+      resources:
+        requests:
+          cpu: 10m
+          memory: 16Mi
+        limits:
+          cpu: 100m
+          memory: 64Mi
+
   podSecurityContext:
     runAsUser: 0
 


### PR DESCRIPTION
## Summary

`seichi-minecraft/mariadb-0` の slow log を Loki で扱えるようにする第 1 段階。

MariaDB は slow log を stdout/stderr に直接書けない ([MDEV-26625](https://jira.mariadb.org/browse/MDEV-26625) 未解決) ため、emptyDir を共有する sidecar で `tail -F` して pod stdout 化する。この PR はその **sidecar と共有 volume** のみを追加する。Alloy 側の multiline + regex パイプラインは別 PR で投入する（パイプラインは sidecar 不在時も無害、逆も同様）。

## Changes

- `seichi-minecraft/mariadb/mariadb.yaml`
  - `spec.volumes` に `slow-log` (emptyDir) を追加
  - `spec.volumeMounts` に `/var/log/mysql` を追加 (primary mariadb container から slow log を書く)
  - `spec.sidecarContainers` に `slow-log-tailer` (busybox 1.37.0) を追加
  - `myCnf` は変更なし (既に `slow_query_log_file=/var/log/mysql/mysql-slow.log` を指定済み)

`spec.volumes` / `spec.volumeMounts` は mariadb-operator v26.3.0 が primary と sidecar の両方に自動伝播するため、`sidecarContainers[].volumeMounts` で同じ mountPath を再指定すると `mountPath: must be unique` エラーで StatefulSet 作成が失敗する。この挙動は kind で検証済み。

## Verification

本番と同等構成の kind cluster で事前検証済み：

- cert-manager v1.20.2 / mariadb-operator v26.3.0 / loki v3.6.7 / grafana-k8s-monitoring v4.0.2 を順次インストール
- 本 PR と同じ sidecar 設定を適用し、Pod 2/2 Ready を確認
- sysbench (oltp_read_write, 4 threads, 60s) で **139 slow query** を発生、sidecar の stdout に全 entry が流れ、後段の Alloy で `loki_process_custom_mariadb_slow_query_seconds_count{user="sbuser"} = 139` を確認
- true indexed series = 2 (cardinality 爆発無し)
- パース失敗 0 件

## Test plan

- [ ] merge → ArgoCD sync
- [ ] `autoUpdateDataPlane: false` のため手動で `kubectl rollout restart statefulset/mariadb -n seichi-minecraft`
- [ ] `kubectl -n seichi-minecraft get pod mariadb-0` で `READY 2/2` を確認
- [ ] `kubectl -n seichi-minecraft logs mariadb-0 -c slow-log-tailer --tail=30` で `# User@Host:` から始まる slow log エントリが流れていることを確認
- [ ] jemalloc / perf_schema 計装のメトリクスに退行が無いことを `MariaDB Overview` dashboard で確認

## Rollback

`spec.volumes` / `spec.volumeMounts` / `spec.sidecarContainers` を削除した PR を出すだけ。sidecar は primary mariadb に一切影響しないため、rollback 時も primary 再起動で済む。

🤖 Generated with [Claude Code](https://claude.com/claude-code)