### PR TITLE
Minecraftサーバーのメンテナンスモードを解除

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/maintenance-mode/configmap.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/maintenance-mode/configmap.yaml
@@ -8,4 +8,4 @@ data:
   # この値を "true" に変更すると、全Minecraftサーバーが即座にReadinessProbeで失敗し、
   # Serviceのエンドポイントから除外される（トラフィック遮断）。
   # Pod自体は起動したままなので、メンテナンス作業は継続可能。
-  enabled: "true"
+  enabled: "false"


### PR DESCRIPTION
## Summary

ロールバック作業完了に伴い、`maintenance-mode` ConfigMap の \`enabled\` を \`false\` に戻してトラフィックを再開する。

## ロールバック完了内容

- mcserver world: s1, s2, s3, s5, s7（PBSバックアップ 2026-04-27 19:00 UTC 時点）
- mariadb database: flyway, seichi-portal, seichi-timed-stats-conifers, seichiassist（Garage S3 backup 2026-04-27 19:00 UTC 時点）

## Test plan

- [ ] ArgoCD で ConfigMap が反映されることを確認（sync window 注意）
- [ ] 全 mcserver の readinessProbe が成功し、Service Endpoints に Pod IP が戻ることを確認
- [ ] 外部からの接続が回復していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)