### PR TITLE
Migrate Terraform Kubernetes resources to v1

### DIFF
--- a/terraform/kubernetes_v1_resource_imports.tf
+++ b/terraform/kubernetes_v1_resource_imports.tf
@@ -1,0 +1,672 @@
+removed {
+  from = kubernetes_namespace.onp_seichi_debug_gateway
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_namespace_v1.onp_seichi_debug_gateway
+  id = "seichi-debug-gateway"
+}
+removed {
+  from = kubernetes_namespace.onp_seichi_debug_minecraft
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_namespace_v1.onp_seichi_debug_minecraft
+  id = "seichi-debug-minecraft"
+}
+removed {
+  from = kubernetes_namespace.onp_seichi_gateway
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_namespace_v1.onp_seichi_gateway
+  id = "seichi-gateway"
+}
+removed {
+  from = kubernetes_namespace.onp_seichi_minecraft
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_namespace_v1.onp_seichi_minecraft
+  id = "seichi-minecraft"
+}
+removed {
+  from = kubernetes_namespace.onp_argocd
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_namespace_v1.onp_argocd
+  id = "argocd"
+}
+removed {
+  from = kubernetes_namespace.onp_argo
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_namespace_v1.onp_argo
+  id = "argo"
+}
+removed {
+  from = kubernetes_namespace.onp_monitoring
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_namespace_v1.onp_monitoring
+  id = "monitoring"
+}
+removed {
+  from = kubernetes_namespace.onp_synology_csi
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_namespace_v1.onp_synology_csi
+  id = "synology-csi"
+}
+removed {
+  from = kubernetes_namespace.onp_democratic_csi
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_namespace_v1.onp_democratic_csi
+  id = "democratic-csi"
+}
+removed {
+  from = kubernetes_namespace.cloudflared_tunnel_exits
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_namespace_v1.cloudflared_tunnel_exits
+  id = "cloudflared-tunnel-exits"
+}
+removed {
+  from = kubernetes_namespace.garage
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_namespace_v1.garage
+  id = "garage"
+}
+removed {
+  from = kubernetes_namespace.garage_admin
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_namespace_v1.garage_admin
+  id = "garage-admin"
+}
+removed {
+  from = kubernetes_namespace.kyverno
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_namespace_v1.kyverno
+  id = "kyverno"
+}
+removed {
+  from = kubernetes_namespace.kubechecks
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_namespace_v1.kubechecks
+  id = "kubechecks"
+}
+removed {
+  from = kubernetes_secret.onp_argocd_github_oauth_app_secret
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.onp_argocd_github_oauth_app_secret
+  id = "argocd/argocd-github-oauth-app-secret"
+}
+removed {
+  from = kubernetes_secret.onp_argocd_applicationset_controller_github_app_secret
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.onp_argocd_applicationset_controller_github_app_secret
+  id = "argocd/argocd-applicationset-controller-github-app-secret"
+}
+removed {
+  from = kubernetes_secret.onp_argocd_workflows_sso
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.onp_argocd_workflows_sso
+  id = "argocd/argo-workflows-sso"
+}
+removed {
+  from = kubernetes_secret.onp_argo_workflows_sso
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.onp_argo_workflows_sso
+  id = "argo/argo-workflows-sso"
+}
+removed {
+  from = kubernetes_secret.onp_grafana_github_oauth_app_secret
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.onp_grafana_github_oauth_app_secret
+  id = "monitoring/grafana-github-oauth-app-secret"
+}
+removed {
+  from = kubernetes_secret.onp_synology_csi
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.onp_synology_csi
+  id = "synology-csi/client-info-secret"
+}
+removed {
+  from = kubernetes_secret.onp_democratic_csi_sc_truenas_03
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.onp_democratic_csi_sc_truenas_03
+  id = "democratic-csi/democratic-csi-driver-config-sc-truenas-03"
+}
+removed {
+  from = kubernetes_secret.cloudflared_tunnel_credential
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.cloudflared_tunnel_credential
+  id = "cloudflared-tunnel-exits/cloudflared-tunnel-credential"
+}
+removed {
+  from = kubernetes_secret.garage_loki_credentials
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.garage_loki_credentials
+  id = "monitoring/garage-loki-credentials"
+}
+removed {
+  from = kubernetes_secret.garage_thanos_credentials
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.garage_thanos_credentials
+  id = "monitoring/garage-thanos-credentials"
+}
+removed {
+  from = kubernetes_secret.garage_seichi_minecraft_credentials
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.garage_seichi_minecraft_credentials
+  id = "seichi-minecraft/garage-s3-credentials"
+}
+removed {
+  from = kubernetes_secret.garage_backup_s3_credentials
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.garage_backup_s3_credentials
+  id = "garage/garage-backup-s3-credentials"
+}
+removed {
+  from = kubernetes_secret.garage_backup_failure_notify_webhook
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.garage_backup_failure_notify_webhook
+  id = "garage/backup-failure-notify-webhook"
+}
+removed {
+  from = kubernetes_secret.garage_admin_api_token
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.garage_admin_api_token
+  id = "garage/garage-admin-api-token"
+}
+removed {
+  from = kubernetes_secret.garage_admin_github_oauth
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.garage_admin_github_oauth
+  id = "garage-admin/garage-admin-github-oauth"
+}
+removed {
+  from = kubernetes_secret.garage_admin_token
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.garage_admin_token
+  id = "garage-admin/garage-admin-token"
+}
+removed {
+  from = kubernetes_secret.garage_admin_s3
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.garage_admin_s3
+  id = "garage-admin/garage-admin-s3"
+}
+removed {
+  from = kubernetes_secret.truenas_exporter_api_key
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.truenas_exporter_api_key
+  id = "monitoring/truenas-exporter-api-key"
+}
+removed {
+  from = kubernetes_secret.onp_kubechecks_github_app_secret
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.onp_kubechecks_github_app_secret
+  id = "kubechecks/kubechecks-github-app-secret"
+}
+removed {
+  from = kubernetes_secret.mariadb_monitoring_password
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.mariadb_monitoring_password
+  id = "seichi-minecraft/mariadb-monitoring-password"
+}
+removed {
+  from = kubernetes_secret.mariadb_pr_review_password
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.mariadb_pr_review_password
+  id = "kube-system/mariadb-pr-review-password"
+}
+removed {
+  from = kubernetes_secret.idea_reaction_discord_token
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.idea_reaction_discord_token
+  id = "seichi-minecraft/idea-reaction-discord-token"
+}
+removed {
+  from = kubernetes_secret.idea_reaction_redmine_api_key
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.idea_reaction_redmine_api_key
+  id = "seichi-minecraft/idea-reaction-redmine-api-key"
+}
+removed {
+  from = kubernetes_secret.babyrite_discord_token
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.babyrite_discord_token
+  id = "seichi-minecraft/babyrite-discord-token"
+}
+removed {
+  from = kubernetes_secret.onp_minecraft_debug_secrets
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.onp_minecraft_debug_secrets
+  id = "seichi-debug-minecraft/mcserver--common--config-secrets"
+}
+removed {
+  from = kubernetes_secret.onp_minecraft_debug_seichiassist_webhook_secrets
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.onp_minecraft_debug_seichiassist_webhook_secrets
+  id = "seichi-debug-minecraft/mcserver--seichiassist-webhook--config-secrets"
+}
+removed {
+  from = kubernetes_secret.onp_minecraft_prod_secrets
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.onp_minecraft_prod_secrets
+  id = "seichi-minecraft/mcserver--common--config-secrets"
+}
+removed {
+  from = kubernetes_secret.onp_minecraft_prod_lobby_secrets
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.onp_minecraft_prod_lobby_secrets
+  id = "seichi-minecraft/mcserver--lobby--config-secrets"
+}
+removed {
+  from = kubernetes_secret.onp_minecraft_prod_seichiassist_webhook_secrets
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.onp_minecraft_prod_seichiassist_webhook_secrets
+  id = "seichi-minecraft/mcserver--seichiassist-webhook--config-secrets"
+}
+removed {
+  from = kubernetes_secret.onp_minecraft_prod_one_day_to_reset_secrets
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.onp_minecraft_prod_one_day_to_reset_secrets
+  id = "seichi-minecraft/mcserver--one-day-to-reset--config-secrets"
+}
+removed {
+  from = kubernetes_secret.onp_minecraft_prod_kagawa_secrets
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.onp_minecraft_prod_kagawa_secrets
+  id = "seichi-minecraft/mcserver--kagawa--config-secrets"
+}
+removed {
+  from = kubernetes_secret.argo_events_github_access_token
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.argo_events_github_access_token
+  id = "seichi-minecraft/argo-events-github-access-token"
+}
+removed {
+  from = kubernetes_secret.seichiassist_downloader_develop_release_notify_webhook
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.seichiassist_downloader_develop_release_notify_webhook
+  id = "seichi-minecraft/seichiassist-downloader-develop-release-notify-webhook"
+}
+removed {
+  from = kubernetes_secret.seichiassist_downloader_master_release_notify_webhook
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.seichiassist_downloader_master_release_notify_webhook
+  id = "seichi-minecraft/seichiassist-downloader-master-release-notify-webhook"
+}
+removed {
+  from = kubernetes_secret.onp_minecraft_prod_bugsink_admin_password
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.onp_minecraft_prod_bugsink_admin_password
+  id = "seichi-minecraft/bugsink-admin-password"
+}
+removed {
+  from = kubernetes_secret.onp_minecraft_prod_mariadb_root_password
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.onp_minecraft_prod_mariadb_root_password
+  id = "seichi-minecraft/mariadb"
+}
+removed {
+  from = kubernetes_secret.onp_minecraft_debug_mariadb_root_password
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.onp_minecraft_debug_mariadb_root_password
+  id = "seichi-debug-minecraft/mariadb"
+}
+removed {
+  from = kubernetes_secret.seichi_portal_meilisearch_master_key
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.seichi_portal_meilisearch_master_key
+  id = "seichi-minecraft/seichi-portal-meilisearch-master-key"
+}
+removed {
+  from = kubernetes_secret.tailscale_approval_bot_secrets
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.tailscale_approval_bot_secrets
+  id = "seichi-minecraft/tailscale-approval-bot-secrets"
+}
+removed {
+  from = kubernetes_secret.backup_failure_notify_webhook
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.backup_failure_notify_webhook
+  id = "seichi-minecraft/backup-failure-notify-webhook"
+}
+removed {
+  from = kubernetes_secret.argocd_backup_workflow_auth_token
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.argocd_backup_workflow_auth_token
+  id = "seichi-minecraft/argocd-auth-token"
+}
+removed {
+  from = kubernetes_secret.pbs_credentials
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = kubernetes_secret_v1.pbs_credentials
+  id = "seichi-minecraft/pbs-credentials"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.14.4"
+
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"

--- a/terraform/onp_cluster_minecraft_secrets.tf
+++ b/terraform/onp_cluster_minecraft_secrets.tf
@@ -1,5 +1,5 @@
-resource "kubernetes_secret" "onp_minecraft_debug_secrets" {
-  depends_on = [kubernetes_namespace.onp_seichi_debug_minecraft]
+resource "kubernetes_secret_v1" "onp_minecraft_debug_secrets" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_debug_minecraft]
 
   metadata {
     name      = "mcserver--common--config-secrets"
@@ -14,8 +14,8 @@ resource "kubernetes_secret" "onp_minecraft_debug_secrets" {
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "onp_minecraft_debug_seichiassist_webhook_secrets" {
-  depends_on = [kubernetes_namespace.onp_seichi_minecraft]
+resource "kubernetes_secret_v1" "onp_minecraft_debug_seichiassist_webhook_secrets" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 
   metadata {
     name      = "mcserver--seichiassist-webhook--config-secrets"
@@ -31,8 +31,8 @@ resource "kubernetes_secret" "onp_minecraft_debug_seichiassist_webhook_secrets" 
 }
 
 
-resource "kubernetes_secret" "onp_minecraft_prod_secrets" {
-  depends_on = [kubernetes_namespace.onp_seichi_minecraft]
+resource "kubernetes_secret_v1" "onp_minecraft_prod_secrets" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 
   metadata {
     name      = "mcserver--common--config-secrets"
@@ -48,8 +48,8 @@ resource "kubernetes_secret" "onp_minecraft_prod_secrets" {
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "onp_minecraft_prod_lobby_secrets" {
-  depends_on = [kubernetes_namespace.onp_seichi_minecraft]
+resource "kubernetes_secret_v1" "onp_minecraft_prod_lobby_secrets" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 
   metadata {
     name      = "mcserver--lobby--config-secrets"
@@ -63,8 +63,8 @@ resource "kubernetes_secret" "onp_minecraft_prod_lobby_secrets" {
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "onp_minecraft_prod_seichiassist_webhook_secrets" {
-  depends_on = [kubernetes_namespace.onp_seichi_minecraft]
+resource "kubernetes_secret_v1" "onp_minecraft_prod_seichiassist_webhook_secrets" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 
   metadata {
     name      = "mcserver--seichiassist-webhook--config-secrets"
@@ -82,8 +82,8 @@ resource "kubernetes_secret" "onp_minecraft_prod_seichiassist_webhook_secrets" {
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "onp_minecraft_prod_one_day_to_reset_secrets" {
-  depends_on = [kubernetes_namespace.onp_seichi_minecraft]
+resource "kubernetes_secret_v1" "onp_minecraft_prod_one_day_to_reset_secrets" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 
   metadata {
     name      = "mcserver--one-day-to-reset--config-secrets"
@@ -97,8 +97,8 @@ resource "kubernetes_secret" "onp_minecraft_prod_one_day_to_reset_secrets" {
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "onp_minecraft_prod_kagawa_secrets" {
-  depends_on = [kubernetes_namespace.onp_seichi_minecraft]
+resource "kubernetes_secret_v1" "onp_minecraft_prod_kagawa_secrets" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 
   metadata {
     name      = "mcserver--kagawa--config-secrets"
@@ -112,8 +112,8 @@ resource "kubernetes_secret" "onp_minecraft_prod_kagawa_secrets" {
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "argo_events_github_access_token" {
-  depends_on = [kubernetes_namespace.onp_seichi_minecraft]
+resource "kubernetes_secret_v1" "argo_events_github_access_token" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 
   metadata {
     name      = "argo-events-github-access-token"
@@ -128,8 +128,8 @@ resource "kubernetes_secret" "argo_events_github_access_token" {
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "seichiassist_downloader_develop_release_notify_webhook" {
-  depends_on = [kubernetes_namespace.onp_seichi_minecraft]
+resource "kubernetes_secret_v1" "seichiassist_downloader_develop_release_notify_webhook" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 
   metadata {
     name      = "seichiassist-downloader-develop-release-notify-webhook"
@@ -143,8 +143,8 @@ resource "kubernetes_secret" "seichiassist_downloader_develop_release_notify_web
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "seichiassist_downloader_master_release_notify_webhook" {
-  depends_on = [kubernetes_namespace.onp_seichi_minecraft]
+resource "kubernetes_secret_v1" "seichiassist_downloader_master_release_notify_webhook" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 
   metadata {
     name      = "seichiassist-downloader-master-release-notify-webhook"
@@ -158,8 +158,8 @@ resource "kubernetes_secret" "seichiassist_downloader_master_release_notify_webh
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "onp_minecraft_prod_bugsink_admin_password" {
-  depends_on = [kubernetes_namespace.onp_seichi_minecraft]
+resource "kubernetes_secret_v1" "onp_minecraft_prod_bugsink_admin_password" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 
   metadata {
     name      = "bugsink-admin-password"
@@ -203,8 +203,8 @@ resource "random_password" "minecraft__prod_mariadb_litebans_password" {
   override_special = "!#$%&*()-_=+[]{}<>:?"
 }
 
-resource "kubernetes_secret" "onp_minecraft_prod_mariadb_root_password" {
-  depends_on = [kubernetes_namespace.onp_seichi_minecraft]
+resource "kubernetes_secret_v1" "onp_minecraft_prod_mariadb_root_password" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 
   metadata {
     name      = "mariadb"
@@ -246,8 +246,8 @@ resource "random_password" "minecraft__debug_mariadb_luckperms_password" {
   override_special = "!#$%&*()-_=+[]{}<>:?"
 }
 
-resource "kubernetes_secret" "onp_minecraft_debug_mariadb_root_password" {
-  depends_on = [kubernetes_namespace.onp_seichi_debug_minecraft]
+resource "kubernetes_secret_v1" "onp_minecraft_debug_mariadb_root_password" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_debug_minecraft]
 
   metadata {
     name      = "mariadb"
@@ -265,8 +265,8 @@ resource "kubernetes_secret" "onp_minecraft_debug_mariadb_root_password" {
 }
 
 
-resource "kubernetes_secret" "seichi_portal_meilisearch_master_key" {
-  depends_on = [kubernetes_namespace.onp_seichi_minecraft]
+resource "kubernetes_secret_v1" "seichi_portal_meilisearch_master_key" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 
   metadata {
     name      = "seichi-portal-meilisearch-master-key"
@@ -280,8 +280,8 @@ resource "kubernetes_secret" "seichi_portal_meilisearch_master_key" {
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "tailscale_approval_bot_secrets" {
-  depends_on = [kubernetes_namespace.onp_seichi_minecraft]
+resource "kubernetes_secret_v1" "tailscale_approval_bot_secrets" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 
   metadata {
     name      = "tailscale-approval-bot-secrets"
@@ -299,8 +299,8 @@ resource "kubernetes_secret" "tailscale_approval_bot_secrets" {
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "backup_failure_notify_webhook" {
-  depends_on = [kubernetes_namespace.onp_seichi_minecraft]
+resource "kubernetes_secret_v1" "backup_failure_notify_webhook" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 
   metadata {
     name      = "backup-failure-notify-webhook"
@@ -314,8 +314,8 @@ resource "kubernetes_secret" "backup_failure_notify_webhook" {
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "argocd_backup_workflow_auth_token" {
-  depends_on = [kubernetes_namespace.onp_seichi_minecraft]
+resource "kubernetes_secret_v1" "argocd_backup_workflow_auth_token" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 
   metadata {
     name      = "argocd-auth-token"
@@ -330,8 +330,8 @@ resource "kubernetes_secret" "argocd_backup_workflow_auth_token" {
 }
 
 # pbs-credentials: seichi-minecraft に配置し、seichi-debug-minecraft と garage に複製
-resource "kubernetes_secret" "pbs_credentials" {
-  depends_on = [kubernetes_namespace.onp_seichi_minecraft]
+resource "kubernetes_secret_v1" "pbs_credentials" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 
   metadata {
     name      = "pbs-credentials"

--- a/terraform/onp_cluster_namespaces.tf
+++ b/terraform/onp_cluster_namespaces.tf
@@ -1,16 +1,16 @@
-resource "kubernetes_namespace" "onp_seichi_debug_gateway" {
+resource "kubernetes_namespace_v1" "onp_seichi_debug_gateway" {
   metadata {
     name = "seichi-debug-gateway"
   }
 }
 
-resource "kubernetes_namespace" "onp_seichi_debug_minecraft" {
+resource "kubernetes_namespace_v1" "onp_seichi_debug_minecraft" {
   metadata {
     name = "seichi-debug-minecraft"
   }
 }
 
-resource "kubernetes_namespace" "onp_seichi_gateway" {
+resource "kubernetes_namespace_v1" "onp_seichi_gateway" {
   metadata {
     name = "seichi-gateway"
     labels = {
@@ -19,7 +19,7 @@ resource "kubernetes_namespace" "onp_seichi_gateway" {
   }
 }
 
-resource "kubernetes_namespace" "onp_seichi_minecraft" {
+resource "kubernetes_namespace_v1" "onp_seichi_minecraft" {
   metadata {
     name = "seichi-minecraft"
     labels = {
@@ -28,19 +28,19 @@ resource "kubernetes_namespace" "onp_seichi_minecraft" {
   }
 }
 
-resource "kubernetes_namespace" "onp_argocd" {
+resource "kubernetes_namespace_v1" "onp_argocd" {
   metadata {
     name = "argocd"
   }
 }
 
-resource "kubernetes_namespace" "onp_argo" {
+resource "kubernetes_namespace_v1" "onp_argo" {
   metadata {
     name = "argo"
   }
 }
 
-resource "kubernetes_namespace" "onp_monitoring" {
+resource "kubernetes_namespace_v1" "onp_monitoring" {
   metadata {
     name = "monitoring"
     labels = {
@@ -49,43 +49,43 @@ resource "kubernetes_namespace" "onp_monitoring" {
   }
 }
 
-resource "kubernetes_namespace" "onp_synology_csi" {
+resource "kubernetes_namespace_v1" "onp_synology_csi" {
   metadata {
     name = "synology-csi"
   }
 }
 
-resource "kubernetes_namespace" "onp_democratic_csi" {
+resource "kubernetes_namespace_v1" "onp_democratic_csi" {
   metadata {
     name = "democratic-csi"
   }
 }
 
-resource "kubernetes_namespace" "cloudflared_tunnel_exits" {
+resource "kubernetes_namespace_v1" "cloudflared_tunnel_exits" {
   metadata {
     name = "cloudflared-tunnel-exits"
   }
 }
 
-resource "kubernetes_namespace" "garage" {
+resource "kubernetes_namespace_v1" "garage" {
   metadata {
     name = "garage"
   }
 }
 
-resource "kubernetes_namespace" "garage_admin" {
+resource "kubernetes_namespace_v1" "garage_admin" {
   metadata {
     name = "garage-admin"
   }
 }
 
-resource "kubernetes_namespace" "kyverno" {
+resource "kubernetes_namespace_v1" "kyverno" {
   metadata {
     name = "kyverno"
   }
 }
 
-resource "kubernetes_namespace" "kubechecks" {
+resource "kubernetes_namespace_v1" "kubechecks" {
   metadata {
     name = "kubechecks"
   }

--- a/terraform/onp_cluster_secrets.tf
+++ b/terraform/onp_cluster_secrets.tf
@@ -10,8 +10,8 @@ resource "helm_release" "kubernetes_replicator" {
   cleanup_on_fail = true
 }
 
-resource "kubernetes_secret" "onp_argocd_github_oauth_app_secret" {
-  depends_on = [kubernetes_namespace.onp_argocd]
+resource "kubernetes_secret_v1" "onp_argocd_github_oauth_app_secret" {
+  depends_on = [kubernetes_namespace_v1.onp_argocd]
 
   metadata {
     name      = "argocd-github-oauth-app-secret"
@@ -30,8 +30,8 @@ resource "kubernetes_secret" "onp_argocd_github_oauth_app_secret" {
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "onp_argocd_applicationset_controller_github_app_secret" {
-  depends_on = [kubernetes_namespace.onp_argocd]
+resource "kubernetes_secret_v1" "onp_argocd_applicationset_controller_github_app_secret" {
+  depends_on = [kubernetes_namespace_v1.onp_argocd]
 
   metadata {
     name      = "argocd-applicationset-controller-github-app-secret"
@@ -54,8 +54,8 @@ resource "kubernetes_secret" "onp_argocd_applicationset_controller_github_app_se
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "onp_argocd_workflows_sso" {
-  depends_on = [kubernetes_namespace.onp_argocd]
+resource "kubernetes_secret_v1" "onp_argocd_workflows_sso" {
+  depends_on = [kubernetes_namespace_v1.onp_argocd]
 
   metadata {
     name      = "argo-workflows-sso"
@@ -70,8 +70,8 @@ resource "kubernetes_secret" "onp_argocd_workflows_sso" {
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "onp_argo_workflows_sso" {
-  depends_on = [kubernetes_namespace.onp_argo]
+resource "kubernetes_secret_v1" "onp_argo_workflows_sso" {
+  depends_on = [kubernetes_namespace_v1.onp_argo]
 
   metadata {
     name      = "argo-workflows-sso"
@@ -86,8 +86,8 @@ resource "kubernetes_secret" "onp_argo_workflows_sso" {
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "onp_grafana_github_oauth_app_secret" {
-  depends_on = [kubernetes_namespace.onp_monitoring]
+resource "kubernetes_secret_v1" "onp_grafana_github_oauth_app_secret" {
+  depends_on = [kubernetes_namespace_v1.onp_monitoring]
 
   metadata {
     name      = "grafana-github-oauth-app-secret"
@@ -102,8 +102,8 @@ resource "kubernetes_secret" "onp_grafana_github_oauth_app_secret" {
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "onp_synology_csi" {
-  depends_on = [kubernetes_namespace.onp_synology_csi]
+resource "kubernetes_secret_v1" "onp_synology_csi" {
+  depends_on = [kubernetes_namespace_v1.onp_synology_csi]
 
   metadata {
     name      = "client-info-secret"
@@ -117,8 +117,8 @@ resource "kubernetes_secret" "onp_synology_csi" {
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "onp_democratic_csi_sc_truenas_03" {
-  depends_on = [kubernetes_namespace.onp_democratic_csi]
+resource "kubernetes_secret_v1" "onp_democratic_csi_sc_truenas_03" {
+  depends_on = [kubernetes_namespace_v1.onp_democratic_csi]
 
   metadata {
     name      = "democratic-csi-driver-config-sc-truenas-03"
@@ -134,8 +134,8 @@ resource "kubernetes_secret" "onp_democratic_csi_sc_truenas_03" {
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "cloudflared_tunnel_credential" {
-  depends_on = [kubernetes_namespace.cloudflared_tunnel_exits]
+resource "kubernetes_secret_v1" "cloudflared_tunnel_credential" {
+  depends_on = [kubernetes_namespace_v1.cloudflared_tunnel_exits]
 
   metadata {
     name      = "cloudflared-tunnel-credential"
@@ -153,8 +153,8 @@ resource "kubernetes_secret" "cloudflared_tunnel_credential" {
 }
 
 # Garage S3-compatible object storage credentials
-resource "kubernetes_secret" "garage_loki_credentials" {
-  depends_on = [kubernetes_namespace.onp_monitoring]
+resource "kubernetes_secret_v1" "garage_loki_credentials" {
+  depends_on = [kubernetes_namespace_v1.onp_monitoring]
 
   metadata {
     name      = "garage-loki-credentials"
@@ -169,8 +169,8 @@ resource "kubernetes_secret" "garage_loki_credentials" {
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "garage_thanos_credentials" {
-  depends_on = [kubernetes_namespace.onp_monitoring]
+resource "kubernetes_secret_v1" "garage_thanos_credentials" {
+  depends_on = [kubernetes_namespace_v1.onp_monitoring]
 
   metadata {
     name      = "garage-thanos-credentials"
@@ -198,8 +198,8 @@ resource "kubernetes_secret" "garage_thanos_credentials" {
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "garage_seichi_minecraft_credentials" {
-  depends_on = [kubernetes_namespace.onp_seichi_minecraft]
+resource "kubernetes_secret_v1" "garage_seichi_minecraft_credentials" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 
   metadata {
     name      = "garage-s3-credentials"
@@ -217,8 +217,8 @@ resource "kubernetes_secret" "garage_seichi_minecraft_credentials" {
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "garage_backup_s3_credentials" {
-  depends_on = [kubernetes_namespace.garage]
+resource "kubernetes_secret_v1" "garage_backup_s3_credentials" {
+  depends_on = [kubernetes_namespace_v1.garage]
 
   metadata {
     name      = "garage-backup-s3-credentials"
@@ -233,8 +233,8 @@ resource "kubernetes_secret" "garage_backup_s3_credentials" {
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "garage_backup_failure_notify_webhook" {
-  depends_on = [kubernetes_namespace.garage]
+resource "kubernetes_secret_v1" "garage_backup_failure_notify_webhook" {
+  depends_on = [kubernetes_namespace_v1.garage]
 
   metadata {
     name      = "backup-failure-notify-webhook"
@@ -249,8 +249,8 @@ resource "kubernetes_secret" "garage_backup_failure_notify_webhook" {
 }
 
 # Garage Admin API token (shared between Garage daemon and Admin Console)
-resource "kubernetes_secret" "garage_admin_api_token" {
-  depends_on = [kubernetes_namespace.garage]
+resource "kubernetes_secret_v1" "garage_admin_api_token" {
+  depends_on = [kubernetes_namespace_v1.garage]
 
   metadata {
     name      = "garage-admin-api-token"
@@ -265,8 +265,8 @@ resource "kubernetes_secret" "garage_admin_api_token" {
 }
 
 # Garage Admin Console secrets
-resource "kubernetes_secret" "garage_admin_github_oauth" {
-  depends_on = [kubernetes_namespace.garage_admin]
+resource "kubernetes_secret_v1" "garage_admin_github_oauth" {
+  depends_on = [kubernetes_namespace_v1.garage_admin]
 
   metadata {
     name      = "garage-admin-github-oauth"
@@ -282,8 +282,8 @@ resource "kubernetes_secret" "garage_admin_github_oauth" {
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "garage_admin_token" {
-  depends_on = [kubernetes_namespace.garage_admin]
+resource "kubernetes_secret_v1" "garage_admin_token" {
+  depends_on = [kubernetes_namespace_v1.garage_admin]
 
   metadata {
     name      = "garage-admin-token"
@@ -297,8 +297,8 @@ resource "kubernetes_secret" "garage_admin_token" {
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "garage_admin_s3" {
-  depends_on = [kubernetes_namespace.garage_admin]
+resource "kubernetes_secret_v1" "garage_admin_s3" {
+  depends_on = [kubernetes_namespace_v1.garage_admin]
 
   metadata {
     name      = "garage-admin-s3"
@@ -314,8 +314,8 @@ resource "kubernetes_secret" "garage_admin_s3" {
 }
 
 # TrueNAS Exporter API key
-resource "kubernetes_secret" "truenas_exporter_api_key" {
-  depends_on = [kubernetes_namespace.onp_monitoring]
+resource "kubernetes_secret_v1" "truenas_exporter_api_key" {
+  depends_on = [kubernetes_namespace_v1.onp_monitoring]
 
   metadata {
     name      = "truenas-exporter-api-key"
@@ -329,8 +329,8 @@ resource "kubernetes_secret" "truenas_exporter_api_key" {
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "onp_kubechecks_github_app_secret" {
-  depends_on = [kubernetes_namespace.kubechecks]
+resource "kubernetes_secret_v1" "onp_kubechecks_github_app_secret" {
+  depends_on = [kubernetes_namespace_v1.kubechecks]
 
   metadata {
     name      = "kubechecks-github-app-secret"
@@ -363,8 +363,8 @@ resource "random_password" "minecraft__prod_mariadb_monitoring_password" {
 }
 
 # mariadb-monitoring-password: seichi-minecraft に配置し、monitoring と PR namespaces に複製
-resource "kubernetes_secret" "mariadb_monitoring_password" {
-  depends_on = [kubernetes_namespace.onp_seichi_minecraft]
+resource "kubernetes_secret_v1" "mariadb_monitoring_password" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 
   metadata {
     name      = "mariadb-monitoring-password"
@@ -382,7 +382,7 @@ resource "kubernetes_secret" "mariadb_monitoring_password" {
 }
 
 # mariadb-pr-review-password: kube-system に配置し、PR namespaces に複製
-resource "kubernetes_secret" "mariadb_pr_review_password" {
+resource "kubernetes_secret_v1" "mariadb_pr_review_password" {
   metadata {
     name      = "mariadb-pr-review-password"
     namespace = "kube-system"
@@ -400,8 +400,8 @@ resource "kubernetes_secret" "mariadb_pr_review_password" {
   type = "Opaque"
 }
 
-resource "kubernetes_secret" "idea_reaction_discord_token" {
-  depends_on = [kubernetes_namespace.onp_seichi_minecraft]
+resource "kubernetes_secret_v1" "idea_reaction_discord_token" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 
   metadata {
     name      = "idea-reaction-discord-token"
@@ -413,8 +413,8 @@ resource "kubernetes_secret" "idea_reaction_discord_token" {
   }
 }
 
-resource "kubernetes_secret" "idea_reaction_redmine_api_key" {
-  depends_on = [kubernetes_namespace.onp_seichi_minecraft]
+resource "kubernetes_secret_v1" "idea_reaction_redmine_api_key" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 
   metadata {
     name      = "idea-reaction-redmine-api-key"
@@ -426,8 +426,8 @@ resource "kubernetes_secret" "idea_reaction_redmine_api_key" {
   }
 }
 
-resource "kubernetes_secret" "babyrite_discord_token" {
-  depends_on = [kubernetes_namespace.onp_seichi_minecraft]
+resource "kubernetes_secret_v1" "babyrite_discord_token" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 
   metadata {
     name      = "babyrite-discord-token"


### PR DESCRIPTION
## Summary
- migrate deprecated Terraform Kubernetes namespace resources to kubernetes_namespace_v1
- migrate deprecated Kubernetes Secret resources to kubernetes_secret_v1
- add moved blocks so existing Terraform state can move to the v1 resource addresses

## Verification
- terraform fmt -check
- terraform validate could not run in my local environment because provider plugins fail to start with "Failed to load plugin schemas"; the same command should be checked in CI/user environment where provider plugins load successfully