### PR TITLE
feat: slow log Top 20 table に db 列を追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard-slow-log-loki.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/grafana-dashboard-slow-log-loki.yaml
@@ -294,6 +294,12 @@ data:
                 ]
               },
               {
+                "matcher": { "id": "byName", "options": "db" },
+                "properties": [
+                  { "id": "custom.width", "value": 160 }
+                ]
+              },
+              {
                 "matcher": { "id": "byName", "options": "Time" },
                 "properties": [
                   { "id": "custom.width", "value": 170 }
@@ -329,7 +335,7 @@ data:
               "options": {
                 "source": "Line",
                 "format": "regexp",
-                "regExp": "/User@Host:\\s+(?<user>[^\\[]+)\\[.*?Query_time:\\s+(?<query_time>[\\d.]+)\\s+Lock_time:\\s+(?<lock_time>[\\d.]+)\\s+Rows_sent:\\s+(?<rows_sent>\\d+)\\s+Rows_examined:\\s+(?<rows_examined>\\d+).*?SET timestamp=\\d+;\\s*(?<query>.*)/s"
+                "regExp": "/User@Host:\\s+(?<user>[^\\[]+)\\[.*?Schema:\\s(?<db>\\S*)\\s+QC_hit.*?Query_time:\\s+(?<query_time>[\\d.]+)\\s+Lock_time:\\s+(?<lock_time>[\\d.]+)\\s+Rows_sent:\\s+(?<rows_sent>\\d+)\\s+Rows_examined:\\s+(?<rows_examined>\\d+).*?SET timestamp=\\d+;\\s*(?<query>.*)/s"
               }
             },
             {
@@ -373,7 +379,8 @@ data:
                   "rows_sent": 3,
                   "lock_time": 4,
                   "user": 5,
-                  "query": 6
+                  "db": 6,
+                  "query": 7
                 },
                 "renameByName": {}
               }


### PR DESCRIPTION
## 変更内容
Top 20 slowest individual queries table に `db` 列を追加。

- `extractFields` の regex に `Schema:\s(?<db>\S*)\s+QC_hit` を挿入
- `organize.indexByName` の `user` (5) と `query` の間に `db` (6) を入れ、`query` は 7 に繰り下げ
- fieldConfig override で `db` 列の幅を 160px に設定

## 空 schema の扱い
mariadb-metrics など `Schema:` が空 (`Schema:   QC_hit:` のように 3 スペース) のケースは空文字列として表示される。Node.js で以下 3 パターン検証済み:
- `Schema: seichiassist` → `db: "seichiassist"`
- `Schema:` (空) → `db: ""`
- `Schema: coreprotect__mc_s2` → `db: "coreprotect__mc_s2"`

## Test plan
- [ ] sync 後 Top 20 table に db 列が user の右に表示される
- [ ] seichiassist / coreprotect__mc_s2 等が正しく表示される
- [ ] 空 schema (mariadb-metrics) のセルが空で表示され regex 全体が壊れない

🤖 Generated with [Claude Code](https://claude.com/claude-code)