### PR TITLE
feat:
  メンテモードを各サーバごとに設定できるように

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -86,30 +86,39 @@ spec:
 
 ### 概要
 
-メンテナンスモードを有効化すると、全Minecraftサーバーが自動的にKubernetesのServiceエンドポイントから除外され、新規接続を受け付けなくなります。Pod自体は起動したままのため、管理者はサーバーにアクセスしてメンテナンス作業を継続できます。
+メンテナンスモードを有効化すると、対象のMinecraftサーバーが自動的にKubernetesのServiceエンドポイントから除外され、新規接続を受け付けなくなります。Pod自体は起動したままのため、管理者はサーバーにアクセスしてメンテナンス作業を継続できます。
 
 ### 仕組み
 
-- 各MinecraftサーバーのreadinessProbeが、5秒ごとに `maintenance-mode` ConfigMapの `enabled` フィールドを確認
-- `enabled: "true"` の場合、readinessProbeが失敗し続ける
+- 各MinecraftサーバーのreadinessProbeが、5秒ごとに `maintenance-mode` ConfigMapを確認
+- `enabled: "true"`（全サーバー共通）または `enabled--{suffix}: "true"`（サーバー個別）の場合、readinessProbeが失敗し続ける
 - `failureThreshold: 18` × `periodSeconds: 5` = 90秒後にServiceエンドポイントから除外され、トラフィックが遮断される
 - Pod再起動は不要で、ConfigMap変更後5秒以内に反映開始
 - GitOpsによる管理のため、変更履歴が全てGitに記録される
 
 ### メンテナンスモードの有効化
 
-[maintenance-mode/configmap.yaml](./seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/maintenance-mode/configmap.yaml) を編集し、`enabled` を `"true"` に変更してコミット＆プッシュします。
+[maintenance-mode/configmap.yaml](./seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/maintenance-mode/configmap.yaml) を編集してコミット＆プッシュします。ArgoCDが自動的に変更を検知し、数分以内に反映されます。
+
+**全サーバーを対象にする場合:**
 
 ```yaml
 data:
-  enabled: "true"  # falseをtrueに変更
+  enabled: "true"
 ```
 
-ArgoCDが自動的に変更を検知し、数分以内に反映されます。反映後、5秒以内に全サーバーのreadinessProbeが失敗し始め、90秒後に全トラフィックが遮断されます。
+**特定サーバーのみを対象にする場合（例: s1のみ）:**
+
+```yaml
+data:
+  enabled--s1: "true"
+```
+
+対応するsuffix: `s1` / `s2` / `s3` / `s5` / `s7` / `lobby` / `votelistener` / `kagawa` / `one-day-to-reset`
 
 ### メンテナンスモードの無効化
 
-同じファイルで `enabled: "false"` に戻してコミット＆プッシュするだけです。ArgoCDが反映後、5秒以内にreadinessProbeが成功し始め、即座にServiceエンドポイントに復帰します。
+同じファイルで変更したキーを `"false"` に戻してコミット＆プッシュするだけです。ArgoCDが反映後、5秒以内にreadinessProbeが成功し始め、即座にServiceエンドポイントに復帰します。
 
 ### 注意事項
 

--- a/docs/runbooks/maintenance-mode.md
+++ b/docs/runbooks/maintenance-mode.md
@@ -3,36 +3,44 @@
 ## 概要
 
 整地鯖のMinecraftサーバー群のメンテナンスモード操作手順。
-トラフィックを遮断しつつ、Pod自体は起動したままにできる。
+全サーバー一括、または特定サーバーのみを対象に、トラフィックを遮断しつつPod自体は起動したままにできる。
 
 ## 仕組み
 
-- 各MinecraftサーバーのreadinessProbeが`maintenance-mode` ConfigMapを確認
-- `enabled: "true"`の場合、readinessProbeが失敗
-- 90秒後にServiceエンドポイントから除外される
+- 各MinecraftサーバーのreadinessProbeが、5秒ごとに`maintenance-mode` ConfigMapを確認
+- `enabled: "true"`（全サーバー共通）または`enabled--{suffix}: "true"`（サーバー個別）の場合、readinessProbeが失敗し続ける
+- `failureThreshold: 18` × `periodSeconds: 5` = 90秒後にServiceエンドポイントから除外され、トラフィックが遮断される
 - Pod再起動不要、ConfigMap変更後5秒以内に反映開始
