### PR TITLE
fix: pin cosign signing to OCI 1.1 referrers mode and verify post-sign

### DIFF
--- a/.github/workflows/build_mcserver_base_images.yaml
+++ b/.github/workflows/build_mcserver_base_images.yaml
@@ -97,7 +97,17 @@ jobs:
       - name: Sign container image with Cosign
         if: github.ref == 'refs/heads/main'
         run: |
-          cosign sign --yes \
+          cosign sign --yes --registry-referrers-mode=oci-1-1 \
+            ${{ env.DOCKER_OUTPUT_IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+
+      # Kyverno のポリシー (verify-image-signatures.yaml) と同じ条件で検証し、
+      # 署名と検証側のモードがズレた瞬間に CI を fail させる。
+      - name: Verify signature like Kyverno does
+        if: github.ref == 'refs/heads/main'
+        run: |
+          cosign verify \
+            --certificate-identity-regexp 'https://github\.com/GiganticMinecraft/.+' \
+            --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
             ${{ env.DOCKER_OUTPUT_IMAGE_NAME }}@${{ steps.build.outputs.digest }}
 
       - name: Run Trivy vulnerability scanner

--- a/.github/workflows/build_mcserver_images.yaml
+++ b/.github/workflows/build_mcserver_images.yaml
@@ -125,7 +125,17 @@ jobs:
       - if: steps.should_build.outputs.should_build == 'true' && github.ref == 'refs/heads/main'
         name: Sign container image with Cosign
         run: |
-          cosign sign --yes \
+          cosign sign --yes --registry-referrers-mode=oci-1-1 \
+            ${{ matrix.image }}@${{ steps.build.outputs.digest }}
+
+      # Kyverno のポリシー (verify-image-signatures.yaml) と同じ条件で検証し、
+      # 署名と検証側のモードがズレた瞬間に CI を fail させる。
+      - if: steps.should_build.outputs.should_build == 'true' && github.ref == 'refs/heads/main'
+        name: Verify signature like Kyverno does
+        run: |
+          cosign verify \
+            --certificate-identity-regexp 'https://github\.com/GiganticMinecraft/.+' \
+            --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
             ${{ matrix.image }}@${{ steps.build.outputs.digest }}
 
       - if: steps.should_build.outputs.should_build == 'true' && steps.build.outputs.digest != ''

--- a/.github/workflows/mod_downloader.yaml
+++ b/.github/workflows/mod_downloader.yaml
@@ -83,7 +83,17 @@ jobs:
       - name: Sign container image with Cosign
         if: github.ref == 'refs/heads/main'
         run: |
-          cosign sign --yes \
+          cosign sign --yes --registry-referrers-mode=oci-1-1 \
+            ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
+
+      # Kyverno のポリシー (verify-image-signatures.yaml) と同じ条件で検証し、
+      # 署名と検証側のモードがズレた瞬間に CI を fail させる。
+      - name: Verify signature like Kyverno does
+        if: github.ref == 'refs/heads/main'
+        run: |
+          cosign verify \
+            --certificate-identity-regexp 'https://github\.com/GiganticMinecraft/.+' \
+            --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
             ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
 
       - name: Run Trivy vulnerability scanner

--- a/.github/workflows/truenas_exporter.yaml
+++ b/.github/workflows/truenas_exporter.yaml
@@ -85,7 +85,17 @@ jobs:
       - name: Sign container image with Cosign
         if: github.ref == 'refs/heads/main'
         run: |
-          cosign sign --yes \
+          cosign sign --yes --registry-referrers-mode=oci-1-1 \
+            ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
+
+      # Kyverno のポリシー (verify-image-signatures.yaml) と同じ条件で検証し、
+      # 署名と検証側のモードがズレた瞬間に CI を fail させる。
+      - name: Verify signature like Kyverno does
+        if: github.ref == 'refs/heads/main'
+        run: |
+          cosign verify \
+            --certificate-identity-regexp 'https://github\.com/GiganticMinecraft/.+' \
+            --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
             ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
 
       - name: Run Trivy vulnerability scanner


### PR DESCRIPTION
## 背景

`sigstore/cosign-installer` v3→v4 への renovate 更新 (commit f1a7fe4f2, 2026-04-22) で内部 cosign が 2.x→3.x にバンプされ、**署名のデフォルト保存モードが暗黙に変わった**：

| | Cosign 2.x (旧) | Cosign 3.x (新, 現在) |
|---|---|---|
| デフォルト保存先 | レガシー `sha256-<digest>.sig` タグ | OCI 1.1 Referrers API |

その結果：

- 4-22 以降にビルドされたイメージは **OCI 1.1 referrer 側にしか署名がない**（例: `seichi_minecraft_server_production_s1@sha256:1ae1a5163...`）
- Kyverno (chart 3.7.2 / app v1.17.2) のイメージ検証は **デフォルトでレガシー `.sig` タグを探しに行く** (`cosignOCI11: false` がデフォルト)
- → Kyverno が "no signatures found" の PolicyViolation を発行

`cosign verify` 自体は引けるのに Kyverno は引けない、という状況になっていた。

## 変更内容

- `cosign sign` に `--registry-referrers-mode=oci-1-1` を**明示**
  - 現在のデフォルトと同じ挙動だが、cosign-installer のさらなるバンプでデフォルトが再度揺れても影響を受けないようにする
- 署名直後に **Kyverno と同じ subject/issuer 条件で `cosign verify`** を実行する step を追加
  - Kyverno と CI で「同じ署名を引けるか」を build 時間で同期チェックできる
  - 今回のような暗黙のモード変化があっても、本番 admission ではなく PR の CI で fail する

対象ワークフロー:
- .github/workflows/mod_downloader.yaml
- .github/workflows/build_mcserver_images.yaml
- .github/workflows/build_mcserver_base_images.yaml
- .github/workflows/truenas_exporter.yaml

## このPRに含めなかったもの

意図的に分離している。本 PR は CI 側を「明示化＋整合性チェック」するに留め、検証側 (Kyverno) と既存イメージへの影響操作は別 PR で扱う：

- **Kyverno ポリシーへの `cosignOCI11: true` 追加**: 別 PR。
  デプロイ済みの全 digest が OCI 1.1 referrer 側に署名を持っているか先に確認しないと、レガシー `.sig` のみで署名された古いイメージが新たに違反になる可能性がある。
- **`mod-downloader:sha-6f4c728` のリビルド**: 当該イメージはそもそも署名ステップ追加 (2026-03-13) より前のビルドで未署名。モード問題ではないので別対応。
- **PolicyReport 違反のアラート化**: 監視レイヤの話なので別途。

## Test plan

- [ ] PR CI (mod_downloader workflow など) が新しい verify step まで含めて通ること
- [ ] 既存の cosign sign 挙動（OCI 1.1 referrer への push）が変わらないこと（フラグ明示化のみ）
- [ ] マージ後、本番ブランチでビルドされた次のイメージが新しい verify step を通過すること