### PR TITLE
Bump Garage to v2.3.0 and drop image.tag pin

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/garage.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/garage.yaml
@@ -46,7 +46,7 @@ spec:
 
         image:
           repository: dxflrs/amd64_garage
-          tag: "v2.2.0"
+          tag: "v2.3.0"
           pullPolicy: IfNotPresent
 
         resources:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/garage.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/garage.yaml
@@ -46,7 +46,6 @@ spec:
 
         image:
           repository: dxflrs/amd64_garage
-          tag: "v2.3.0"
           pullPolicy: IfNotPresent
 
         resources:


### PR DESCRIPTION
## Summary

Garage v2.2.0 のサイレント書き込みエラー bug (PR #1360, prio/critical + kind/correctness) を取り込むため image を v2.3.0 にバンプする。同時に **image.tag の pin を撤廃** して chart の appVersion を使う形に変える。

## 真因 (silent write errors)

Garage v2.2.0 は `File::write_all()` の後に `flush()` していなかったため、flush 時にしか露出しない I/O エラー (ENOSPC、transient FS / iSCSI エラー等) を見逃して PUT 200 を返していた。v2.3.0 で 1 行追加 (`f.flush().await?`) により修正済み。

我々の症状: Pyroscope V2 segment-writer が `uploaded block (~700ms)` log を出した後、30 秒後の compaction GET が `Internal error: conflict/inconsistency between object and version state, version is deleted` で失敗する事象が継続発生。aws cli の HEAD でも 404。Loki/Thanos は同 Garage cluster で問題なし (write pattern が異なるため transient I/O エラーを踏まない)。

## 構造的な追加修正: image.tag pin の撤廃

chart の values.yaml が明示的に「`set the image tag, please prefer using the chart version and not this to avoid compatibility issues`」と推奨しているにも関わらず、これまで image.tag を `"v2.2.0"` で pin していた。結果、Renovate が PR #4891 で chart 側 `targetRevision` を v2.3.0 に上げた時、**image.tag は別 manager に拾われず v2.2.0 に取り残されたまま** となり silent write fix を取り逃した。

`image.tag` を削除して chart の appVersion (= `targetRevision` の git tag) を使う形に変更。これで chart と image の version が構造的に同期され、Renovate が `targetRevision` 1 箇所更新するだけで image も追随する。

## Test plan

- [ ] マージ後 ArgoCD が garage を sync し、StatefulSet が rolling restart で v2.3.0 image に切り替わる
- [ ] `kubectl get pod -n garage -o jsonpath='{...}'` で全 Pod が v2.3.0 を使っていること
- [ ] Pyroscope の `Key not found` / `version is deleted` エラーが収束すること
- [ ] Garage の `block_ref` 保留 / `resync queue length` が頭打ち or 減少すること
- [ ] Loki/Thanos など他テナントへの影響がないこと

## 参考

- Garage PR #1360 (backport to garage-v2): https://git.deuxfleurs.fr/Deuxfleurs/garage/pulls/1360
- Original PR #1358: https://git.deuxfleurs.fr/Deuxfleurs/garage/pulls/1358
- Issue #1355: "Garage accepts uploads when disk full, violating replication_factor guarantee"
- Fix commit: 668dfea4e2cebd44ed92abb61e72c935aff0bda6
- 過去の "chart version だけ上がった" Renovate PR: #4891

🤖 Generated with [Claude Code](https://claude.com/claude-code)