### PR TITLE
ops: メンテナンスモード ON (#4886 の mariadb 手動 rollout のため)

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/maintenance-mode/configmap.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/maintenance-mode/configmap.yaml
@@ -8,4 +8,4 @@ data:
   # この値を "true" に変更すると、全Minecraftサーバーが即座にReadinessProbeで失敗し、
   # Serviceのエンドポイントから除外される（トラフィック遮断）。
   # Pod自体は起動したままなので、メンテナンス作業は継続可能。
-  enabled: "false"
+  enabled: "true"


### PR DESCRIPTION
## Summary

#4886 (mariadb slow log sidecar) は merge 済み。`spec.updateStrategy.autoUpdateDataPlane: false` のため ArgoCD sync 後に **手動で `kubectl rollout restart statefulset/mariadb -n seichi-minecraft`** が必要。再起動中の接続エラーを各 mcserver に見せないよう、事前に全 MC サーバーへのトラフィックを遮断する。

[runbook: メンテナンスモード](https://github.com/GiganticMinecraft/seichi_infra/blob/main/docs/runbooks/maintenance-mode.md) に沿った操作。

## Changes

- `seichi-minecraft/maintenance-mode/configmap.yaml`: `enabled: "false"` → `"true"`

## オペレーション手順

1. **本 PR merge** → ArgoCD sync
2. **各 mcserver の readinessProbe が NG** になり、90 秒以内に Service エンドポイントから除外される（Pod は起動したまま）
3. `kubectl rollout restart statefulset/mariadb -n seichi-minecraft`
4. 新 Pod が `READY 2/2` になり、`kubectl logs mariadb-0 -c slow-log-tailer` で slow log が流れることを確認
5. **別 PR でメンテナンスモード OFF** (`enabled: "false"` 戻し)

## Rollback

enabled を "false" に戻す PR をマージするだけ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)