+- GitOpsによる管理のため、変更履歴が全てGitに記録される
 
 ## 手順
 
-### メンテナンスモードの有効化
+### 全サーバーのメンテナンスモードを有効化
 
-1. `seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/maintenance-mode/configmap.yaml`を編集
-
-2. `enabled`を`"true"`に変更
+1. `seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/maintenance-mode/configmap.yaml`を編集し、`enabled`を`"true"`に変更:
    ```yaml
    data:
      enabled: "true"
    ```
+2. コミット＆プッシュ
+3. ArgoCDが自動反映（数分以内）。反映後、5秒以内に全サーバーのreadinessProbeが失敗し始め、90秒後に全トラフィックが遮断される
 
-3. コミット＆プッシュ
+### 特定サーバーのみメンテナンスモードを有効化
 
-4. ArgoCDが自動反映（数分以内）
+1. 同ファイルを編集し、対象サーバーの`enabled--{suffix}`を`"true"`に変更（例: s1のみ）:
+   ```yaml
+   data:
+     enabled--s1: "true"
+   ```
+   対応するsuffix: `s1` / `s2` / `s3` / `s5` / `s7` / `lobby` / `votelistener` / `kagawa` / `one-day-to-reset`
+2. コミット＆プッシュ
+3. ArgoCDが自動反映（数分以内）。反映後、対象サーバーのみreadinessProbeが失敗し始め、90秒後にトラフィックが遮断される
 
 ### メンテナンスモードの無効化
 
-1. 同ファイルで`enabled: "false"`に変更
-
+1. 同ファイルで変更したキーを`"false"`に戻す
 2. コミット＆プッシュ
+3. ArgoCDが反映後、5秒以内にreadinessProbeが成功し始め、即座にServiceエンドポイントに復帰する
 
 ## 注意事項
 

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/maintenance-mode/configmap.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/maintenance-mode/configmap.yaml
@@ -8,4 +8,15 @@ data:
   # この値を "true" に変更すると、全Minecraftサーバーが即座にReadinessProbeで失敗し、
   # Serviceのエンドポイントから除外される（トラフィック遮断）。
   # Pod自体は起動したままなので、メンテナンス作業は継続可能。
+  # グローバル: "true" で全サーバに影響
   enabled: "false"
+  # 各サーバ個別: "true" で当該サーバのみに影響
+  enabled--s1: "false"
+  enabled--s2: "false"
+  enabled--s3: "false"
+  enabled--s5: "false"
+  enabled--s7: "false"
+  enabled--lobby: "false"
+  enabled--votelistener: "false"
+  enabled--kagawa: "false"
+  enabled--one-day-to-reset: "false"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/argo-workflows-backup-all-databases.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/argo-workflows-backup-all-databases.yaml
@@ -55,8 +55,8 @@ spec:
         command: [sh]
         source: |
           set -e
-          MAINTENANCE_ENABLED=$(kubectl get configmap maintenance-mode -n seichi-minecraft -o jsonpath='{.data.enabled}' 2>/dev/null || echo "false")
-          if [ "$MAINTENANCE_ENABLED" = "true" ]; then
+          ALL_SERVERS_MAINTENANCE_ENABLED=$(kubectl get configmap maintenance-mode -n seichi-minecraft -o jsonpath='{.data.enabled}' 2>/dev/null || echo "false")
+          if [ "$ALL_SERVERS_MAINTENANCE_ENABLED" = "true" ]; then
             echo "メンテナンスモードが有効です。バックアップワークフローをスキップします。"
             exit 1
           fi

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--kagawa/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--kagawa/stateful-set.yaml
@@ -120,7 +120,8 @@ spec:
                 - -c
                 - |
                   # メンテナンスモードチェック（ConfigMapをボリュームマウントで読み取り）
-                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null; then
+                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null || \
+                     grep -q "^true$" /maintenance-mode/enabled--kagawa 2>/dev/null; then
                     echo "Maintenance mode is enabled"
                     exit 1
                   fi

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/argo-workflows-backup.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/argo-workflows-backup.yaml
@@ -51,7 +51,7 @@ spec:
         source: |
           set -e
           ALL_SERVERS_MAINTENANCE_ENABLED=$(kubectl get configmap maintenance-mode -n seichi-minecraft -o jsonpath='{.data.enabled}' 2>/dev/null || echo "false")
