### PR TITLE
fix: slow log Top 20 table の maxLines を 5000 に戻す (No data 復旧)

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard-slow-log-loki.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard-slow-log-loki.yaml
@@ -227,7 +227,7 @@ data:
         },
         {
           "datasource": { "type": "loki", "uid": "${loki_ds}" },
-          "description": "時間範囲内の個別スロークエリを query_time 降順で上位20件表示。犯人特定用のスキャン可能な table ビュー。Loki API の direction=backward (default) で新しい順に最大 20000 行取得後 client-side sort するため、極端に長い時間範囲 (7d 以上など) では古い時間帯の slow query が母集団から漏れる可能性あり。通常の運用レンジ (1h〜24h) では全量カバー可能。",
+          "description": "時間範囲内の個別スロークエリを query_time 降順で上位20件表示。犯人特定用のスキャン可能な table ビュー。Loki 側 max_entries_limit_per_query のデフォルト 5000 に合わせて maxLines=5000 としており、direction=backward (default) のため約 17h (5000/290 entries/h) を超える時間範囲では古い側の slow query が母集団から漏れる。問題調査時は time range を短く (1h〜数時間) 絞るのが推奨。",
           "fieldConfig": {
             "defaults": {
               "custom": {
@@ -318,7 +318,7 @@ data:
             {
               "datasource": { "type": "loki", "uid": "${loki_ds}" },
               "expr": "{source=\"mariadb-slow\", pod=~\"$pod\"} | query_time > $min_query_time",
-              "maxLines": 20000,
+              "maxLines": 5000,
               "queryType": "range",
               "refId": "A"
             }

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard-slow-log-loki.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard-slow-log-loki.yaml
@@ -227,7 +227,7 @@ data:
         },
         {
           "datasource": { "type": "loki", "uid": "${loki_ds}" },
-          "description": "時間範囲内の個別スロークエリを query_time 降順で上位20件表示。犯人特定用のスキャン可能な table ビュー。Loki 側 max_entries_limit_per_query のデフォルト 5000 に合わせて maxLines=5000 としており、direction=backward (default) のため約 17h (5000/290 entries/h) を超える時間範囲では古い側の slow query が母集団から漏れる。問題調査時は time range を短く (1h〜数時間) 絞るのが推奨。",
+          "description": "時間範囲内の個別スロークエリを query_time 降順で上位20件表示。犯人特定用のスキャン可能な table ビュー。Loki 側 max_entries_limit_per_query (default 5000) に合わせて maxLines=5000。対象期間の slow query が 5000 件を超えると direction=backward のため新しい側 5000 件のみが母集団となり、古い slow query が top-20 から漏れる。件数ベースの制限なので burst 時は短時間でも到達しうる (平常時 ~290 entries/h で目安 17h)。漏れたら time range を短くするか、$min_query_time を上げて母集団を絞るのが推奨。",
           "fieldConfig": {
             "defaults": {
               "custom": {


### PR DESCRIPTION
## 背景

PR #4910 でも Top 20 table は **No data** のまま。真の原因はパネル側のエラーメッセージを見れば一目瞭然だった:

> max entries limit per query exceeded, limit > max_entries_limit_per_query (20000 > 5000)

`maxLines: 20000` が Loki 側 `max_entries_limit_per_query` (default 5000) を超過していたため、クエリ自体がサーバ側で rejected されていた。

## 経緯の反省

エラーを最初に確認せず、transformation に原因があると推測して PR #4910 で labels-ベース抽出 → regex-on-Line 抽出に切り替えたが、あれは早計な判断だった。regex 方式自体は動作するので維持するが、transformation の切り替えは本件とは無関係。

## 変更内容
- panel target `maxLines: 20000 → 5000` (Loki default に合わせる)
- description を実態に合わせて更新: default 5000 / 直近 newest 5000 行 / ~17h(5000÷290 entries/h) でカバー

## 将来の運用
長時間範囲 (例: 7d) で top-N を正確に見たい場合は Loki config の `limits_config.max_entries_limit_per_query` を引き上げる必要あり。現状は優先度低いので別 PR で検討。

## Test plan
- [ ] ArgoCD sync 後 Top 20 table にデータが表示される
- [ ] query_time / rows_examined 閾値 color (緑→黄→橙→赤) が機能
- [ ] 既存 logs panel は不変

🤖 Generated with [Claude Code](https://claude.com/claude-code)