### PR TITLE
fix: slow-log-tailer sidecar で LD_PRELOAD を空に上書き

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
@@ -84,6 +84,14 @@ spec:
     # ウォームアップクエリは運用上重要ではないのでそのトレードオフを受け入れる。
     - name: slow-log-tailer
       image: busybox:1.37.0
+      # mariadb-operator は spec.env を primary と sidecar の両方に伝播する。
+      # primary 用の LD_PRELOAD=jemalloc が busybox sidecar にも適用されると、
+      # jemalloc が無いため ld.so が "cannot be preloaded" と毎プロセス ERROR 行を
+      # stdout に吐き、Alloy の multiline パイプラインに紛れ込んで slow log を汚す。
+      # sidecar 側で空に上書きして無効化する。
+      env:
+        - name: LD_PRELOAD
+          value: ""
       command: ["/bin/sh", "-c"]
       args:
         - |


### PR DESCRIPTION
## Summary

#4886 で追加した `slow-log-tailer` sidecar の stdout に下記の ERROR 行が混入している：

\`\`\`
ERROR: ld.so: object '/usr/lib/x86_64-linux-gnu/libjemalloc.so.2' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
\`\`\`

## Root cause

- mariadb-operator は \`spec.env\` を primary container (mariadb) と sidecar container (slow-log-tailer) の **両方** に伝播する
- primary 用の \`LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2\` が busybox の sidecar にも適用される
- busybox image には jemalloc が入っていないため、sidecar 内の \`sh\` / \`tail\` が exec される度に ld.so が失敗して ERROR 行を stdout に出す
- 機能的には "ignored." と出てそのまま実行継続するので無害だが、以下 2 つの副作用がある:
  1. Alloy の \`loki.process.mariadb_slow\` の \`stage.multiline { firstline = "^# User@Host:" }\` にこの ERROR 行が引っかからないので、直前のスロークエリイベントの末尾に吸収されて Loki に届く slow log 本文を汚す
  2. default の podLogsViaLoki パイプライン側でも slow-log-tailer container のログとしてノイズが流れる

## Fix

sidecar container 側に \`env: [{name: LD_PRELOAD, value: ""}]\` を明示指定して pod-level の \`LD_PRELOAD\` を無効化する。kubernetes の container env は pod env より優先されるので、primary は jemalloc 付きで動き続ける。

## Test plan

- [ ] merge → ArgoCD sync
- [ ] \`autoUpdateDataPlane: false\` のため手動で \`kubectl rollout restart statefulset/mariadb -n seichi-minecraft\`
- [ ] \`kubectl logs mariadb-0 -c slow-log-tailer\` に ERROR 行が出ていないこと
- [ ] \`kubectl exec mariadb-0 -c mariadb -- mariadb -uroot -p"\$MARIADB_ROOT_PASSWORD" -Ne "SHOW GLOBAL VARIABLES LIKE 'version_malloc_library'"\` が \`jemalloc 5.x\` のままで **primary は影響を受けていない**ことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)