### PR TITLE
Raise Tempo OTLP gRPC receive message size limit

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-tempo.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-tempo.yaml
@@ -27,6 +27,14 @@ spec:
                   - local-blocks
                   - service-graphs
                   - span-metrics
+          server:
+            grpc_server_max_recv_msg_size: 16777216
+            grpc_server_max_send_msg_size: 16777216
+          receivers:
+            otlp:
+              protocols:
+                grpc:
+                  max_recv_msg_size_mib: 16
         persistence:
           enabled: true
           accessModes:


### PR DESCRIPTION
## Summary
Sets `tempo.server.grpc_server_max_recv_msg_size` / `grpc_server_max_send_msg_size` and `tempo.receivers.otlp.protocols.grpc.max_recv_msg_size_mib` to 16 MiB on the Tempo Helm release, replacing the protocol's 4 MiB default.

## Why
On the live cluster, `otelcol_exporter_send_failed_spans_total{component_id="otelcol.exporter.otlp.localtempo",error_type="ResourceExhausted",error_permanent="true"}` is increasing (~1200 dropped spans in observed window). `tempo_discarded_spans_total` is 0 in every reason bucket, so Tempo's normal ingest/discard path isn't the cause — the rejection happens before ingest, at the gRPC receive layer when an export batch exceeds the default 4 MiB.

This is the symptom that surfaced as "publisher SERVER span never reaches Tempo": SERVER spans are 1 per request, so when a batch is rejected wholesale they go missing, while INTERNAL/CLIENT spans (4–5 per request) survive in the batches that fit. 24-hour `traces_spanmetrics_calls_total{service="seichi-game-data-publisher",span_kind="SPAN_KIND_SERVER"}` is ~15, confirming the SDK does emit them; only ingest is dropping batches that contain them.

`error_permanent=true` means retrying the same batch will fail again, so retry tuning is not the right knob — the gRPC receive ceiling is.

Reference: https://grafana.com/docs/tempo/latest/troubleshooting/querying/response-too-large/

## Test plan
- [ ] After ArgoCD sync: `otelcol_exporter_send_failed_spans_total` for `otelcol.exporter.otlp.localtempo` stops growing
- [ ] Single trace contains publisher SERVER + publisher CLIENT + server SERVER spans linked by the same trace_id
- [ ] `traces_spanmetrics_calls_total{service="seichi-game-data-publisher",span_kind="SPAN_KIND_SERVER"}` 1h rate becomes non-trivial (was ~0.6/h before)

## Follow-ups (not in this PR)
- Trim publisher INTERNAL spans further so individual export batches stay smaller
- Consider tuning Alloy's batch processor `send_batch_max_size` to keep gRPC frames well under the cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)