### PR TITLE
fix(garage-backup-to-pbs): dump 用ボリュームを永続 PVC 化し容量を 400Gi に拡張

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/argo-workflows-backup.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/argo-workflows-backup.yaml
@@ -144,15 +144,9 @@ spec:
                 - name: title
                   value: "garage バックアップ失敗"
 
-  volumeClaimTemplates:
-    - metadata:
-        name: dump-volume
-      spec:
-        accessModes: ["ReadWriteOnce"]
-        storageClassName: topolvm-provisioner
-        resources:
-          requests:
-            storage: 200Gi
   volumes:
+    - name: dump-volume
+      persistentVolumeClaim:
+        claimName: garage-backup-dump
     - name: pbs-tmpfs
       emptyDir: {}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/argo-workflows-backup.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/argo-workflows-backup.yaml
@@ -66,6 +66,25 @@ spec:
           BUCKETS=$(aws $S3_OPTS s3 ls | awk '{print $3}')
           echo "Found buckets: $BUCKETS"
 
+          # 永続 PVC 上で Garage から削除済みバケットのディレクトリが残ると
+          # 不要なデータを PBS に送り続けることになるため、sync 前に掃除する
+          echo "=== Pruning orphaned bucket directories ==="
+          for dir in "$DUMP_DIR"/*/; do
+            [ -d "$dir" ] || continue
+            existing=$(basename "$dir")
+            found=0
+            for b in $BUCKETS; do
+              if [ "$b" = "$existing" ]; then
+                found=1
+                break
+              fi
+            done
+            if [ "$found" = 0 ]; then
+              echo "Removing orphaned directory: $dir"
+              rm -rf "$dir"
+            fi
+          done
+
           for bucket in $BUCKETS; do
             echo "--- Syncing bucket: $bucket ---"
             mkdir -p "$DUMP_DIR/$bucket"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/argo-workflows-restore.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/argo-workflows-restore.yaml
@@ -126,7 +126,7 @@ spec:
         storageClassName: topolvm-provisioner
         resources:
           requests:
-            storage: 200Gi
+            storage: 400Gi
   volumes:
     - name: pbs-tmpfs
       emptyDir: {}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/kustomization.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./pvc.yaml
   - ./argo-workflows-backup.yaml
   - ./argo-workflows-restore.yaml
   - ./workflow-sa.yaml

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/pvc.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: garage-backup-dump
+  namespace: garage
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: topolvm-provisioner
+  resources:
+    requests:
+      storage: 400Gi


### PR DESCRIPTION
## Summary
- `backup--garage-to-pbs` WorkflowTemplate の dump 用 PVC を、毎実行時に作成していた 200Gi の一時 PVC (`volumeClaimTemplates`) から、永続 PVC `garage-backup-dump` (400Gi, topolvm-provisioner, RWO, namespace: garage) に変更。
- これにより `aws s3 sync` が差分転送として機能するようになり、(a) バケット合計 ~264 GiB で容量不足により失敗していた問題を解消、(b) 毎日 ~264 GiB の書き込みが差分のみ (数〜数十 GiB 想定) に減り NVMe SSD 寿命への負担を大幅軽減。
- `restore--garage-from-pbs` は稀実行で使い捨ての方が合理的なため本 PR では変更せず。

## Context
- 直近の定時実行 `backup--garage-to-pbs-1776474000` が `[Errno 28] No space left on device` で失敗 (thanos bucket dump 途中)。原因: バケット合計 ~264 GiB > PVC 200 GiB。
- バケット内訳: loki 93.9 / thanos 86.5 / mariadb-backups 54.0 / mc-worlds 29.5 / その他 < 1 GiB。
- 本設計は毎日フル DL しているため、SN8100 2TB (1200 TBW) で WAF 2x 仮定だと寿命 4〜5 年と試算。差分 sync に切り替えることで寿命試算が大幅に伸びる見込み。

## Test plan
- [x] `kustomize build seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs` が exit 0 で生成物を出力することを確認済み。
- [ ] マージ後 ArgoCD の `cluster-wide-apps-garage-backup-to-pbs` Application で新 PVC `garage-backup-dump` が Synced / Healthy になること。
- [ ] 次回定時実行 (10:00 JST) の Workflow が `dump-volume` を claimName 参照でマウントし、正常完了すること。1 回目は実質フル DL 相当になるが、2 回目以降は差分動作になることを `kubectl logs` の `Completed X/Y` で確認。
- [ ] wk ノードの `topolvm-vg` (/dev/sdb, 1 TiB) 空き容量が想定どおり減ること (<= 400 GiB 消費)。