### PR TITLE
feat: slow log Top 20 table に query 列を追加し Line は非表示に

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard-slow-log-loki.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard-slow-log-loki.yaml
@@ -300,7 +300,7 @@ data:
                 ]
               },
               {
-                "matcher": { "id": "byName", "options": "Line" },
+                "matcher": { "id": "byName", "options": "query" },
                 "properties": [
                   { "id": "custom.cellOptions", "value": { "type": "auto", "wrapText": true } }
                 ]
@@ -329,7 +329,7 @@ data:
               "options": {
                 "source": "Line",
                 "format": "regexp",
-                "regExp": "/User@Host:\\s+(?<user>[^\\[]+)\\[.*?Query_time:\\s+(?<query_time>[\\d.]+)\\s+Lock_time:\\s+(?<lock_time>[\\d.]+)\\s+Rows_sent:\\s+(?<rows_sent>\\d+)\\s+Rows_examined:\\s+(?<rows_examined>\\d+)/s"
+                "regExp": "/User@Host:\\s+(?<user>[^\\[]+)\\[.*?Query_time:\\s+(?<query_time>[\\d.]+)\\s+Lock_time:\\s+(?<lock_time>[\\d.]+)\\s+Rows_sent:\\s+(?<rows_sent>\\d+)\\s+Rows_examined:\\s+(?<rows_examined>\\d+).*?SET timestamp=\\d+;\\s*(?<query>.*)/s"
               }
             },
             {
@@ -363,7 +363,8 @@ data:
                   "labels": true,
                   "tsNs": true,
                   "labelTypes": true,
-                  "id": true
+                  "id": true,
+                  "Line": true
                 },
                 "indexByName": {
                   "Time": 0,
@@ -372,7 +373,7 @@ data:
                   "rows_sent": 3,
                   "lock_time": 4,
                   "user": 5,
-                  "Line": 6
+                  "query": 6
                 },
                 "renameByName": {}
               }

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard-slow-log-loki.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard-slow-log-loki.yaml
@@ -302,7 +302,7 @@ data:
               {
                 "matcher": { "id": "byName", "options": "query" },
                 "properties": [
-                  { "id": "custom.cellOptions", "value": { "type": "auto", "wrapText": true } }
+                  { "id": "custom.cellOptions", "value": { "type": "auto", "wrapText": false, "cellValueInspect": true } }
                 ]
               }
             ]


### PR DESCRIPTION
## 背景
現状 Top 20 table の最終列 (Line) に slow log の生テキストがそのまま表示されている:

```
# User@Host: mcserver[mcserver] @  [10.96.132.192]
# Thread_id: 69903  Schema: seichiassist  QC_hit: No
# Query_time: 1.090836  Lock_time: 0.000018  Rows_sent: 0  Rows_examined: 0
# Rows_affected: 2  Bytes_sent: 11
use `seichiassist`;
SET timestamp=1776490818;
INSERT INTO mine_stack ... ON DUPLICATE KEY UPDATE amount = VALUES(amount);
```

header 情報は他の列 (user / query_time / rows_*) に既に展開済みなので、末尾の Line 列には SQL 本体だけあれば十分。

## 変更内容
- `extractFields` の regex に `SET timestamp=<n>;\\s*(?<query>.*)` を追加して SQL 本体を `query` named group として切り出し
- `organize.excludeByName.Line = true` で Line 列を非表示
- `organize.indexByName` の末尾を `Line → query` に変更
- fieldConfig override の Line → query にリネーム (wrapText はそのまま)

## 事前検証
Node.js で 2 パターン (`use <db>;` あり/なし) を試し、どちらも query だけが正しく抽出されることを確認済み。

## Test plan
- [ ] sync 後 Top 20 table の最終列が SQL のみになる
- [ ] `use <db>;` なしのケース (mariadb-metrics など) でも query 列が空にならない
- [ ] query_time / rows_examined の色付けは維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)