### PR TITLE
Pin game-data deployments to :master and switch Image Updater to digest mode

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/seichi-game-data-publisher-image-updater.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/seichi-game-data-publisher-image-updater.yaml
@@ -11,7 +11,10 @@ spec:
     - namePattern: "seichi-minecraft-seichi-game-data-publisher"
       images:
         - alias: publisher
-          imageName: ghcr.io/giganticminecraft/seichi-game-data-publisher
+          # Track digest changes on the rolling :master tag (re-pushed by CI on
+          # every merge to default branch). Same shape as mcserver--lobby; works
+          # around the ApplicationSet wiping kustomize.images overrides each
+          # reconcile cycle.
+          imageName: ghcr.io/giganticminecraft/seichi-game-data-publisher:master
           commonUpdateSettings:
-            updateStrategy: latest
-            allowTags: "regexp:^sha-"
+            updateStrategy: digest

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/seichi-game-data-server-image-updater.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/seichi-game-data-server-image-updater.yaml
@@ -11,7 +11,10 @@ spec:
     - namePattern: "seichi-minecraft-seichi-game-data-server"
       images:
         - alias: server
-          imageName: ghcr.io/giganticminecraft/seichi-game-data-server
+          # Track digest changes on the rolling :master tag (re-pushed by CI on
+          # every merge to default branch). Same shape as mcserver--lobby; works
+          # around the ApplicationSet wiping kustomize.images overrides each
+          # reconcile cycle.
+          imageName: ghcr.io/giganticminecraft/seichi-game-data-server:master
           commonUpdateSettings:
-            updateStrategy: latest
-            allowTags: "regexp:^sha-"
+            updateStrategy: digest

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-game-data-publisher/publisher-server/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-game-data-publisher/publisher-server/deployment.yaml
@@ -30,7 +30,12 @@ spec:
             - configMapRef:
                 name: seichi-game-data-publisher-server
 
-          image: ghcr.io/giganticminecraft/seichi-game-data-publisher:sha-745211e
+          # Track the rolling :master tag so Argo Image Updater can swap
+          # digests in. Per-commit pinning happens by setting a sha- tag here
+          # if you ever need to roll back (and disabling Image Updater for
+          # this image temporarily).
+          image: ghcr.io/giganticminecraft/seichi-game-data-publisher:master
+          imagePullPolicy: Always
           name: seichi-game-data-publisher-server
           ports:
             - containerPort: 80

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-game-data-server/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-game-data-server/deployment.yaml
@@ -34,7 +34,12 @@ spec:
                   name: mariadb
                   key: mcserver-password
 
-          image: ghcr.io/giganticminecraft/seichi-game-data-server:sha-019129d
+          # Track the rolling :master tag so Argo Image Updater can swap
+          # digests in. Per-commit pinning happens by setting a sha- tag here
+          # if you ever need to roll back (and disabling Image Updater for
+          # this image temporarily).
+          image: ghcr.io/giganticminecraft/seichi-game-data-server:master
+          imagePullPolicy: Always
           name: seichi-game-data-server
           ports:
             - containerPort: 80

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-game-data-server/kustomization.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-game-data-server/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: seichi-minecraft
+resources:
+  - "configmap.yaml"
+  - "deployment.yaml"
+  - "service.yaml"


### PR DESCRIPTION
## Summary
Pivots the game-data services to the same digest-on-stable-tag pattern that mcserver--lobby uses, because the `latest` + `sha-` regex pattern we tried first never reaches the cluster. Why it failed: `seichi-minecraft-apps` ApplicationSet re-templates `Application.spec.source` every reconcile, erasing the `kustomize.images` overrides Image Updater writes.

Changes:
- Deployment image references switched from `:sha-<commit>` to `:master`, with `imagePullPolicy: Always` so the new digest is pulled on the next pod restart even when the rendered manifest momentarily falls back to a bare `:master` reference.
- ImageUpdater CRs now use `imageName: ...:master` and `updateStrategy: digest` (the `latest` strategy is also deprecated upstream — Image Updater logs a warning telling us to switch).
- Adds `kustomization.yaml` under `seichi-game-data-server/`. Without it, Image Updater skips the Application as "Directory type" and never even attempts an update.

## Dependencies
The `:master` tag has to exist in `ghcr.io` first, which requires:
- GiganticMinecraft/seichi-game-data-publisher#160
- GiganticMinecraft/seichi-game-data-server#297

Merge order: those two first, wait for one master-branch build of each (so `:master` becomes a valid registry reference), then this PR. Otherwise the deployments will land in `ImagePullBackOff`.

Note: this PR overlaps publisher's `deployment.yaml` with #4989 (OTel env wiring + CPU limit). Either one will need a trivial rebase depending on merge order.

## Test plan
- [x] `kubectl kustomize` renders both paths cleanly
- [x] `kubectl apply --dry-run=server` accepts both ImageUpdater CRs
- [ ] After merge: confirm pods restart on `:master`, Image Updater no longer logs the "Directory type" skip nor the override-ping-pong cycle, and a subsequent application PR triggers an automatic rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)