### PR TITLE
Add -write-path=segment-writer for Pyroscope v2 storage

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-pyroscope.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-pyroscope.yaml
@@ -34,6 +34,11 @@ spec:
           extraArgs:
             # structuredConfig 内の ${VAR} を環境変数で展開させる
             config.expand-env: "true"
+            # architecture.storage=v2 では write-path=segment-writer も必須だが
+            # chart 2.0.1 は v2 を立てても write-path を自動セットしない (確認済)。
+            # 起動時に "write-path=segment-writer is required for v2 storage layer"
+            # で fatal するため明示する。
+            write-path: segment-writer
 
           extraCustomEnvVars:
             - name: GARAGE_S3_ACCESS_KEY_ID


### PR DESCRIPTION
## Summary

#4985 で chart-native の `architecture.storage.v2: true` に切り替えたが、StatefulSet の args を確認すると chart 2.0.1 は v2 storage を立てても **`-write-path=segment-writer` を自動でセットしない** (chart 側の漏れと思われる)。pyroscope-0 が同じ fatal で crash-loop し続けている:

```
failed creating pyroscope: write-path=segment-writer is required for v2 storage layer
```

`extraArgs` で明示的に補う。

## 確認済の事実

`architecture.storage.v2: true` 設定下で chart が組み立てた CLI args (実機 StatefulSet より):

```
-target=all
-architecture.storage=v2                                          ← chart-native で OK
-query-backend.address=dns:///_grpc._tcp.pyroscope-headless...    ← chart-native で OK
-metastore.address=...                                            ← chart-native で OK
-metastore.raft.bootstrap-peers=...                               ← chart-native で OK
-memberlist.cluster-label=monitoring-pyroscope
-memberlist.join=dns+pyroscope-memberlist...
-config.file=/etc/pyroscope/config.yaml
-config.expand-env=true                                           ← extraArgs から
```

→ `-write-path=...` だけが欠落。query-backend / metastore は `architecture.storage.v2: true` で正しく組まれているので、write-path の不足のみが残課題。

## Test plan

- [ ] マージ後 ArgoCD が pyroscope を sync し、pyroscope-0 が Running になる
- [ ] Pod ログに "failed creating pyroscope" が出ていないこと
- [ ] `/ring-segment-writer` が ACTIVE を返すこと
- [ ] Garage の `pyroscope` bucket にオブジェクトが書き込まれ始めること
- [ ] Grafana の Pyroscope datasource (Explore) で profile を引けること

🤖 Generated with [Claude Code](https://claude.com/claude-code)