### PR TITLE
fix: Discord リリース通知から開発者向け情報を除去

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/sensor.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/sensor.yaml
@@ -252,9 +252,11 @@ spec:
                           sed -i '/^<!--.*-->$/d' /tmp/release-body.txt
 
                           # 開発者向け情報を除去 (プレイヤー向け通知には不要)
-                          sed -i 's/ by @[^ ]* in https:\/\/github\.com\/[^ ]*//g' /tmp/release-body.txt
-                          sed -i '/^\*\*Full Changelog\*\*/d' /tmp/release-body.txt
-                          sed -i '/^## What'\''s Changed/d' /tmp/release-body.txt
+                          sed -i \
+                            -e 's/ by @[^ ]* in https:\/\/github\.com\/[^ ]*//g' \
+                            -e '/^\*\*Full Changelog\*\*/d' \
+                            -e '/^## What'\''s Changed/d' \
+                            /tmp/release-body.txt
 
                           # Discord embed description の 4096 文字制限に対応
                           body=$(head -c 4000 /tmp/release-body.txt)

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/sensor.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichiassist-downloader/sensor.yaml
@@ -251,6 +251,11 @@ spec:
                           # HTML コメント行を除去 (GitHub 自動生成リリースノートの先頭コメント)
                           sed -i '/^<!--.*-->$/d' /tmp/release-body.txt
 
+                          # 開発者向け情報を除去 (プレイヤー向け通知には不要)
+                          sed -i 's/ by @[^ ]* in https:\/\/github\.com\/[^ ]*//g' /tmp/release-body.txt
+                          sed -i '/^\*\*Full Changelog\*\*/d' /tmp/release-body.txt
+                          sed -i '/^## What'\''s Changed/d' /tmp/release-body.txt
+
                           # Discord embed description の 4096 文字制限に対応
                           body=$(head -c 4000 /tmp/release-body.txt)
                           if [ "$(wc -c < /tmp/release-body.txt)" -gt 4000 ]; then


### PR DESCRIPTION
## 概要

- SeichiAssist の master リリース時に Discord へ送る通知で、GitHub 自動生成リリースノートに含まれる開発者向け文字列が表示されていた
- プレイヤー向け通知には不要なため、Discord 送信前に以下の 3 種類を sed で除去するようにした
  - `by @username in https://github.com/...`（各 PR 末尾の貢献者帰属）
  - `**Full Changelog**: ...`（差分比較リンク行）
  - `## What's Changed`（セクションヘッダー行）

## 確認事項

- 変更は `send-discord-embed-for-master` テンプレート内のシェルスクリプトのみで、他テンプレートや develop 向け通知への影響はない
- sed パターンは既存の HTML コメント除去処理と同じ箇所に追記しており、処理順序に問題はない
- 実際の通知は次回 master リリース時に確認が必要

## 補足

- PR タイトル部分（`* バグ修正` など）は残り、変更内容の概要はそのまま伝わる

🤖 Generated with Claude Code