### PR TITLE
refactor: MariaDB Overview Storage row を bar gauge ベースに再構成

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard.yaml
@@ -517,7 +517,46 @@ data:
         },
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "description": "PVC (storage-mariadb-0) の使用率。80% を超えたら容量拡張・不要テーブル削除を検討。",
+          "description": "storage-mariadb-0 の使用量。閾値 70% / 85% で色が変わる。",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "thresholds" },
+              "min": 0,
+              "max": 644245094400,
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  { "color": "green",  "value": null },
+                  { "color": "orange", "value": 70 },
+                  { "color": "red",    "value": 85 }
+                ]
+              },
+              "unit": "bytes"
+            }
+          },
+          "gridPos": { "h": 5, "w": 16, "x": 0, "y": 97 },
+          "id": 80,
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+            "showUnfilled": true,
+            "valueMode": "color"
+          },
+          "targets": [
+            {
+              "datasource": { "type": "prometheus", "uid": "${datasource}" },
+              "expr": "kubelet_volume_stats_used_bytes{namespace=\"seichi-minecraft\", persistentvolumeclaim=\"storage-mariadb-0\"}",
+              "legendFormat": "used",
+              "refId": "A"
+            }
+          ],
+          "title": "Disk Usage (used / 600 GiB)",
+          "type": "bargauge"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "description": "現在使用率 %。threshold green<70 / orange 70-85 / red >85。",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "thresholds" },
@@ -534,8 +573,8 @@ data:
               "unit": "percent"
             }
           },
-          "gridPos": { "h": 5, "w": 6, "x": 0, "y": 97 },
-          "id": 80,
+          "gridPos": { "h": 5, "w": 8, "x": 16, "y": 97 },
+          "id": 81,
           "options": {
             "colorMode": "background",
             "graphMode": "none",
@@ -557,42 +596,6 @@ data:
         },
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "description": "現在使用中の物理データ量 / PVC 総容量。",
-          "fieldConfig": {
-            "defaults": {
-              "color": { "mode": "palette-classic" },
-              "unit": "bytes"
-            }
-          },
-          "gridPos": { "h": 5, "w": 6, "x": 6, "y": 97 },
-          "id": 81,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-            "textMode": "auto"
-          },
-          "targets": [
-            {
-              "datasource": { "type": "prometheus", "uid": "${datasource}" },
-              "expr": "kubelet_volume_stats_used_bytes{namespace=\"seichi-minecraft\", persistentvolumeclaim=\"storage-mariadb-0\"}",
-              "legendFormat": "used",
-              "refId": "A"
-            },
-            {
-              "datasource": { "type": "prometheus", "uid": "${datasource}" },
-              "expr": "kubelet_volume_stats_capacity_bytes{namespace=\"seichi-minecraft\", persistentvolumeclaim=\"storage-mariadb-0\"}",
-              "legendFormat": "capacity",
-              "refId": "B"
-            }
-          ],
-          "title": "Disk Used / Capacity",
-          "type": "stat"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "description": "使用量の時系列推移。右肩上がりの急勾配は予想外の書き込み発生を示唆。Total Table Size (all DBs) と対比すると、DB 以外 (binlog、slow log、tmp 等) の使用量も推定できる。",
           "fieldConfig": {
             "defaults": {
@@ -605,7 +608,7 @@ data:
               "unit": "bytes"
             }
           },
-          "gridPos": { "h": 10, "w": 12, "x": 12, "y": 97 },
+          "gridPos": { "h": 8, "w": 16, "x": 0, "y": 102 },
           "id": 82,
           "targets": [
             {
@@ -642,7 +645,7 @@ data:
               "decimals": 0
             }
           },
-          "gridPos": { "h": 5, "w": 12, "x": 0, "y": 102 },
+          "gridPos": { "h": 8, "w": 8, "x": 16, "y": 102 },
           "id": 83,
           "options": {
             "colorMode": "background",


### PR DESCRIPTION
## Summary

#4899 で追加した Storage row が stat 4 枚並びで視覚的なインパクトが弱かったので、bar gauge を中心に置き直す。

## Before → After

### Before
- stat × 4 (Usage %, Used, Capacity, Days Until Full)
- 数字が並ぶだけで「どれだけ埋まっているか」が一目では伝わらない

### After

| Panel | サイズ | 表示内容 |
|---|---|---|
| **Disk Usage (used / 600 GiB)** | bargauge 16x5 | プログレスバーで used/capacity を可視化、閾値 70% / 85% で色変化 |
| Disk Usage % | stat 8x5 | 補助的な数値 |
| Disk Usage Over Time | timeseries 16x8 | 推移 (既存) |
| Est. Days Until Full (7d trend) | stat 8x8 | 容量到達予測 (既存) |

## 設計の選択理由

- bar gauge: プログレスバー状で「満タンまでどれくらい」を直感的に表現。Grafana docs でも disk capacity 系で推奨される定番
- capacity は hardcode (600 GiB = 644245094400 bytes)。PVC resize は稀で、`configFromData` transformation の複雑さを避けるトレードオフ
- 閾値は percentage mode で指定、実際のバイト数から自動計算

## 現状確認

- 実 PVC capacity: 600 GiB (`kubectl get pvc storage-mariadb-0`)
- 使用量: 46.6 GiB (7.8%) — 余裕あり

🤖 Generated with [Claude Code](https://claude.com/claude-code)