### PR TITLE
feat: alloy-logs ServiceMonitor を追加して Prometheus に metrics を流す

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/alloy-logs-servicemonitor/servicemonitor.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/alloy-logs-servicemonitor/servicemonitor.yaml
@@ -1,0 +1,28 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: alloy-logs
+  namespace: monitoring
+  labels:
+    # kube-prometheus-stack の Prometheus は podMonitorSelector / serviceMonitorSelector を
+    # matchLabels: {release: prometheus} で絞っているので、この label が無いと無視される。
+    release: prometheus
+spec:
+  # k8s-monitoring chart が作る Service: k8s-monitoring-alloy-logs
+  # 目的: alloy-logs が loki.process 内の stage.metrics で発行する
+  # loki_process_custom_mariadb_slow_query_seconds_* ヒストグラム等を Prometheus に取り込む。
+  # clusterMetrics.enabled が false (kube-prometheus-stack 側で K8s metrics を取っているため) の設定下で
+  # alloy-logs 自身の自己 metrics と loki.process 経由で emit される custom metrics を
+  # 拾うためには別経路の scrape 設定が必要で、それが本 ServiceMonitor。
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: alloy-logs
+  namespaceSelector:
+    matchNames:
+      - monitoring
+  endpoints:
+    - port: http-metrics
+      interval: 30s
+      path: /metrics
+      # 6 node (worker + CP) それぞれの alloy-logs pod が持つ自己メトリクスを取得する。
+      # pod ごとに node label が付くので Prometheus 側で分かる。


### PR DESCRIPTION
## Summary

#4887 で alloy-logs の \`loki.process.mariadb_slow\` に足した \`stage.metrics\` がヒストグラム \`loki_process_custom_mariadb_slow_query_seconds_*\` を emit しているが、**Prometheus からは見えない** 問題を解消する。

## Root cause

k8s-monitoring chart の \`clusterMetrics.enabled: false\` (kube-prometheus-stack と役割分担) の結果、chart 側に alloy の metrics を scrape する経路が無い。kube-prometheus-stack の Prometheus は \`release: prometheus\` label の \`ServiceMonitor\` / \`PodMonitor\` しか選ばないので、alloy-logs の \`/metrics\` (port 12345 \`http-metrics\`) を拾えない。

## Fix

\`cluster-wide-apps/alloy-logs-servicemonitor/servicemonitor.yaml\` を追加。k8s-monitoring chart が自動生成する Service \`k8s-monitoring-alloy-logs\` に対し 30s 間隔で scrape。

## Test plan

- [ ] merge → ArgoCD が cluster-wide-apps-alloy-logs-servicemonitor Application を作成 → sync
- [ ] Grafana Explore (Prometheus) で \`loki_process_custom_mariadb_slow_query_seconds_bucket\` が返るか
- [ ] 同じく \`loki_process_custom_mariadb_slow_query_seconds_count\` / \`_sum\` が返るか
- [ ] Prometheus targets 画面で \`serviceMonitor/monitoring/alloy-logs\` が UP になっているか

## Scope

本 PR は Prometheus-side の経路を張るだけで、Dashboard 等は変更しない。既存 Loki ベースのクエリ (\`unwrap query_time | quantile_over_time\`) も引き続き動くので、冗長化として機能する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)