### PR TITLE
feat: slow log dashboard に Top 20 slowest queries table 追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard-slow-log-loki.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard-slow-log-loki.yaml
@@ -227,7 +227,7 @@ data:
         },
         {
           "datasource": { "type": "loki", "uid": "${loki_ds}" },
-          "description": "時間範囲内の個別スロークエリを query_time 降順で上位20件表示。犯人特定用のスキャン可能な table ビュー。structured_metadata (query_time / rows_examined / rows_sent / lock_time / user / db) を列として展開する。",
+          "description": "時間範囲内の個別スロークエリを query_time 降順で上位20件表示。犯人特定用のスキャン可能な table ビュー。Loki API の direction=backward (default) で新しい順に最大 20000 行取得後 client-side sort するため、極端に長い時間範囲 (7d 以上など) では古い時間帯の slow query が母集団から漏れる可能性あり。通常の運用レンジ (1h〜24h) では全量カバー可能。",
           "fieldConfig": {
             "defaults": {
               "custom": {
@@ -324,7 +324,7 @@ data:
             {
               "datasource": { "type": "loki", "uid": "${loki_ds}" },
               "expr": "{source=\"mariadb-slow\", pod=~\"$pod\"} | query_time > $min_query_time",
-              "maxLines": 5000,
+              "maxLines": 20000,
               "queryType": "range",
               "refId": "A"
             }
@@ -333,6 +333,14 @@ data:
             {
               "id": "extractFields",
               "options": { "source": "labels" }
+            },
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "names": ["Time", "query_time", "rows_examined", "rows_sent", "lock_time", "user", "Line"]
+                }
+              }
             },
             {
               "id": "convertFieldType",
@@ -361,12 +369,7 @@ data:
             {
               "id": "organize",
               "options": {
-                "excludeByName": {
-                  "id": true,
-                  "tsNs": true,
-                  "labels": true,
-                  "labelTypes": true
-                },
+                "excludeByName": {},
                 "indexByName": {
                   "Time": 0,
                   "query_time": 1,
@@ -374,8 +377,7 @@ data:
                   "rows_sent": 3,
                   "lock_time": 4,
                   "user": 5,
-                  "db": 6,
-                  "Line": 7
+                  "Line": 6
                 },
                 "renameByName": {}
               }

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard-slow-log-loki.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard-slow-log-loki.yaml
@@ -294,12 +294,6 @@ data:
                 ]
               },
               {
-                "matcher": { "id": "byName", "options": "db" },
-                "properties": [
-                  { "id": "custom.width", "value": 140 }
-                ]
-              },
-              {
                 "matcher": { "id": "byName", "options": "Time" },
                 "properties": [
                   { "id": "custom.width", "value": 170 }

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard-slow-log-loki.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard-slow-log-loki.yaml
@@ -222,13 +222,172 @@ data:
           "gridPos": { "h": 1, "w": 24, "x": 0, "y": 24 },
           "id": 101,
           "panels": [],
-          "title": "Raw slow queries",
+          "title": "Top offenders & raw log",
           "type": "row"
         },
         {
           "datasource": { "type": "loki", "uid": "${loki_ds}" },
+          "description": "時間範囲内の個別スロークエリを query_time 降順で上位20件表示。犯人特定用のスキャン可能な table ビュー。structured_metadata (query_time / rows_examined / rows_sent / lock_time / user / db) を列として展開する。",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "left",
+                "cellOptions": { "type": "auto" },
+                "filterable": true
+              }
+            },
+            "overrides": [
+              {
+                "matcher": { "id": "byName", "options": "query_time" },
+                "properties": [
+                  { "id": "unit", "value": "s" },
+                  { "id": "decimals", "value": 3 },
+                  { "id": "custom.cellOptions", "value": { "type": "color-background", "mode": "gradient" } },
+                  { "id": "thresholds", "value": {
+                    "mode": "absolute",
+                    "steps": [
+                      { "color": "green", "value": null },
+                      { "color": "yellow", "value": 0.5 },
+                      { "color": "orange", "value": 1 },
+                      { "color": "red", "value": 5 }
+                    ]
+                  } },
+                  { "id": "custom.width", "value": 110 }
+                ]
+              },
+              {
+                "matcher": { "id": "byName", "options": "lock_time" },
+                "properties": [
+                  { "id": "unit", "value": "s" },
+                  { "id": "decimals", "value": 3 },
+                  { "id": "custom.width", "value": 100 }
+                ]
+              },
+              {
+                "matcher": { "id": "byName", "options": "rows_examined" },
+                "properties": [
+                  { "id": "unit", "value": "short" },
+                  { "id": "custom.cellOptions", "value": { "type": "color-background", "mode": "gradient" } },
+                  { "id": "thresholds", "value": {
+                    "mode": "absolute",
+                    "steps": [
+                      { "color": "green", "value": null },
+                      { "color": "yellow", "value": 10000 },
+                      { "color": "orange", "value": 100000 },
+                      { "color": "red", "value": 1000000 }
+                    ]
+                  } },
+                  { "id": "custom.width", "value": 130 }
+                ]
+              },
+              {
+                "matcher": { "id": "byName", "options": "rows_sent" },
+                "properties": [
+                  { "id": "unit", "value": "short" },
+                  { "id": "custom.width", "value": 100 }
+                ]
+              },
+              {
+                "matcher": { "id": "byName", "options": "user" },
+                "properties": [
+                  { "id": "custom.width", "value": 120 }
+                ]
+              },
+              {
+                "matcher": { "id": "byName", "options": "db" },
+                "properties": [
+                  { "id": "custom.width", "value": 140 }
+                ]
+              },
+              {
+                "matcher": { "id": "byName", "options": "Time" },
+                "properties": [
+                  { "id": "custom.width", "value": 170 }
+                ]
+              },
+              {
+                "matcher": { "id": "byName", "options": "Line" },
+                "properties": [
+                  { "id": "custom.cellOptions", "value": { "type": "auto", "wrapText": true } }
+                ]
+              }
+            ]
+          },
+          "gridPos": { "h": 12, "w": 24, "x": 0, "y": 25 },
+          "id": 11,
+          "options": {
+            "cellHeight": "sm",
+            "footer": { "show": false },
+            "showHeader": true
+          },
+          "targets": [
+            {
+              "datasource": { "type": "loki", "uid": "${loki_ds}" },
+              "expr": "{source=\"mariadb-slow\", pod=~\"$pod\"} | query_time > $min_query_time",
+              "maxLines": 5000,
+              "queryType": "range",
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "extractFields",
+              "options": { "source": "labels" }
+            },
+            {
+              "id": "convertFieldType",
+              "options": {
+                "conversions": [
+                  { "destinationType": "number", "targetField": "query_time" },
+                  { "destinationType": "number", "targetField": "lock_time" },
+                  { "destinationType": "number", "targetField": "rows_examined" },
+                  { "destinationType": "number", "targetField": "rows_sent" }
+                ]
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  { "field": "query_time", "desc": true }
+                ]
+              }
+            },
+            {
+              "id": "limit",
+              "options": { "limitField": 20 }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "id": true,
+                  "tsNs": true,
+                  "labels": true,
+                  "labelTypes": true
+                },
+                "indexByName": {
+                  "Time": 0,
+                  "query_time": 1,
+                  "rows_examined": 2,
+                  "rows_sent": 3,
+                  "lock_time": 4,
+                  "user": 5,
+                  "db": 6,
+                  "Line": 7
+                },
+                "renameByName": {}
+              }
+            }
+          ],
+          "title": "Top 20 slowest individual queries",
+          "type": "table"
+        },
+        {
+          "datasource": { "type": "loki", "uid": "${loki_ds}" },
           "description": "Individual slow queries with bind values. Each entry is one slow log event (multi-line) with structured_metadata fields shown as badges.",
-          "gridPos": { "h": 16, "w": 24, "x": 0, "y": 25 },
+          "gridPos": { "h": 16, "w": 24, "x": 0, "y": 37 },
           "id": 10,
           "options": {
             "dedupStrategy": "none",


### PR DESCRIPTION
## Summary
- 生ログ panel の上に query_time 降順 **Top 20 table** を追加し、犯人クエリの特定をスクロールから一覧スキャンに変える
- `query_time` / `rows_examined` は閾値ベースで cell background を gradient color (緑/黄/橙/赤) で着色
- `structured_metadata` を列展開するため `extractFields(source: labels)` transformation を使用（Grafana 9 以降の公式推奨 migration path）
- extractFields は indexed label も含めて全部抽出してしまうため、filterFieldsByName の include names で `Time / query_time / rows_examined / rows_sent / lock_time / user / Line` のみ通す allow-list 方式
- Loki API の `direction=backward` (default) による truncation 対策として `maxLines: 20000` (~3日 range まで全量カバー)

## Panel layout changes
- Row id=101: `Raw slow queries` → `Top offenders & raw log` に改称
- 新規 panel id=11 (table, h=12): Top 20 slowest queries
- 既存 panel id=10 (logs) の y=25 → y=37 へ shift

## Why not 既存 log panel で十分?
生ログ panel は 1 行 = 1 event の raw text 表示で、query_time / rows_examined / user が badge として埋もれる。
時間範囲に 100+ 件のスロークエリが積まれると視認でスキャンしきれず、「どのクエリが一番重かった」に即答できない。
table 化すると:
- 降順ソート済みで最悪 query が top に固定
- 閾値色付けで重さが視覚的に区別 (1s / 5s、10k / 100k / 1M rows)
- column filter で user 絞り込みも UI から可能 (\`filterable: true\`)

## Test plan
- [ ] ArgoCD sync 後 Grafana で MariaDB Slow Query Log (Loki) を開き、"Top offenders & raw log" row に table panel が表示されること
- [ ] Top 20 table の row が query_time 降順で並んでいること
- [ ] query_time >= 1s の cell が orange、>= 5s の cell が red で着色されていること
- [ ] rows_examined >= 100k の cell が orange、>= 1M の cell が red で着色されていること
- [ ] \$pod / \$min_query_time 変数変更時に table も追従すること
- [ ] 既存の logs panel (id=10) が table の下に表示され、挙動変化なしであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)