### PR TITLE
Align game data query log level

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-game-data-publisher/publisher-server/configmap.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-game-data-publisher/publisher-server/configmap.yaml
@@ -5,9 +5,9 @@ metadata:
 data:
   # Expect game-data-server service to be in the same namespace
   GAME_DATA_SERVER_GRPC_ENDPOINT_URL: "http://seichi-game-data-server:80"
-  # Base level info; the previous "debug" base flooded Loki with hyper_util
-  # connection-pool DEBUG events from the OTLP exporter (~2 lines/sec).
-  RUST_LOG: "info"
+  # Base level info; keep sqlx::query at debug to match the game-data stack's
+  # query tracing policy without enabling noisy crate-wide DEBUG logs.
+  RUST_LOG: "info,sqlx::query=debug"
   RUST_BACKTRACE: "1"
 
   # OpenTelemetry: traces, metrics, logs are pushed to the cluster's Alloy


### PR DESCRIPTION
## Summary
- align seichi-game-data-publisher's RUST_LOG with seichi-game-data-server by enabling only sqlx::query=debug on top of info
- keep crate-wide DEBUG disabled to avoid the previous hyper_util OTLP exporter log noise

## Notes
- publisher does not currently use sqlx, so this is primarily a policy alignment with no expected extra query logs today
- server already uses info,sqlx::query=debug to attach SQLx query events to spans

## Test plan
- [x] YAML parses
- [x] git diff --check