### PR TITLE
ci: Set COSIGN_EXPERIMENTAL environment variable

### DIFF
--- a/.github/workflows/build_mcserver_images.yaml
+++ b/.github/workflows/build_mcserver_images.yaml
@@ -127,6 +127,8 @@ jobs:
         run: |
           cosign sign --yes --registry-referrers-mode=oci-1-1 \
             ${{ matrix.image }}@${{ steps.build.outputs.digest }}
+        env:
+          COSIGN_EXPERIMENTAL: 1
 
       # Kyverno のポリシー (verify-image-signatures.yaml) と同じ条件で検証し、
       # 署名と検証側のモードがズレた瞬間に CI を fail させる。


### PR DESCRIPTION
> Error: invalid argument "oci-1-1" for "--registry-referrers-mode" flag: in order to use  mode "oci-1-1", you must set COSIGN_EXPERIMENTAL=1
error during command execution: invalid argument "oci-1-1" for "--registry-referrers-mode" flag: in order to use  mode "oci-1-1", you must set COSIGN_EXPERIMENTAL=1
Error: Process completed with exit code 1.