### PR TITLE
fix: expand `max-world-size` in `server.properties` of s5

### DIFF
--- a/docker-images/mcservers/production/seichi-servers/individual-images/s5/custom-minecraft-server-configs/server.properties
+++ b/docker-images/mcservers/production/seichi-servers/individual-images/s5/custom-minecraft-server-configs/server.properties
@@ -21,7 +21,8 @@ enable-command-block=true
 max-players=256
 network-compression-threshold=64
 resource-pack-sha1=
-max-world-size=10000
+# Earth整地の長辺が36864なので、それに合わせて10000から拡大
+max-world-size=20000
 server-port=25565
 debug=false
 server-ip=


### PR DESCRIPTION
バニラのワールドボーダーの設定をいくらしても、最大で直径が20,000ブロックより広がらなかった。
※DynMap上では設定されているので不思議に思う。
これは、`max-world-size`が 10,000に設定されているからだと思われる。