### PR TITLE
Pyroscope の自己 scrape を停止

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-pyroscope.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-pyroscope.yaml
@@ -40,6 +40,19 @@ spec:
           persistence:
             enabled: false
 
+          # Pyroscope 自身への自己 scrape を停止。
+          # chart デフォルトは pyroscope Pod に
+          # profiles.grafana.com/{cpu,memory,goroutine}.scrape="true" を付与し、
+          # 同クラスタの alloy-profiles が 15s 間隔で自分を scrape する。
+          # distributor の received_compressed_bytes_sum を type 別に集計したところ、
+          # goroutine + mutex + block (= Pyroscope 自身しか出せない種別) だけで
+          # 全受信量の 45% を占めていたため、自己 scrape を無効化する。
+          # 既存キー (port_name, service_git_ref 等) は helm の map merge で残る。
+          podAnnotations:
+            profiles.grafana.com/cpu.scrape: "false"
+            profiles.grafana.com/memory.scrape: "false"
+            profiles.grafana.com/goroutine.scrape: "false"
+
           extraArgs:
             # structuredConfig 内の ${VAR} を環境変数で展開させる
             config.expand-env: "true"


### PR DESCRIPTION
## 背景

Pyroscope distributor の \`received_compressed_bytes_sum\` を type 別に集計したところ、Pyroscope 自身しか出せない種別 (goroutine + mutex + block) だけで全受信量の **45%** を占めていた。残りの memory / process_cpu にも自己 scrape 由来分が含まれるため、実際の支配率はさらに高い。

| type | 累積バイト | 比率 | Pyroscope 自身が出せるか |
|---|---|---|---|
| goroutine | 35.4 MB | 42% | ✓ (Java/Rust は不可) |
| memory | 25.8 MB | 31% | ✓ |
| process_cpu | 19.5 MB | 23% | ✓ |
| mutex | 1.7 MB | 2% | ✓ |
| block | 0.8 MB | 1% | ✓ |

原因は Pyroscope chart のデフォルト podAnnotations:

\`\`\`
profiles.grafana.com/cpu.scrape:       "true"
profiles.grafana.com/memory.scrape:    "true"
profiles.grafana.com/goroutine.scrape: "true"
\`\`\`

これにより同クラスタの alloy-profiles が pyroscope-0 を 15 秒間隔で scrape し、その結果が再び pyroscope に push される自己ループになっていた。

## 変更

values の \`pyroscope.podAnnotations\` で 3 キーを \`"false"\` に上書き。helm の map merge により \`port_name\` / \`service_git_ref\` 等のメタ系 annotation は維持される（helm template で確認済）。

## 期待される効果

- Pyroscope 受信量: **約 50% 減**
- Pyroscope → Garage S3 への \`block_bytes_written\`: 同程度減
- worker ノードの \`node_pressure_io_waiting\`: 連動して低下（特に sdj=data-garage-* PV）

## Test plan

- [ ] ArgoCD sync 後、pyroscope-0 の Pod annotation が \`*.scrape="false"\` になっていること
- [ ] \`kubectl exec pyroscope-0 -- /bin/sh -c 'wget -qO- :4040/metrics | grep received_compressed_bytes_sum'\` で goroutine/mutex/block の \`_count\` が増加しなくなること（=自己 scrape 由来流入の停止）
- [ ] 30 分〜1 時間後、Garage の \`rate(block_bytes_written[5m])\` 合計が下がっていること
- [ ] worker の \`rate(node_pressure_io_waiting_seconds_total[5m])\` が下がっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)