### PR TITLE
fix: slow log Top 20 table を regex-on-Line 抽出に変更 (No data 復旧)

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard-slow-log-loki.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard-slow-log-loki.yaml
@@ -326,14 +326,10 @@ data:
           "transformations": [
             {
               "id": "extractFields",
-              "options": { "source": "labels" }
-            },
-            {
-              "id": "filterFieldsByName",
               "options": {
-                "include": {
-                  "names": ["Time", "query_time", "rows_examined", "rows_sent", "lock_time", "user", "Line"]
-                }
+                "source": "Line",
+                "format": "regexp",
+                "regExp": "/User@Host:\\s+(?<user>[^\\[]+)\\[.*?Query_time:\\s+(?<query_time>[\\d.]+)\\s+Lock_time:\\s+(?<lock_time>[\\d.]+)\\s+Rows_sent:\\s+(?<rows_sent>\\d+)\\s+Rows_examined:\\s+(?<rows_examined>\\d+)/s"
               }
             },
             {
@@ -363,7 +359,12 @@ data:
             {
               "id": "organize",
               "options": {
-                "excludeByName": {},
+                "excludeByName": {
+                  "labels": true,
+                  "tsNs": true,
+                  "labelTypes": true,
+                  "id": true
+                },
                 "indexByName": {
                   "Time": 0,
                   "query_time": 1,


### PR DESCRIPTION
## 現象
`Top 20 slowest individual queries` パネルが **No data** を表示
- URL: https://grafana.onp-k8s.admin.seichi.click/d/mariadb-slow-log-loki

## 調査で確認できたこと
- Loki クエリ自体は正常に return(MCP / Grafana `/api/ds/query` 両方で 5 件以上)
- Grafana data frame の `labels` field には structured_metadata も merge されている(`responseUtils.ts:54-80` + 実データ直接確認)
- `extractFields(source: "labels")` の挙動を local simulation で再現すると、`query_time` / `rows_examined` / `user` 等が field として抽出される
- `filterFieldsByName` / `convertFieldType` / `sortBy` は unit test 通っている
- **理論上は現行 transformations で動作するはず**なのに本番は空

## なぜ切り替えるか
provisioned dashboard は API 経由で一時編集できない(`"Cannot save provisioned dashboard"`)ので、遠隔での bisect が困難。理論上動くはずのアプローチを深追いするより、**Alloy server-side pipeline と同じ regex を Grafana 側でも使う**方式に倒すほうが確実性が高い。

## 変更内容
- `extractFields(source: "labels")` → `extractFields(source: "Line", format: "regexp", regExp: <Alloy と同じ pattern>)`
- regex: `/User@Host:\s+(?<user>[^\[]+)\[.*?Query_time:\s+(?<query_time>[\d.]+)\s+Lock_time:\s+(?<lock_time>[\d.]+)\s+Rows_sent:\s+(?<rows_sent>\d+)\s+Rows_examined:\s+(?<rows_examined>\d+)/s`
- Node.js で regex 動作検証済み: `{user: "mcserver", query_time: "0.109185", lock_time: "0.000041", rows_sent: "55199", rows_examined: "110398"}`
- `filterFieldsByName` 廃止、`organize.excludeByName` で `labels / tsNs / labelTypes / id` を非表示に統合

## 副次効果
- labels merge の挙動に依存しなくなり Grafana バージョン差に強くなる
- Alloy 側の regex と同じなので、将来 slow log format 変更時は両方一緒に更新すれば良い

## Test plan
- [ ] sync 後 `Top 20 slowest individual queries` panel に row が降順で表示される
- [ ] `query_time` / `rows_examined` の cell background が閾値通り着色される
- [ ] 旧 logs panel (id=10) は影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)