### PR TITLE
Enrol game-data services in Argo Image Updater

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/seichi-game-data-publisher-image-updater.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/seichi-game-data-publisher-image-updater.yaml
@@ -1,0 +1,17 @@
+apiVersion: argocd-image-updater.argoproj.io/v1alpha1
+kind: ImageUpdater
+metadata:
+  name: seichi-game-data-publisher
+  namespace: argocd
+spec:
+  namespace: argocd
+  writeBackConfig:
+    method: argocd
+  applicationRefs:
+    - namePattern: "seichi-minecraft-seichi-game-data-publisher"
+      images:
+        - alias: publisher
+          imageName: ghcr.io/giganticminecraft/seichi-game-data-publisher
+          commonUpdateSettings:
+            updateStrategy: latest
+            allowTags: "regexp:^sha-"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/seichi-game-data-server-image-updater.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/seichi-game-data-server-image-updater.yaml
@@ -1,0 +1,17 @@
+apiVersion: argocd-image-updater.argoproj.io/v1alpha1
+kind: ImageUpdater
+metadata:
+  name: seichi-game-data-server
+  namespace: argocd
+spec:
+  namespace: argocd
+  writeBackConfig:
+    method: argocd
+  applicationRefs:
+    - namePattern: "seichi-minecraft-seichi-game-data-server"
+      images:
+        - alias: server
+          imageName: ghcr.io/giganticminecraft/seichi-game-data-server
+          commonUpdateSettings:
+            updateStrategy: latest
+            allowTags: "regexp:^sha-"


### PR DESCRIPTION
## Summary
Adds `ImageUpdater` CRs for `seichi-game-data-publisher` and `seichi-game-data-server`, matching the new-style pattern already used for `mcserver--lobby` and `garage-admin` in the same directory.

Both CI pipelines publish only `sha-<short>` and a daily `YYYYMMDD` tag (no stable `:latest` tag), so the chosen strategy is:
- `updateStrategy: latest` (i.e. newest pushed image)
- `allowTags: "regexp:^sha-"` (filter out the daily tags)
- `writeBackConfig.method: argocd` (same as every other image-updater entry in this directory; the override lives in the Application spec rather than the Git manifest)

The Application objects are generated by the `seichi-minecraft-apps` ApplicationSet, so annotations on the Application metadata would be wiped by reconciliation — the standalone `ImageUpdater` CR avoids that.

This unblocks automatic rollouts for the upcoming OTel and continuous profiling work (#4989, GiganticMinecraft/seichi-game-data-publisher#158, GiganticMinecraft/seichi-game-data-server#296). After this lands, merging the application PRs will roll out without a manual SHA bump.

## Test plan
- [x] `kubectl apply --dry-run=server` accepted both manifests
- [ ] After merge: confirm two new `ImageUpdater` resources show up in `argocd` namespace and pick up the next `sha-*` tag pushed by CI
- [ ] Confirm the deployment image SHA in-cluster updates while the Git manifest stays as the last reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)