### PR TITLE
Migrate Pyroscope to v2 architecture with Garage S3 backend

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-pyroscope.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-pyroscope.yaml
@@ -17,11 +17,40 @@ spec:
     helm:
       values: |
         pyroscope:
+          # v2 アーキテクチャ: profile を Garage (S3 互換) に直接書き込むため
+          # ローカル PVC は不要。chart デフォルトでも false だが意図を明示する。
           persistence:
             enabled: false
-            accessModes:
-              - ReadWriteOnce
-            size: 100Gi
+
+          extraArgs:
+            # structuredConfig 内の ${VAR} を環境変数で展開させる
+            config.expand-env: "true"
+            # v1 dual mode を抜けて v2 (segment-writer + object storage) のみで動作させる
+            architecture.storage: v2
+
+          extraCustomEnvVars:
+            - name: GARAGE_S3_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: garage-pyroscope-credentials
+                  key: AWS_ACCESS_KEY_ID
+            - name: GARAGE_S3_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: garage-pyroscope-credentials
+                  key: AWS_SECRET_ACCESS_KEY
+
+          structuredConfig:
+            storage:
+              backend: s3
+              s3:
+                endpoint: garage.garage.svc.cluster.local:3900
+                bucket_name: pyroscope
+                region: seichi-cloud
+                access_key_id: ${GARAGE_S3_ACCESS_KEY_ID}
+                secret_access_key: ${GARAGE_S3_SECRET_ACCESS_KEY}
+                insecure: true
+                force_path_style: true
   syncPolicy:
     automated:
       prune: true

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -300,6 +300,18 @@ variable "garage_thanos_secret_access_key" {
   sensitive   = true
 }
 
+variable "garage_pyroscope_access_key_id" {
+  description = "Garage access key ID for Pyroscope (v2 object storage backend)"
+  type        = string
+  sensitive   = true
+}
+
+variable "garage_pyroscope_secret_access_key" {
+  description = "Garage secret access key for Pyroscope (v2 object storage backend)"
+  type        = string
+  sensitive   = true
+}
+
 variable "garage_seichi_minecraft_access_key_id" {
   description = "Garage access key ID for seichi-minecraft (plugins, backups, worlds)"
   type        = string

--- a/terraform/onp_cluster_secrets.tf
+++ b/terraform/onp_cluster_secrets.tf
@@ -198,6 +198,22 @@ resource "kubernetes_secret_v1" "garage_thanos_credentials" {
   type = "Opaque"
 }
 
+resource "kubernetes_secret_v1" "garage_pyroscope_credentials" {
+  depends_on = [kubernetes_namespace_v1.onp_monitoring]
+
+  metadata {
+    name      = "garage-pyroscope-credentials"
+    namespace = "monitoring"
+  }
+
+  data = {
+    "AWS_ACCESS_KEY_ID"     = var.garage_pyroscope_access_key_id
+    "AWS_SECRET_ACCESS_KEY" = var.garage_pyroscope_secret_access_key
+  }
+
+  type = "Opaque"
+}
+
 resource "kubernetes_secret_v1" "garage_seichi_minecraft_credentials" {
   depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 


### PR DESCRIPTION
## Summary

- Pyroscope 2.0 の v2 アーキテクチャ (segment-writer + object storage) へ実態として移行する変更。chart 2.0.1 へのバンプ ([#4933](https://github.com/GiganticMinecraft/seichi_infra/pull/4933)) は完了済みだが、values が最小構成のまま `architecture.storage=v1-v2-dual`・filesystem backend で動作しており、Pod 再起動で profile データが消失する状態。
- Garage S3 を backend に設定し、不要な PVC 設定を削除し、\`-architecture.storage=v2\` を明示して v1 パスを停止する。
- 認証情報は Loki と同じパターン: \`garage-pyroscope-credentials\` Secret を Terraform で発行 → chart の \`extraCustomEnvVars\` で注入 → \`structuredConfig\` 内を \`\${VAR}\` で展開 (\`-config.expand-env=true\`)。

## Changes

- \`grafana-pyroscope.yaml\`: \`structuredConfig.storage\` で Garage S3 を指定、\`extraArgs\` で \`config.expand-env\` と \`architecture.storage=v2\` を設定、PVC 設定の dead code を削除
- \`terraform/main.tf\`: \`garage_pyroscope_access_key_id\` / \`garage_pyroscope_secret_access_key\` variable を追加
- \`terraform/onp_cluster_secrets.tf\`: \`monitoring/garage-pyroscope-credentials\` Secret リソースを追加 (Loki/Thanos と同じディレクトリ)

## マージ前に必要な手動作業

1. **Garage 側で bucket と access key を発行**
   - bucket: \`pyroscope\` (region: \`seichi-cloud\`)
   - access key: 上記 bucket への R/W 権限を付与
2. **GitHub Actions Secrets に登録** (snake_case→大文字化のルールに従う)
   - \`TF_VAR_GARAGE_PYROSCOPE_ACCESS_KEY_ID\`
   - \`TF_VAR_GARAGE_PYROSCOPE_SECRET_ACCESS_KEY\`
3. これらが揃った状態でマージすると \`terraform apply\` ワークフローが走り、Secret が作成され、ArgoCD が新 values で sync する想定

## Test plan

- [ ] Garage に \`pyroscope\` bucket と access key を発行
- [ ] GitHub Actions Secret に \`TF_VAR_GARAGE_PYROSCOPE_ACCESS_KEY_ID\` / \`TF_VAR_GARAGE_PYROSCOPE_SECRET_ACCESS_KEY\` を登録
- [ ] マージ後、\`terraform apply\` workflow が成功すること
- [ ] ArgoCD で pyroscope Application が Synced/Healthy になること
- [ ] Pyroscope Pod ログで S3 backend に接続できているか確認 (object-store 関連のエラーが出ていないこと)
- [ ] Garage 側で \`pyroscope\` bucket にオブジェクトが書き込まれていることを確認
- [ ] Grafana の Pyroscope datasource (Explore) で profile を引けること
- [ ] 既存の Java/eBPF/pprof profiling (k8s-monitoring 経由) が継続して push できていること

## 参考

- [Introducing Pyroscope 2.0 (Grafana blog)](https://grafana.com/blog/pyroscope-2-0-release/)
- [Pyroscope v1 → v2 migration guide](https://grafana.com/docs/pyroscope/latest/reference-pyroscope-v2-architecture/migrate-from-v1/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)