### PR TITLE
Use chart-native architecture.storage knob for Pyroscope v2

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-pyroscope.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-pyroscope.yaml
@@ -16,6 +16,15 @@ spec:
     targetRevision: 2.0.1
     helm:
       values: |
+        # chart-native の v1/v2 切替 knob。
+        # この knob を立てると chart 側が write-path=segment-writer や
+        # enable-query-backend 等の関連フラグ群を内部で組み立てる。
+        # extraArgs に -architecture.storage=v2 を直接渡すと不整合が起きる。
+        architecture:
+          storage:
+            v1: false
+            v2: true
+
         pyroscope:
           # v2 アーキテクチャ: profile を Garage (S3 互換) に直接書き込むため
           # ローカル PVC は不要。chart デフォルトでも false だが意図を明示する。
@@ -25,10 +34,6 @@ spec:
           extraArgs:
             # structuredConfig 内の ${VAR} を環境変数で展開させる
             config.expand-env: "true"
-            # v1 dual mode を抜けて v2 (segment-writer + object storage) のみで動作させる
-            # architecture.storage=v2 では write-path=segment-writer も必須 (起動時 fatal)
-            architecture.storage: v2
-            write-path: segment-writer
 
           extraCustomEnvVars:
             - name: GARAGE_S3_ACCESS_KEY_ID

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-pyroscope.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-pyroscope.yaml
@@ -26,7 +26,9 @@ spec:
             # structuredConfig 内の ${VAR} を環境変数で展開させる
             config.expand-env: "true"
             # v1 dual mode を抜けて v2 (segment-writer + object storage) のみで動作させる
+            # architecture.storage=v2 では write-path=segment-writer も必須 (起動時 fatal)
             architecture.storage: v2
+            write-path: segment-writer
 
           extraCustomEnvVars:
             - name: GARAGE_S3_ACCESS_KEY_ID


### PR DESCRIPTION
## Summary

#4983 のフォローアップ。pyroscope-0 が以下のエラーで crash-loop:

```
failed creating pyroscope: write-path=segment-writer is required for v2 storage layer
```

調査の結果、chart には `architecture.storage.v1` / `architecture.storage.v2` という独自の Helm knob があり、これを立てると chart 側が `write-path=segment-writer` や `enable-query-backend` など **v2 必須の関連フラグ群を内部で組み立てる**仕組みになっていた。#4983 では `extraArgs` に `-architecture.storage=v2` を直接渡したが、これは上記組み立てロジックを bypass するため不整合が起きる (chart の default `migration.segmentWriterWeight=1.0` 等とも矛盾)。

chart-native の knob に切り替え、`extraArgs` は `config.expand-env` のみ残す。

## Changes

- `architecture.storage.v1: false` / `architecture.storage.v2: true` をトップレベルで設定
- `extraArgs` から `architecture.storage` / `write-path` を削除

## 補足: 他に必須なものは?

- chart のデフォルトで `architecture.migration.segmentWriterWeight: 1.0` / `queryBackendFrom: "auto"` なので、書き込みも読み出しも v2 経路に倒れる
- single-binary mode では metastore-raft / segment-writer ring / compaction-worker / query-backend が自動的に enable される (公式 deployment-modes ドキュメント記載)
- object storage 設定 (`structuredConfig.storage`) は #4983 で投入済み

## Test plan

- [ ] マージ後 ArgoCD が pyroscope を sync し、pyroscope-0 が Running になる
- [ ] Pod ログに `failed creating pyroscope` が出ていないこと
- [ ] `/ring-segment-writer` が ACTIVE を返すこと
- [ ] Garage の `pyroscope` bucket にオブジェクトが書き込まれ始めること
- [ ] Grafana の Pyroscope datasource (Explore) で profile を引けること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
