### PR TITLE
Wire OTel and Pyroscope env for game-data services

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-game-data-publisher/publisher-server/configmap.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-game-data-publisher/publisher-server/configmap.yaml
@@ -7,3 +7,16 @@ data:
   GAME_DATA_SERVER_GRPC_ENDPOINT_URL: "http://seichi-game-data-server:80"
   RUST_LOG: "debug,h2::codec::framed_read=info"
   RUST_BACKTRACE: "1"
+
+  # OpenTelemetry: traces, metrics, logs are pushed to the cluster's Alloy
+  # receiver, which fans out to Tempo / Mimir / Loki. Disabling the exporter
+  # is as simple as removing OTEL_EXPORTER_OTLP_ENDPOINT.
+  OTEL_SERVICE_NAME: "seichi-game-data-publisher"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://k8s-monitoring-alloy-receiver.monitoring.svc.cluster.local:4318"
+  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
+  OTEL_TRACES_SAMPLER: "parentbased_always_on"
+  OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=production"
+
+  # Continuous profiler push target. Unset to disable.
+  PYROSCOPE_SERVER_ADDRESS: "http://pyroscope.monitoring.svc.cluster.local:4040"
+  PYROSCOPE_APPLICATION_NAME: "seichi-game-data-publisher"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-game-data-publisher/publisher-server/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-game-data-publisher/publisher-server/deployment.yaml
@@ -19,11 +19,14 @@ spec:
     spec:
       containers:
         - resources:
+            # Bumped from 50m to 300m to absorb the OTel exporter and
+            # pprof-rs profiler overhead; the previous 50m limit caused 90%+
+            # CFS throttling even with avg CPU usage <10m.
             requests:
-              cpu: 20m
+              cpu: 50m
               memory: 512Mi
             limits:
-              cpu: 50m
+              cpu: 300m
               memory: 768Mi
 
           envFrom:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-game-data-server/configmap.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-game-data-server/configmap.yaml
@@ -3,7 +3,10 @@ kind: ConfigMap
 metadata:
   name: seichi-game-data-server-config
 data:
-  RUST_LOG: "info"
+  # `debug` is enabled to surface sqlx::query events (db.statement,
+  # rows_returned, elapsed_secs) which are emitted at Debug level and become
+  # logs attached to each gRPC span via OTLP.
+  RUST_LOG: "info,sqlx::query=debug"
   HTTP_HOST: "0.0.0.0"
   HTTP_PORT: "80"
 
@@ -13,3 +16,16 @@ data:
   DB_USER: "mcserver"
 
   # Db password will be read from mcserver--common--config-secrets secret
+
+  # OpenTelemetry: traces, metrics, logs are pushed to the cluster's Alloy
+  # receiver, which fans out to Tempo / Mimir / Loki. Disabling the exporter
+  # is as simple as removing OTEL_EXPORTER_OTLP_ENDPOINT.
+  OTEL_SERVICE_NAME: "seichi-game-data-server"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://k8s-monitoring-alloy-receiver.monitoring.svc.cluster.local:4318"
+  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
+  OTEL_TRACES_SAMPLER: "parentbased_always_on"
+  OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=production"
+
+  # Continuous profiler push target. Unset to disable.
+  PYROSCOPE_SERVER_ADDRESS: "http://pyroscope.monitoring.svc.cluster.local:4040"
+  PYROSCOPE_APPLICATION_NAME: "seichi-game-data-server"


### PR DESCRIPTION
## Summary
- `seichi-game-data-publisher-server` configmap: add `OTEL_*` (service name, OTLP endpoint pointing at `k8s-monitoring-alloy-receiver.monitoring:4318`, `http/protobuf`, `parentbased_always_on` sampler, `deployment.environment=production`) and `PYROSCOPE_*` (server `pyroscope.monitoring:4040`, application name).
- `seichi-game-data-publisher-server` deployment: bump CPU limit from 50m to 300m. The previous 50m limit was causing **93% CFS throttling at ~9m average usage** (visible in the cluster's PSI metrics), and the OTel exporter plus the in-process pprof profiler will add more burst load.
- `seichi-game-data-server-config` configmap: same `OTEL_*` / `PYROSCOPE_*` env. Loosens `RUST_LOG` to `info,sqlx::query=debug` so sqlx's per-query events (`db.statement`, `rows_returned`, `elapsed_secs`) actually fire and ride along each gRPC span as OTLP logs.

The publisher / server image tags are **not** bumped in this PR. They will land in a follow-up once the matching application PRs merge and CI publishes new images:
- GiganticMinecraft/seichi-game-data-publisher#158
- GiganticMinecraft/seichi-game-data-server#296

The application binaries gracefully no-op when these env vars are unset, so this PR can land before or after the image bump without breaking anything.

## Test plan
- [ ] `kubectl diff -f` clean (no unrelated drift)
- [ ] Once merged + image bumped: confirm pods come up healthy, CPU throttling on publisher drops, traces / metrics / logs reach the respective backends, profiles appear in Pyroscope under `seichi-game-data-publisher` and `seichi-game-data-server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)