### PR TITLE
feat: alloy-logs に mariadb slow log の multiline パーサを追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-k8s-monitoring.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-k8s-monitoring.yaml
@@ -160,6 +160,109 @@ spec:
                 }
                 forward_to = [loki.write.localloki.receiver]
               }
+
+              // ---- MariaDB slow query log parsing ----
+              // mariadb Pod に同居する "slow-log-tailer" sidecar が slow log を pod stdout に
+              // 中継している。default の podLogsViaLoki でも line-by-line で Loki に届くが、
+              // それとは別に multiline で 1 イベントに再結合し、structured_metadata を付けて
+              // Prometheus ヒストグラムも併発行する。
+              discovery.kubernetes "mariadb_slow" {
+                role = "pod"
+                selectors {
+                  role  = "pod"
+                  field = "spec.nodeName=" + sys.env("HOSTNAME")
+                }
+              }
+
+              discovery.relabel "mariadb_slow" {
+                targets = discovery.kubernetes.mariadb_slow.targets
+
+                rule {
+                  source_labels = ["__meta_kubernetes_pod_container_name"]
+                  regex         = "slow-log-tailer"
+                  action        = "keep"
+                }
+                rule {
+                  source_labels = ["__meta_kubernetes_namespace"]
+                  target_label  = "namespace"
+                }
+                rule {
+                  source_labels = ["__meta_kubernetes_pod_name"]
+                  target_label  = "pod"
+                }
+                rule {
+                  source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+                  separator     = "/"
+                  replacement   = "/var/log/pods/*$1/*.log"
+                  target_label  = "__path__"
+                }
+              }
+
+              // loki.source.file はグロブ展開をしないので、必ず local.file_match を挟む。
+              local.file_match "mariadb_slow" {
+                path_targets = discovery.relabel.mariadb_slow.output
+              }
+
+              loki.source.file "mariadb_slow" {
+                targets       = local.file_match.mariadb_slow.targets
+                forward_to    = [loki.process.mariadb_slow.receiver]
+                tail_from_end = true
+              }
+
+              loki.process "mariadb_slow" {
+                // containerd の pod log ヘッダを剥がす
+                stage.cri {}
+
+                // MariaDB は同じ秒のクエリでは "# Time:" を省略するので、
+                // 毎イベント必ず出現する "# User@Host:" を境界にする。
+                // 先頭の "# Time:" 行は前イベントの末尾に混ざるが regex で読み飛ばすので OK。
+                stage.multiline {
+                  firstline     = "^# User@Host:"
+                  max_wait_time = "3s"
+                  max_lines     = 500
+                }
+
+                // "\\S+" は "root[root]" を greedy に食って後続の "[" で fail するので、
+                // user は "[^\\[]+" で "[" の手前までを捕まえる。
+                stage.regex {
+                  expression = "(?s)User@Host:\\s+(?P<user>[^\\[]+)\\[.*?Query_time:\\s+(?P<query_time>[\\d.]+)\\s+Lock_time:\\s+(?P<lock_time>[\\d.]+)\\s+Rows_sent:\\s+(?P<rows_sent>\\d+)\\s+Rows_examined:\\s+(?P<rows_examined>\\d+)"
+                }
+
+                // 低カーディナリティだけ label 化
+                stage.labels {
+                  values = {
+                    user = "",
+                  }
+                }
+                stage.static_labels {
+                  values = {
+                    source = "mariadb-slow",
+                  }
+                }
+
+                // 高カーディナリティは structured_metadata (Loki v3 で index されない)
+                stage.structured_metadata {
+                  values = {
+                    query_time    = "",
+                    lock_time     = "",
+                    rows_examined = "",
+                    rows_sent     = "",
+                  }
+                }
+
+                // Prometheus ヒストグラムとしても発行
+                // (Alloy の命名規則で "loki_process_custom_" プレフィックスが付く)
+                stage.metrics {
+                  metric.histogram {
+                    name        = "mariadb_slow_query_seconds"
+                    description = "MariaDB slow query execution time (seconds)"
+                    source      = "query_time"
+                    buckets     = [0.1, 0.25, 0.5, 1, 2, 5, 10]
+                  }
+                }
+
+                forward_to = [loki.write.localloki.receiver]
+              }
           alloy-receiver:
             presets: [deployment]
             extraConfig: |-


### PR DESCRIPTION
## Summary

#4886 で追加する mariadb sidecar の stdout を拾い、multiline 再結合・フィールド抽出・Prometheus ヒストグラム化する Alloy パイプラインを追加する。

## 設計

- slow-log-tailer の pod log は default の podLogsViaLoki でも line-by-line で Loki に届くので、本パイプラインは **structured** なストリーム (`source=mariadb-slow`) を**並行で**生成する。生ストリーム (grep fallback) は失われない
- user だけ index label (低カーディナリティ)、`query_time` / `lock_time` / `rows_examined` / `rows_sent` は structured_metadata (Loki v3 で index されない)
- Prometheus ヒストグラム `loki_process_custom_mariadb_slow_query_seconds_*` を併発行し、P95 等のアラートが書ける状態にする

## 検証で発見した落とし穴（全て反映済み）

| 問題 | 解決 |
|---|---|
| `loki.source.file` はグロブ展開しない | `local.file_match` を中継 |
| MariaDB は同秒クエリで \`# Time:\` を省略する | multiline firstline を \`^# User@Host:\` に |
| 正規表現の \`\\S+\` が \`root[root]\` を greedy に食って後続パターン失敗 | user を \`[^\\[]+\` で "[" 手前まで |
| \`metric.histogram\` にラベル書くと syntax error | 無名ブロック + \`name = "..."\` 属性 |

## Verification

kind cluster (cert-manager v1.20.2 / mariadb-operator v26.3.0 / loki v3.6.7 / grafana-k8s-monitoring v4.0.2) で事前検証済み。

- sysbench (oltp_read_write, 4 threads, 60s) で 139 slow query 発生
- `loki_process_custom_mariadb_slow_query_seconds_count{user=\"sbuser\"} = 139` (メトリクス OK)
- true indexed series count = 2 (cardinality 爆発無し — series API で確認)
- `| query_time > 0.07` による structured_metadata フィルタ動作確認
- Grafana Explore / Dashboard 両方で表示確認

## Test plan

- [ ] #4886 merge 後に本 PR を merge (順番依存は無いが、データが流れる順はそう)
- [ ] ArgoCD sync 後に `kubectl -n monitoring rollout restart daemonset k8s-monitoring-alloy-logs`
- [ ] Grafana Explore で \`{source="mariadb-slow"}\` が本番 mariadb-0 の slow query を返すか確認
- [ ] \`{source="mariadb-slow"} | query_time > 1\` で 1 秒超のクエリが (あれば) 返るか確認
- [ ] Prometheus で \`loki_process_custom_mariadb_slow_query_seconds_bucket\` が発行されているか

## Rollback

本 PR の diff を revert するだけ。default podLogsViaLoki は独立に動き続けるので、rollback 中も slow log は line-by-line で Loki に届き続ける。

🤖 Generated with [Claude Code](https://claude.com/claude-code)