### PR TITLE
Drop publisher RUST_LOG to info

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-game-data-publisher/publisher-server/configmap.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-game-data-publisher/publisher-server/configmap.yaml
@@ -5,7 +5,9 @@ metadata:
 data:
   # Expect game-data-server service to be in the same namespace
   GAME_DATA_SERVER_GRPC_ENDPOINT_URL: "http://seichi-game-data-server:80"
-  RUST_LOG: "debug,h2::codec::framed_read=info"
+  # Base level info; the previous "debug" base flooded Loki with hyper_util
+  # connection-pool DEBUG events from the OTLP exporter (~2 lines/sec).
+  RUST_LOG: "info"
   RUST_BACKTRACE: "1"
 
   # OpenTelemetry: traces, metrics, logs are pushed to the cluster's Alloy


### PR DESCRIPTION
## Summary
Switches `seichi-game-data-publisher-server`'s `RUST_LOG` from `debug,h2::codec::framed_read=info` to plain `info`.

## Why
On the live cluster, sampling 2000 stdout lines from the publisher pod showed:

| count | level | target |
|------:|-------|--------|
| 1854  | DEBUG | `hyper_util::client::legacy::pool` |
|  104  | DEBUG | `h2::codec::framed_write` |
|   26  | DEBUG | `hyper_util::client::legacy::connect::http` |
|   16  | DEBUG | `tower::buffer::worker` |

100% of the DEBUG output is library-level connection-pool / HTTP/2 frame churn from the OTLP exporter, with zero application signal. The app code only emits via `tracing::info!` / `tracing::error!`, so `info` covers everything operationally meaningful and cuts Loki ingest for this service by ~99%.

The old `h2::codec::framed_read=info` directive was a partial workaround for the same problem in the pre-OTel era; it covered only one of the noisy targets and gets superseded by the global `info` floor.

The server-side configmap is already on `info,sqlx::query=debug` (#4989) so this PR only touches publisher.

## Test plan
- [ ] After deploy + restart: confirm publisher pod's per-second log line rate drops to ~0 outside of actual gRPC traffic
- [ ] `kubectl logs -l app=seichi-game-data-publisher-server` no longer shows the `pooling idle connection` flood

🤖 Generated with [Claude Code](https://claude.com/claude-code)