-          PER_SERVER_MAINTENANCE_ENABLED=$(kubectl get configmap maintenance-mode -n seichi-minecraft -o jsonpath='{.data.enabled--lobby}' 2>/dev/null || echo "false")
+          PER_SERVER_MAINTENANCE_ENABLED=$(kubectl get configmap maintenance-mode -n seichi-minecraft -o jsonpath="{.data['enabled--lobby']}" 2>/dev/null || echo "false")
           if [ "$ALL_SERVERS_MAINTENANCE_ENABLED" = "true" ] || [ "$PER_SERVER_MAINTENANCE_ENABLED" = "true" ]; then
             echo "メンテナンスモードが有効です。バックアップワークフローをスキップします。"
             exit 1

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/argo-workflows-backup.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/argo-workflows-backup.yaml
@@ -50,8 +50,9 @@ spec:
         command: ["/bin/sh", "-c"]
         source: |
           set -e
-          MAINTENANCE_ENABLED=$(kubectl get configmap maintenance-mode -n seichi-minecraft -o jsonpath='{.data.enabled}' 2>/dev/null || echo "false")
-          if [ "$MAINTENANCE_ENABLED" = "true" ]; then
+          ALL_SERVERS_MAINTENANCE_ENABLED=$(kubectl get configmap maintenance-mode -n seichi-minecraft -o jsonpath='{.data.enabled}' 2>/dev/null || echo "false")
+          PER_SERVER_MAINTENANCE_ENABLED=$(kubectl get configmap maintenance-mode -n seichi-minecraft -o jsonpath='{.data.enabled--lobby}' 2>/dev/null || echo "false")
+          if [ "$ALL_SERVERS_MAINTENANCE_ENABLED" = "true" ] || [ "$PER_SERVER_MAINTENANCE_ENABLED" = "true" ]; then
             echo "メンテナンスモードが有効です。バックアップワークフローをスキップします。"
             exit 1
           fi

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/stateful-set.yaml
@@ -219,7 +219,8 @@ spec:
                 - -c
                 - |
                   # メンテナンスモードチェック（ConfigMapをボリュームマウントで読み取り）
-                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null; then
+                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null || \
+                     grep -q "^true$" /maintenance-mode/enabled--lobby 2>/dev/null; then
                     echo "Maintenance mode is enabled"
                     exit 1
                   fi

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--one-day-to-reset/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--one-day-to-reset/stateful-set.yaml
@@ -141,7 +141,8 @@ spec:
                 - -c
                 - |
                   # メンテナンスモードチェック（ConfigMapをボリュームマウントで読み取り）
-                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null; then
+                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null || \
+                     grep -q "^true$" /maintenance-mode/enabled--one-day-to-reset 2>/dev/null; then
                     echo "Maintenance mode is enabled"
                     exit 1
                   fi

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
@@ -303,7 +303,8 @@ spec:
                 - -c
                 - |
                   # メンテナンスモードチェック（ConfigMapをボリュームマウントで読み取り）
-                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null; then
+                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null || \
+                     grep -q "^true$" /maintenance-mode/enabled--s1 2>/dev/null; then
                     echo "Maintenance mode is enabled"
                     exit 1
                   fi

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/stateful-set.yaml
@@ -303,7 +303,8 @@ spec:
                 - -c
                 - |
                   # メンテナンスモードチェック（ConfigMapをボリュームマウントで読み取り）
-                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null; then
+                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null || \
+                     grep -q "^true$" /maintenance-mode/enabled--s2 2>/dev/null; then
                     echo "Maintenance mode is enabled"
                     exit 1
                   fi

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/stateful-set.yaml
@@ -303,7 +303,8 @@ spec:
                 - -c
                 - |
                   # メンテナンスモードチェック（ConfigMapをボリュームマウントで読み取り）
-                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null; then
+                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null || \
+                     grep -q "^true$" /maintenance-mode/enabled--s3 2>/dev/null; then
                     echo "Maintenance mode is enabled"
                     exit 1
                   fi

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
@@ -285,7 +285,8 @@ spec:
                 - -c
                 - |
                   # メンテナンスモードチェック（ConfigMapをボリュームマウントで読み取り）
-                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null; then
+                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null || \
+                     grep -q "^true$" /maintenance-mode/enabled--s5 2>/dev/null; then
                     echo "Maintenance mode is enabled"
                     exit 1
                   fi

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/stateful-set.yaml
@@ -279,7 +279,8 @@ spec:
                 - -c
                 - |
                   # メンテナンスモードチェック（ConfigMapをボリュームマウントで読み取り）
