### PR TITLE
ops: メンテナンスモード OFF (mariadb slow log 配備完了後)

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/maintenance-mode/configmap.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/maintenance-mode/configmap.yaml
@@ -8,4 +8,4 @@ data:
   # この値を "true" に変更すると、全Minecraftサーバーが即座にReadinessProbeで失敗し、
   # Serviceのエンドポイントから除外される（トラフィック遮断）。
   # Pod自体は起動したままなので、メンテナンス作業は継続可能。
-  enabled: "true"
+  enabled: "false"


### PR DESCRIPTION
## Summary

#4886 / #4893 / #4887 の適用がすべて完了したのでトラフィックを戻す。

## 完了済み作業

- **#4886**: mariadb slow log tailer sidecar 追加 — merged & applied
- **#4893**: sidecar の LD_PRELOAD を空に上書きして ld.so ERROR 除去 — merged & applied
- **#4887**: Alloy に \`loki.process.mariadb_slow\` multiline パイプライン追加 — merged & applied

## 確認済み状態

- \`mariadb-0\` Pod **2/2 Running** (primary + slow-log-tailer)
- sidecar stdout に \`LD_PRELOAD\` ERROR 行 **0 件**
- Alloy \`/-/reload\` で新 config ロード済み、5 component (discovery / relabel / file_match / source.file / process) 全て healthy
- Grafana Loki で \`{source="mariadb-slow", namespace="seichi-minecraft"}\` に手動 slow query 3 件の到達確認
- \`structuredMetadata\` (\`query_time\`, \`lock_time\`, \`rows_examined\`, \`rows_sent\`) 付与確認

## 残作業

- Prometheus histogram \`loki_process_custom_mariadb_slow_query_seconds_*\` が \`/metrics\` に出ていない件は別途調査（Loki 側の可視化は機能しているので OFF 判断には影響しない）

## Rollback

本 PR を revert するだけ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)