### PR TITLE
fix(garage-backup-to-pbs): activeDeadlineSeconds を 4h → 8h に拡張

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/argo-workflows-backup.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/argo-workflows-backup.yaml
@@ -23,7 +23,7 @@ spec:
   serviceAccountName: garage-workflow-sa
   ttlStrategy:
     secondsAfterCompletion: 86400
-  activeDeadlineSeconds: 14400
+  activeDeadlineSeconds: 28800
   onExit: notify-on-failure
   entrypoint: default
   templates:


### PR DESCRIPTION
## Summary
- `backup--garage-to-pbs` WorkflowTemplate の `activeDeadlineSeconds` を `14400` (4h) から `28800` (8h) に拡張。
- 永続 PVC 化後 (#4922) の初回フル sync が 4h で完了せず SIGTERM される事象が発生しており、頭を打たないよう余裕を持たせる。

## Context
- #4922 で dump 用ボリュームを永続 PVC 化し、差分 sync による SSD 寿命最適化を実現した。
- マージ後最初の定時実行 `backup--garage-to-pbs-1776646800` (2026-04-20 10:00 JST) は、PVC が空の状態からのフル DL となり 4h の deadline 内で完走できなかった:
  - 4h で 271 GiB / 272 GiB を DL、loki バケット残 ~1 GiB で SIGTERM
  - 実効スループット ~19 MiB/s (10 Gbps LAN 想定より低め、garage 側 or S3 API 経由のオーバーヘッドと思われる)
- 定常運用 (差分 sync) では 4h で十分だが、
  - 将来 garage データ量が大きく増えた場合
  - PVC を作り直して再度フル sync 相当になる場合
  の headroom として 8h を確保する。
- `ttlStrategy.secondsAfterCompletion: 86400` は変更せず。完了した Workflow 本体の保持期間 (24h) には影響しない。

## Test plan
- [x] `kustomize build seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs` が exit 0 で成功することを確認済み。
- [ ] マージ後、次回 10:00 JST の定時実行で deadline 警告が出ず完走することを確認。
- [ ] 将来の loki 成長等で 4h を超えてもタイムアウトせず PBS backup まで到達することを、初回以降のログで確認。