### PR TITLE
Disable bundled Alloy in Pyroscope chart

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-pyroscope.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-pyroscope.yaml
@@ -25,6 +25,15 @@ spec:
             v1: false
             v2: true
 
+        # chart 同梱の Alloy (StatefulSet pyroscope-alloy) を無効化。
+        # profile 収集は k8s-monitoring chart の alloy-profiles に一本化する。
+        # 両方有効だと同じ Pod の /debug/pprof/profile を二重 scrape して
+        # "cpu profiling already in use" で片方が 500 で落ちる。
+        # k8s-monitoring 側は cpu/memory/goroutine/block/mutex/fgprof/java/ebpf
+        # を annotation ベースで網羅しており、同梱 Alloy の機能を完全にカバー済。
+        alloy:
+          enabled: false
+
         pyroscope:
           # v2 アーキテクチャ: profile を Garage (S3 互換) に直接書き込むため
           # ローカル PVC は不要。chart デフォルトでも false だが意図を明示する。


### PR DESCRIPTION
## Summary

pyroscope chart は同梱の Alloy (`StatefulSet pyroscope-alloy`、Alloy v1.12.2) を立てて annotation ベースで pprof を scrape している。一方 seichi_infra では k8s-monitoring chart の `alloy-profiles` (DaemonSet 6 nodes、Alloy v1.15.0) でも同じスクレイプをしており、**両方が同じ Pod の `/debug/pprof/profile` を取りに来て CPU profiler が衝突** (1 Pod につき 1 CPU profile しか取れないため `"cpu profiling already in use"` で片側が 500 で落ちる)。実際 #4986 マージ後の pyroscope-0 ログに繰り返し出ていた:

```
GET /debug/pprof/profile?seconds=14 → 500
"Could not enable CPU profiling: cpu profiling already in use"
```
(Alloy v1.12.2 と v1.15.0 の両方から)

## 検証

k8s-monitoring 側 (`k8s-monitoring-alloy-profiles` ConfigMap) が拾う annotation 一覧:

```
profiles.grafana.com/{cpu,memory,goroutine,block,mutex,fgprof}.{scrape,port,path,scheme,container,port_name}
profiles.grafana.com/cpu.ebpf.enabled
profiles.grafana.com/java.enabled
```

→ chart 同梱 Alloy が拾う `cpu/memory/goroutine` は完全カバー済。さらに `block/mutex/fgprof/java/cpu_ebpf` まで網羅しており、k8s-monitoring 側を残して chart 側を切るのが妥当。

## Changes

- `alloy.enabled: false` を追加
- 結果: `pyroscope-alloy` StatefulSet / ConfigMap / Service / SA / RBAC 等が ArgoCD 上から prune される

## Test plan

- [ ] マージ後 `pyroscope-alloy-0` Pod とその関連リソースが消える
- [ ] pyroscope-0 のログに `"cpu profiling already in use"` が出なくなる
- [ ] Grafana の Pyroscope datasource で profile が引き続き取れる (k8s-monitoring 経由が継続)
- [ ] `pyroscope_spy` ラベルで java/ebpf/pprof 各種が継続して見えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)