### PR TITLE
Minecraftサーバーをメンテナンスモードに切り替え

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/maintenance-mode/configmap.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/maintenance-mode/configmap.yaml
@@ -8,4 +8,4 @@ data:
   # この値を "true" に変更すると、全Minecraftサーバーが即座にReadinessProbeで失敗し、
   # Serviceのエンドポイントから除外される（トラフィック遮断）。
   # Pod自体は起動したままなので、メンテナンス作業は継続可能。
-  enabled: "false"
+  enabled: "true"


### PR DESCRIPTION
## 概要

[runbook: maintenance-mode.md](docs/runbooks/maintenance-mode.md) に沿って、Minecraftサーバー群をメンテナンスモードに遷移させる。

`maintenance-mode` ConfigMap の `enabled` を `"false"` → `"true"` に変更。

## 影響

- 全Minecraftサーバーの readinessProbe が失敗し、約90秒後にServiceエンドポイントから除外される（トラフィック遮断）
- Pod自体は起動したまま維持され、メンテナンス作業は継続可能
- ArgoCD が数分以内に自動反映

## 解除手順

[runbook](docs/runbooks/maintenance-mode.md#メンテナンスモードの無効化) に従い、本PRをrevertするか、`enabled: "false"` に戻すPRを作成する。

## Test plan

- [ ] ArgoCD で `maintenance-mode` ConfigMap が反映されることを確認
- [ ] 各Minecraftサーバー Pod の readinessProbe が失敗することを確認（`kubectl get pods -n seichi-minecraft`）
- [ ] Service のエンドポイントから Pod が除外されることを確認（`kubectl get endpoints -n seichi-minecraft`）
- [ ] 外部からの接続が遮断されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)