### PR TITLE
feat: MariaDB Internal Memory Breakdown を timeseries 化

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard.yaml
@@ -374,7 +374,7 @@ data:
           },
           "gridPos": { "h": 8, "w": 12, "x": 12, "y": 67 },
           "id": 61,
-          "options": { "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+          "options": { "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true, "sortBy": "Last *", "sortDesc": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
           "targets": [
             { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "topk(10, mysql_perf_schema_memory_events_used_bytes{instance=~\"$instance\"})", "legendFormat": "{{event_name}}", "refId": "A" }
           ],

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard.yaml
@@ -374,7 +374,7 @@ data:
           },
           "gridPos": { "h": 8, "w": 12, "x": 12, "y": 67 },
           "id": 61,
-          "options": { "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true, "sortBy": "Last *", "sortDesc": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+          "options": { "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
           "targets": [
             { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "topk(10, mysql_perf_schema_memory_events_used_bytes{instance=~\"$instance\"})", "legendFormat": "{{event_name}}", "refId": "A" }
           ],

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard.yaml
@@ -363,22 +363,23 @@ data:
         },
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "description": "perf_schema が計装するイベント別のメモリ使用量 Top 10 を時系列表示。スタック表示で合計の構成が見える。特定イベントの突然の増加 (memory leak の早期検知) にも使える。",
           "fieldConfig": {
             "defaults": {
               "color": { "mode": "palette-classic" },
-              "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "fillOpacity": 80, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineWidth": 1, "scaleDistribution": { "type": "linear" }, "thresholdsStyle": { "mode": "off" } },
+              "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "drawStyle": "line", "fillOpacity": 25, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 3, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "normal" }, "thresholdsStyle": { "mode": "off" } },
               "mappings": [],
               "unit": "bytes"
             }
           },
           "gridPos": { "h": 8, "w": 12, "x": 12, "y": 67 },
           "id": 61,
-          "options": { "barRadius": 0, "barWidth": 0.8, "groupWidth": 0.7, "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true }, "orientation": "horizontal", "showValue": "auto", "stacking": "none", "tooltip": { "mode": "multi", "sort": "desc" }, "xTickLabelRotation": 0 },
+          "options": { "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true, "sortBy": "Last *", "sortDesc": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
           "targets": [
-            { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "topk(10, mysql_perf_schema_memory_events_used_bytes{instance=~\"$instance\"})", "legendFormat": "{{event_name}}", "format": "table", "instant": true, "refId": "A" }
+            { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "topk(10, mysql_perf_schema_memory_events_used_bytes{instance=~\"$instance\"})", "legendFormat": "{{event_name}}", "refId": "A" }
           ],
-          "title": "MariaDB Internal Memory Breakdown (Top 10)",
-          "type": "barchart"
+          "title": "MariaDB Internal Memory Breakdown (Top 10 over time)",
+          "type": "timeseries"
         },
         {
           "collapsed": false,


### PR DESCRIPTION
## Summary

MariaDB Overview dashboard の \`MariaDB Internal Memory Breakdown (Top 10)\` panel は従来 **barchart + instant query (スナップショット)** だったため、現在値だけが見え推移が追えなかった。本日の RSS 肥大化調査 (#4879 / #4886 周辺) で「どのイベントがいつどれだけ伸びたか」の時系列が重要と判明したので timeseries に変更する。

## Changes

Panel id=61 のみ変更:

| 項目 | Before | After |
|---|---|---|
| type | \`barchart\` | \`timeseries\` |
| stacking | none | normal (area stacked) |
| query | 同じ (\`topk(10, mysql_perf_schema_memory_events_used_bytes{...})\`) | 同じ |
| instant/format | \`instant: true, format: table\` | range query |
| legend | table, lastNotNull | table, lastNotNull + max、Last で sort desc |

## なぜ stacked area

- 個々のイベント (\`innodb/buf_buf_pool\` 8GB 等) の推移と、**合計メモリに対する各イベントの寄与度** が同じグラフで読める
- 個別 event 値を追いたい時は tooltip hover で個別行を読める (legend calcs も Last / Max 表示)
- memory leak 兆候の早期発見に有効 (ある系列が単調増加だと目立つ)

## 既知の小さな制約

- \`topk(10, ...)\` はステップごとに top 10 を再計算するので、ある瞬間に 11 位が 10 位に入れ替わると系列の出入りが起きる。実用上大物 (buf_buf_pool, performance_schema 系) は常に top に残るのでノイズは限定的

🤖 Generated with [Claude Code](https://claude.com/claude-code)