-                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null; then
+                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null || \
+                     grep -q "^true$" /maintenance-mode/enabled--s7 2>/dev/null; then
                     echo "Maintenance mode is enabled"
                     exit 1
                   fi

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--votelistener/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--votelistener/stateful-set.yaml
@@ -233,7 +233,8 @@ spec:
                 - -c
                 - |
                   # メンテナンスモードチェック（ConfigMapをボリュームマウントで読み取り）
-                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null; then
+                  if grep -q "^true$" /maintenance-mode/enabled 2>/dev/null || \
+                     grep -q "^true$" /maintenance-mode/enabled--votelistener 2>/dev/null; then
                     echo "Maintenance mode is enabled"
                     exit 1
                   fi

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/workflow-template.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/workflow-template.yaml
@@ -98,7 +98,7 @@ spec:
           STATEFULSET_NAME="{{inputs.parameters.statefulset-name}}"
           SUFFIX="${STATEFULSET_NAME#mcserver--}"
           ALL_SERVERS_MAINTENANCE_ENABLED=$(kubectl get configmap maintenance-mode -n seichi-minecraft -o jsonpath='{.data.enabled}' 2>/dev/null || echo "false")
-          PER_SERVER_MAINTENANCE_ENABLED=$(kubectl get configmap maintenance-mode -n seichi-minecraft -o jsonpath="{.data.enabled--${SUFFIX}}" 2>/dev/null || echo "false")
+          PER_SERVER_MAINTENANCE_ENABLED=$(kubectl get configmap maintenance-mode -n seichi-minecraft -o jsonpath="{.data['enabled--${SUFFIX}']}" 2>/dev/null || echo "false")
           if [ "$ALL_SERVERS_MAINTENANCE_ENABLED" = "true" ] || [ "$PER_SERVER_MAINTENANCE_ENABLED" = "true" ]; then
             echo "メンテナンスモードが有効です。バックアップワークフローをスキップします。"
             exit 1

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/workflow-template.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/workflow-template.yaml
@@ -28,6 +28,10 @@ spec:
         tasks:
           - name: check-maintenance-mode
             template: check-maintenance-mode
+            arguments:
+              parameters:
+                - name: statefulset-name
+                  value: "{{inputs.parameters.statefulset-name}}"
 
           - name: get-timestamp
             template: get-timestamp
@@ -83,13 +87,19 @@ spec:
               - delete-coreprotect-db
 
     - name: check-maintenance-mode
+      inputs:
+        parameters:
+          - name: statefulset-name
       script:
         image: alpine/kubectl:1.35.4
         command: ["/bin/sh", "-c"]
         source: |
           set -e
-          MAINTENANCE_ENABLED=$(kubectl get configmap maintenance-mode -n seichi-minecraft -o jsonpath='{.data.enabled}' 2>/dev/null || echo "false")
-          if [ "$MAINTENANCE_ENABLED" = "true" ]; then
+          STATEFULSET_NAME="{{inputs.parameters.statefulset-name}}"
+          SUFFIX="${STATEFULSET_NAME#mcserver--}"
+          ALL_SERVERS_MAINTENANCE_ENABLED=$(kubectl get configmap maintenance-mode -n seichi-minecraft -o jsonpath='{.data.enabled}' 2>/dev/null || echo "false")
+          PER_SERVER_MAINTENANCE_ENABLED=$(kubectl get configmap maintenance-mode -n seichi-minecraft -o jsonpath="{.data.enabled--${SUFFIX}}" 2>/dev/null || echo "false")
+          if [ "$ALL_SERVERS_MAINTENANCE_ENABLED" = "true" ] || [ "$PER_SERVER_MAINTENANCE_ENABLED" = "true" ]; then
             echo "メンテナンスモードが有効です。バックアップワークフローをスキップします。"
             exit 1
           fi


### PR DESCRIPTION
  ## Summary
  - 各Minecraftサーバごとにメンテモードを個別に設定できるように変更
  - ConfigMapにメンテモード設定を追加
  - DEPLOYMENT.md・runbookドキュメントを更新

  ## Test plan
  - [ ] 各サーバのStatefulSetがConfigMapを正しく参照していることを確認
  - [ ] メンテモードの有効化・無効化が個別サーバに反映されることを確認

  🤖 Generated with [Claude Code](https://claude.com/claude-code)