### PR TITLE
feat(thanos): add Querier / Store / Compactor via kube-thanos jsonnet

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/thanos.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/thanos.yaml
@@ -1,0 +1,28 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: thanos
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io # cascade deletion on this App deletion
+spec:
+  project: cluster-wide-apps
+  source:
+    repoURL: https://github.com/GiganticMinecraft/seichi_infra
+    targetRevision: main
+    path: seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos
+    directory:
+      # vendor 配下や jsonnetfile.json を ArgoCD の manifest scanner に拾わせない
+      include: 'main.jsonnet'
+      jsonnet:
+        libs:
+          - seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/README.md
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/README.md
@@ -1,0 +1,36 @@
+# Thanos Querier / Store Gateway / Compactor
+
+kube-prometheus-stack の Thanos sidecar が Garage S3 にアップロードしている長期メトリクスを、
+Grafana から Prometheus 直結ではなく Thanos Querier 経由で透過的に読めるようにする。
+
+## 構成
+
+`main.jsonnet` が [thanos-io/kube-thanos](https://github.com/thanos-io/kube-thanos) の
+公式 jsonnet ライブラリを `vendor/` 配下から import し、本クラスタ用のパラメータで render する。
+ArgoCD は `directory.jsonnet` でこれを評価して manifest を生成する。
+
+依存は `jsonnetfile.json` で宣言、`jsonnetfile.lock.json` で commit hash 固定。
+Renovate の `jsonnet-bundler` manager (`config:recommended` で標準有効) が
+新しい kube-thanos リリースを検出して PR を出す。
+
+## ローカルでの作業
+
+```bash
+brew install jsonnet jsonnet-bundler
+cd seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos
+
+# 依存更新 (Renovate が自動 PR を出すので通常は不要)
+jb update
+
+# render を確認
+jsonnet -J vendor main.jsonnet | jq '[.[] | {kind, name: .metadata.name}]'
+```
+
+## Grafana datasource を Querier に切替えるには
+
+`prometheus-operator.yaml` の Grafana datasource `Prometheus` の `url` を
+`http://prometheus-kube-prometheus-prometheus:9090` から
+`http://thanos-query.monitoring.svc.cluster.local:9090` に変更すると、
+ローカル直近 (sidecar) + Garage 上の長期 (Store Gateway) の両方が透過的に見える。
+
+切替後は Prometheus の `retention` / `retentionSize` を縮める余地がある (現在 180d / 270GB)。

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/jsonnetfile.json
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/thanos-io/kube-thanos.git",
+          "subdir": "jsonnet/kube-thanos"
+        }
+      },
+      "version": "main"
+    }
+  ],
+  "legacyImports": true
+}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/jsonnetfile.lock.json
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/jsonnetfile.lock.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/thanos-io/kube-thanos.git",
+          "subdir": "jsonnet/kube-thanos"
+        }
+      },
+      "version": "55d4a7c28b2b6c8310cee030c6b319868ec9bd62",
+      "sum": "1dYP6hnUX/+rqIWm9FSVQ1qHGCk3np/8ss0gFdNnjHs="
+    }
+  ],
+  "legacyImports": false
+}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/main.jsonnet
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/main.jsonnet
@@ -1,0 +1,80 @@
+local t = import 'kube-thanos/thanos.libsonnet';
+
+local commonConfig = {
+  namespace: 'monitoring',
+  version: 'v0.41.0',
+  image: 'quay.io/thanos/thanos:v0.41.0',
+  imagePullPolicy: 'IfNotPresent',
+  objectStorageConfig: {
+    name: 'garage-thanos-credentials',
+    key: 'objstore.yml',
+  },
+  volumeClaimTemplate: {
+    spec: {
+      accessModes: ['ReadWriteOnce'],
+      storageClassName: 'synology-iscsi-storage',
+      resources: {
+        requests: { storage: '50Gi' },
+      },
+    },
+  },
+};
+
+local store = t.store(commonConfig {
+  replicas: 1,
+  serviceMonitor: true,
+  resources: {
+    requests: { cpu: '200m', memory: '1Gi' },
+    limits: { memory: '4Gi' },
+  },
+});
+
+local compact = t.compact(commonConfig {
+  replicas: 1,
+  serviceMonitor: true,
+  disableDownsampling: true,
+  resources: {
+    requests: { cpu: '100m', memory: '256Mi' },
+    limits: { memory: '1Gi' },
+  },
+});
+
+local query = t.query(commonConfig {
+  replicas: 2,
+  replicaLabels: ['prometheus_replica'],
+  serviceMonitor: true,
+  autoDownsampling: true,
+  queryTimeout: '5m',
+  lookbackDelta: '15m',
+  stores: [
+    'dnssrv+_grpc._tcp.prometheus-kube-prometheus-thanos-discovery.monitoring.svc.cluster.local',
+    'dnssrv+_grpc._tcp.thanos-store.monitoring.svc.cluster.local',
+  ],
+  resources: {
+    requests: { cpu: '100m', memory: '256Mi' },
+    limits: { memory: '1Gi' },
+  },
+});
+
+local serviceMonitorReleaseLabel = { release: 'prometheus' };
+
+local withReleaseLabel(comp) =
+  if std.objectHas(comp, 'serviceMonitor') && comp.serviceMonitor != null then
+    comp {
+      serviceMonitor+: {
+        metadata+: { labels+: serviceMonitorReleaseLabel },
+      },
+    }
+  else comp;
+
+local toResourceList(comp) = [
+  comp[name]
+  for name in std.objectFields(comp)
+  if comp[name] != null
+     && std.isObject(comp[name])
+     && std.objectHas(comp[name], 'kind')
+];
+
+toResourceList(withReleaseLabel(store))
++ toResourceList(withReleaseLabel(compact))
++ toResourceList(withReleaseLabel(query))

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/jsonnetfile.json
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/jsonnetfile.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "dependencies": [],
+  "legacyImports": true
+}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-bucket-replicate.libsonnet
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-bucket-replicate.libsonnet
@@ -1,0 +1,212 @@
+// These are the defaults for this components configuration.
+// When calling the function to generate the component's manifest,
+// you can pass an object structured like the default to overwrite default values.
+local defaults = {
+  local defaults = self,
+  name: 'thanos-bucket-replicate',
+  namespace: error 'must provide namespace',
+  version: error 'must provide version',
+  image: error 'must provide image',
+  imagePullPolicy: 'IfNotPresent',
+  objectStorageConfig: error 'must provide objectStorageConfig',
+  objectStorageToConfig: error 'must provide objectStorageToConfig',  // Destination object store configuration.
+  resources: {},
+  logLevel: 'info',
+  logFormat: 'logfmt',
+  ports: {
+    http: 10902,
+  },
+  tracing: {},
+  minTime: '',
+  maxTime: '',
+  compactionLevels: [],
+  resolutions: [],
+  extraEnv: [],
+
+  commonLabels:: {
+    'app.kubernetes.io/name': 'thanos-bucket-replicate',
+    'app.kubernetes.io/instance': defaults.name,
+    'app.kubernetes.io/version': defaults.version,
+    'app.kubernetes.io/component': 'object-store-bucket-replicate',
+  },
+
+  podLabelSelector:: {
+    [labelName]: defaults.commonLabels[labelName]
+    for labelName in std.objectFields(defaults.commonLabels)
+    if labelName != 'app.kubernetes.io/version'
+  },
+
+  securityContext:: {
+    fsGroup: 65534,
+    runAsUser: 65534,
+    runAsGroup: 65532,
+    runAsNonRoot: true,
+    seccompProfile: { type: 'RuntimeDefault' },
+  },
+  securityContextContainer:: {
+    runAsUser: defaults.securityContext.runAsUser,
+    runAsGroup: defaults.securityContext.runAsGroup,
+    runAsNonRoot: defaults.securityContext.runAsNonRoot,
+    seccompProfile: defaults.securityContext.seccompProfile,
+    allowPrivilegeEscalation: false,
+    readOnlyRootFilesystem: true,
+    capabilities: { drop: ['ALL'] },
+  },
+
+  serviceAccountAnnotations:: {},
+};
+
+function(params) {
+  local tbr = self,
+
+  // Combine the defaults and the passed params to make the component's config.
+  config:: defaults + params,
+  // Safety checks for combined config of defaults and params
+  assert std.isNumber(tbr.config.replicas) && tbr.config.replicas >= 0 : 'thanos bucket replicate replicas has to be number >= 0',
+  assert std.isObject(tbr.config.resources),
+
+  service: {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+      name: tbr.config.name,
+      namespace: tbr.config.namespace,
+      labels: tbr.config.commonLabels,
+    },
+    spec: {
+      ports: [
+        {
+          assert std.isString(name),
+          assert std.isNumber(tbr.config.ports[name]),
+
+          name: name,
+          port: tbr.config.ports[name],
+          targetPort: tbr.config.ports[name],
+        }
+        for name in std.objectFields(tbr.config.ports)
+      ],
+      selector: tbr.config.podLabelSelector,
+    },
+  },
+
+  serviceAccount: {
+    apiVersion: 'v1',
+    kind: 'ServiceAccount',
+    metadata: {
+      name: tbr.config.name,
+      namespace: tbr.config.namespace,
+      labels: tbr.config.commonLabels,
+      annotations: tbr.config.serviceAccountAnnotations,
+    },
+  },
+
+  deployment:
+    local container = {
+      name: 'thanos-bucket-replicate',
+      image: tbr.config.image,
+      imagePullPolicy: tbr.config.imagePullPolicy,
+      args: [
+        'tools',
+        'bucket',
+        'replicate',
+        '--log.level=' + tbr.config.logLevel,
+        '--log.format=' + tbr.config.logFormat,
+        '--objstore.config=$(OBJSTORE_CONFIG)',
+        '--objstore-to.config=$(OBJSTORE_TO_CONFIG)',
+      ] + (
+        if std.length(tbr.config.tracing) > 0 then [
+          '--tracing.config=' + std.manifestYamlDoc(
+            { config+: { service_name: defaults.name } } + tbr.config.tracing
+          ),
+        ] else []
+      ) + (
+        if std.length(tbr.config.minTime) > 0 then [
+          '--min-time=' + tbr.config.minTime,
+        ] else []
+      ) + (
+        if std.length(tbr.config.maxTime) > 0 then [
+          '--max-time=' + tbr.config.maxTime,
+        ] else []
+      ) + (
+        if std.length(tbr.config.compactionLevels) > 0 then [
+          '--compaction=%d' % compactionLevel
+          for compactionLevel in tbr.config.compactionLevels
+        ] else []
+      ) + (
+        if std.length(tbr.config.resolutions) > 0 then [
+          '--resolution=%s' % resolution
+          for resolution in tbr.config.resolutions
+        ] else []
+      ),
+      env: [
+        { name: 'OBJSTORE_CONFIG', valueFrom: { secretKeyRef: {
+          key: tbr.config.objectStorageConfig.key,
+          name: tbr.config.objectStorageConfig.name,
+        } } },
+        { name: 'OBJSTORE_TO_CONFIG', valueFrom: { secretKeyRef: {
+          key: tbr.config.objectStorageToConfig.key,
+          name: tbr.config.objectStorageToConfig.name,
+        } } },
+        {
+          // Inject the host IP to make configuring tracing convenient.
+          name: 'HOST_IP_ADDRESS',
+          valueFrom: {
+            fieldRef: {
+              fieldPath: 'status.hostIP',
+            },
+          },
+        },
+      ] + (
+        if std.length(tbr.config.extraEnv) > 0 then tbr.config.extraEnv else []
+      ),
+      ports: [
+        { name: name, containerPort: tbr.config.ports[name] }
+        for name in std.objectFields(tbr.config.ports)
+      ],
+      livenessProbe: { failureThreshold: 4, periodSeconds: 30, httpGet: {
+        scheme: 'HTTP',
+        port: tbr.config.ports.http,
+        path: '/-/healthy',
+      } },
+      readinessProbe: { failureThreshold: 20, periodSeconds: 5, httpGet: {
+        scheme: 'HTTP',
+        port: tbr.config.ports.http,
+        path: '/-/ready',
+      } },
+      resources: if tbr.config.resources != {} then tbr.config.resources else {},
+      terminationMessagePolicy: 'FallbackToLogsOnError',
+      volumeMounts: if std.objectHas(tbr.config.objectStorageConfig, 'tlsSecretName') && std.length(tbr.config.objectStorageConfig.tlsSecretName) > 0 then [
+        { name: 'tls-secret', mountPath: tbr.config.objectStorageConfig.tlsSecretMountPath },
+      ] else [],
+    };
+
+    {
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      metadata: {
+        name: tbr.config.name,
+        namespace: tbr.config.namespace,
+        labels: tbr.config.commonLabels,
+      },
+      spec: {
+        replicas: 1,
+        selector: { matchLabels: tbr.config.podLabelSelector },
+        template: {
+          metadata: { labels: tbr.config.commonLabels },
+          spec: {
+            serviceAccountName: tbr.serviceAccount.metadata.name,
+            securityContext: tbr.config.securityContext,
+            containers: [container],
+            volumes: if std.objectHas(tbr.config.objectStorageConfig, 'tlsSecretName') && std.length(tbr.config.objectStorageConfig.tlsSecretName) > 0 then [{
+              name: 'tls-secret',
+              secret: { secretName: tbr.config.objectStorageConfig.tlsSecretName },
+            }] else [],
+            terminationGracePeriodSeconds: 120,
+            nodeSelector: {
+              'kubernetes.io/os': 'linux',
+            },
+          },
+        },
+      },
+    },
+}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-bucket.libsonnet
@@ -1,0 +1,193 @@
+// These are the defaults for this components configuration.
+// When calling the function to generate the component's manifest,
+// you can pass an object structured like the default to overwrite default values.
+local defaults = {
+  local defaults = self,
+  name: 'thanos-bucket',
+  namespace: error 'must provide namespace',
+  version: error 'must provide version',
+  image: error 'must provide image',
+  imagePullPolicy: 'IfNotPresent',
+  objectStorageConfig: error 'must provide objectStorageConfig',
+  resources: {},
+  logLevel: 'info',
+  logFormat: 'logfmt',
+  ports: {
+    http: 10902,
+  },
+  tracing: {},
+  extraEnv: [],
+
+  commonLabels:: {
+    'app.kubernetes.io/name': 'thanos-bucket',
+    'app.kubernetes.io/instance': defaults.name,
+    'app.kubernetes.io/version': defaults.version,
+    'app.kubernetes.io/component': 'object-store-bucket-debugging',
+  },
+
+  podLabelSelector:: {
+    [labelName]: defaults.commonLabels[labelName]
+    for labelName in std.objectFields(defaults.commonLabels)
+    if labelName != 'app.kubernetes.io/version'
+  },
+
+  securityContext:: {
+    fsGroup: 65534,
+    runAsUser: 65534,
+    runAsGroup: 65532,
+    runAsNonRoot: true,
+    seccompProfile: { type: 'RuntimeDefault' },
+  },
+  securityContextContainer:: {
+    runAsUser: defaults.securityContext.runAsUser,
+    runAsGroup: defaults.securityContext.runAsGroup,
+    runAsNonRoot: defaults.securityContext.runAsNonRoot,
+    seccompProfile: defaults.securityContext.seccompProfile,
+    allowPrivilegeEscalation: false,
+    readOnlyRootFilesystem: true,
+    capabilities: { drop: ['ALL'] },
+  },
+
+  serviceAccountAnnotations:: {},
+};
+
+function(params) {
+  local tb = self,
+
+  // Combine the defaults and the passed params to make the component's config.
+  config:: defaults + params,
+  // Safety checks for combined config of defaults and params
+  assert std.isNumber(tb.config.replicas) && tb.config.replicas >= 0 : 'thanos bucket replicas has to be number >= 0',
+  assert std.isObject(tb.config.resources),
+
+  service: {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+      name: tb.config.name,
+      namespace: tb.config.namespace,
+      labels: tb.config.commonLabels,
+    },
+    spec: {
+      ports: [
+        {
+          assert std.isString(name),
+          assert std.isNumber(tb.config.ports[name]),
+
+          name: name,
+          port: tb.config.ports[name],
+          targetPort: tb.config.ports[name],
+        }
+        for name in std.objectFields(tb.config.ports)
+      ],
+      selector: tb.config.podLabelSelector,
+    },
+  },
+
+  serviceAccount: {
+    apiVersion: 'v1',
+    kind: 'ServiceAccount',
+    metadata: {
+      name: tb.config.name,
+      namespace: tb.config.namespace,
+      labels: tb.config.commonLabels,
+      annotations: tb.config.serviceAccountAnnotations,
+    },
+  },
+
+  deployment:
+    local container = {
+      name: 'thanos-bucket',
+      image: tb.config.image,
+      imagePullPolicy: tb.config.imagePullPolicy,
+      args: [
+        'tools',
+        'bucket',
+        'web',
+        '--log.level=' + tb.config.logLevel,
+        '--log.format=' + tb.config.logFormat,
+        '--objstore.config=$(OBJSTORE_CONFIG)',
+      ] + (
+        if std.length(tb.config.tracing) > 0 then [
+          '--tracing.config=' + std.manifestYamlDoc(
+            { config+: { service_name: defaults.name } } + tb.config.tracing
+          ),
+        ] else []
+      ) + (
+        if std.objectHas(tb.config, 'label') then [
+          '--label=' + tb.config.label,
+        ] else []
+      ) + (
+        if std.objectHas(tb.config, 'refresh') then [
+          '--refresh=' + tb.config.refresh,
+        ] else []
+      ),
+      env: [
+        { name: 'OBJSTORE_CONFIG', valueFrom: { secretKeyRef: {
+          key: tb.config.objectStorageConfig.key,
+          name: tb.config.objectStorageConfig.name,
+        } } },
+        {
+          // Inject the host IP to make configuring tracing convenient.
+          name: 'HOST_IP_ADDRESS',
+          valueFrom: {
+            fieldRef: {
+              fieldPath: 'status.hostIP',
+            },
+          },
+        },
+      ] + (
+        if std.length(tb.config.extraEnv) > 0 then tb.config.extraEnv else []
+      ),
+      ports: [
+        { name: name, containerPort: tb.config.ports[name] }
+        for name in std.objectFields(tb.config.ports)
+      ],
+      livenessProbe: { failureThreshold: 4, periodSeconds: 30, httpGet: {
+        scheme: 'HTTP',
+        port: tb.config.ports.http,
+        path: '/-/healthy',
+      } },
+      readinessProbe: { failureThreshold: 20, periodSeconds: 5, httpGet: {
+        scheme: 'HTTP',
+        port: tb.config.ports.http,
+        path: '/-/ready',
+      } },
+      resources: if tb.config.resources != {} then tb.config.resources else {},
+      securityContext: tb.config.securityContextContainer,
+      terminationMessagePolicy: 'FallbackToLogsOnError',
+      volumeMounts: if std.objectHas(tb.config.objectStorageConfig, 'tlsSecretName') && std.length(tb.config.objectStorageConfig.tlsSecretName) > 0 then [
+        { name: 'tls-secret', mountPath: tb.config.objectStorageConfig.tlsSecretMountPath },
+      ] else [],
+    };
+
+    {
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      metadata: {
+        name: tb.config.name,
+        namespace: tb.config.namespace,
+        labels: tb.config.commonLabels,
+      },
+      spec: {
+        replicas: 1,
+        selector: { matchLabels: tb.config.podLabelSelector },
+        template: {
+          metadata: { labels: tb.config.commonLabels },
+          spec: {
+            serviceAccountName: tb.serviceAccount.metadata.name,
+            securityContext: tb.config.securityContext,
+            containers: [container],
+            volumes: if std.objectHas(tb.config.objectStorageConfig, 'tlsSecretName') && std.length(tb.config.objectStorageConfig.tlsSecretName) > 0 then [{
+              name: 'tls-secret',
+              secret: { secretName: tb.config.objectStorageConfig.tlsSecretName },
+            }] else [],
+            terminationGracePeriodSeconds: 120,
+            nodeSelector: {
+              'kubernetes.io/os': 'linux',
+            },
+          },
+        },
+      },
+    },
+}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-compact-default-params.libsonnet
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-compact-default-params.libsonnet
@@ -1,0 +1,63 @@
+// These are the defaults for this components configuration.
+// When calling the function to generate the component's manifest,
+// you can pass an object structured like the default to overwrite default values.
+{
+  local defaults = self,
+  name: 'thanos-compact',
+  namespace: error 'must provide namespace',
+  version: error 'must provide version',
+  image: error 'must provide image',
+  imagePullPolicy: 'IfNotPresent',
+  objectStorageConfig: error 'must provide objectStorageConfig',
+  resources: {},
+  logLevel: 'info',
+  logFormat: 'logfmt',
+  serviceMonitor: false,
+  volumeClaimTemplate: {},
+  retentionResolutionRaw: '0d',
+  retentionResolution5m: '0d',
+  retentionResolution1h: '0d',
+  compactConcurrency: 1,
+  deduplicationReplicaLabels: [],
+  deleteDelay: '48h',
+  disableDownsampling: false,
+  downsampleConcurrency: 1,
+  ports: {
+    http: 10902,
+  },
+  tracing: {},
+  extraEnv: [],
+
+  commonLabels:: {
+    'app.kubernetes.io/name': 'thanos-compact',
+    'app.kubernetes.io/instance': defaults.name,
+    'app.kubernetes.io/version': defaults.version,
+    'app.kubernetes.io/component': 'database-compactor',
+  },
+
+  podLabelSelector:: {
+    [labelName]: defaults.commonLabels[labelName]
+    for labelName in std.objectFields(defaults.commonLabels)
+    if labelName != 'app.kubernetes.io/version'
+  },
+
+  securityContext:: {
+    fsGroup: 65534,
+    runAsUser: 65534,
+    runAsGroup: 65532,
+    runAsNonRoot: true,
+    seccompProfile: { type: 'RuntimeDefault' },
+  },
+
+  securityContextContainer:: {
+    runAsUser: defaults.securityContext.runAsUser,
+    runAsGroup: defaults.securityContext.runAsGroup,
+    runAsNonRoot: defaults.securityContext.runAsNonRoot,
+    seccompProfile: defaults.securityContext.seccompProfile,
+    allowPrivilegeEscalation: false,
+    readOnlyRootFilesystem: true,
+    capabilities: { drop: ['ALL'] },
+  },
+
+  serviceAccountAnnotations:: {},
+}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-compact-shards.libsonnet
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-compact-shards.libsonnet
@@ -1,0 +1,109 @@
+local compactConfigDefaults = import 'kube-thanos/kube-thanos-compact-default-params.libsonnet';
+local compact = import 'kube-thanos/kube-thanos-compact.libsonnet';
+
+// These are the defaults for this components configuration.
+// When calling the function to generate the component's manifest,
+// you can pass an object structured like the default to overwrite default values.
+local defaults = compactConfigDefaults {
+  shards: 1,
+};
+
+function(params)
+  // Combine the defaults and the passed params to make the component's config.
+  local config = defaults + params;
+
+  // Safety checks for combined config of defaults and params
+  assert std.isNumber(config.shards) && config.shards >= 0 : 'thanos compact shards has to be number >= 0';
+  assert std.isArray(config.sourceLabels) && std.length(config.sourceLabels) > 0;
+
+  { config:: config } + {
+    local allShards = self,
+
+    serviceAccount: {
+      apiVersion: 'v1',
+      kind: 'ServiceAccount',
+      metadata: {
+        name: config.name,
+        namespace: config.namespace,
+        labels: config.commonLabels,
+        annotations: config.serviceAccountAnnotations,
+      },
+    },
+
+    shards: {
+      ['shard' + i]: compact(config {
+        name+: '-%d' % i,
+        commonLabels+:: { 'compact.thanos.io/shard': 'shard-' + i },
+      }) {
+        serviceAccount: null,  // one service account for all compactors
+        serviceMonitor: null,  // one service monitor for all compactors
+
+        statefulSet+: {
+          spec+: {
+            template+: {
+              spec+: {
+                serviceAccountName: allShards.serviceAccount.metadata.name,
+                containers: [
+                  if c.name == 'thanos-compact' then c {
+                    args+: [
+                      |||
+                        --selector.relabel-config=
+                          - action: hashmod
+                            source_labels: %s
+                            target_label: shard
+                            modulus: %d
+                          - action: keep
+                            source_labels: ["shard"]
+                            regex: %d
+                      ||| % [config.sourceLabels, config.shards, i],
+                    ],
+                  } else c
+                  for c in super.containers
+                ],
+              },
+            },
+          },
+        },
+      }
+      for i in std.range(0, config.shards - 1)
+    },
+  } + {
+    serviceMonitor: if config.serviceMonitor == true then {
+      apiVersion: 'monitoring.coreos.com/v1',
+      kind: 'ServiceMonitor',
+      metadata+: {
+        name: config.name,
+        namespace: config.namespace,
+        labels: config.commonLabels,
+      },
+      spec: {
+        selector: {
+          matchLabels: {
+            [key]: config.podLabelSelector[key]
+            for key in std.objectFields(config.podLabelSelector)
+            if key != 'app.kubernetes.io/instance'
+          },
+        },
+        endpoints: [
+          {
+            port: 'http',
+            relabelings: [
+              {
+                action: 'replace',
+                sourceLabels: ['namespace', 'pod'],
+                separator: '/',
+                targetLabel: 'instance',
+              },
+              {
+                action: 'replace',
+                sourceLabels: ['__meta_kubernetes_service_label_compact_thanos_io_shard'],
+                regex: 'shard\\-(\\d+)',
+                replacement: '$1',
+                targetLabel: 'shard',
+              },
+            ],
+          },
+        ],
+      },
+    },
+  }

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-compact.libsonnet
@@ -1,0 +1,214 @@
+local defaults = import 'kube-thanos/kube-thanos-compact-default-params.libsonnet';
+
+function(params) {
+  local tc = self,
+
+  // Combine the defaults and the passed params to make the component's config.
+  config:: defaults + params,
+  // Safety checks for combined config of defaults and params
+  assert std.isNumber(tc.config.compactConcurrency),
+  assert std.isNumber(tc.config.downsampleConcurrency),
+  assert std.isNumber(tc.config.replicas) && (tc.config.replicas == 0 || tc.config.replicas == 1) : 'thanos compact replicas can only be 0 or 1',
+  assert std.isObject(tc.config.resources),
+  assert std.isObject(tc.config.volumeClaimTemplate),
+  assert !std.objectHas(tc.config.volumeClaimTemplate, 'spec') || std.assertEqual(tc.config.volumeClaimTemplate.spec.accessModes, ['ReadWriteOnce']) : 'thanos compact PVC accessMode can only be ReadWriteOnce',
+  assert std.isBoolean(tc.config.serviceMonitor),
+  assert std.isArray(tc.config.deduplicationReplicaLabels),
+
+  service: {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+      name: tc.config.name,
+      namespace: tc.config.namespace,
+      labels: tc.config.commonLabels,
+    },
+    spec: {
+      clusterIP: 'None',
+      selector: tc.config.podLabelSelector,
+      ports: [
+        {
+          assert std.isString(name),
+          assert std.isNumber(tc.config.ports[name]),
+
+          name: name,
+          port: tc.config.ports[name],
+          targetPort: tc.config.ports[name],
+        }
+        for name in std.objectFields(tc.config.ports)
+      ],
+    },
+  },
+
+  serviceAccount: {
+    apiVersion: 'v1',
+    kind: 'ServiceAccount',
+    metadata: {
+      name: tc.config.name,
+      namespace: tc.config.namespace,
+      labels: tc.config.commonLabels,
+      annotations: tc.config.serviceAccountAnnotations,
+    },
+  },
+
+  statefulSet:
+    local c = {
+      name: 'thanos-compact',
+      image: tc.config.image,
+      imagePullPolicy: tc.config.imagePullPolicy,
+      args: [
+        'compact',
+        '--wait',
+        '--log.level=' + tc.config.logLevel,
+        '--log.format=' + tc.config.logFormat,
+        '--objstore.config=$(OBJSTORE_CONFIG)',
+        '--data-dir=/var/thanos/compact',
+        '--debug.accept-malformed-index',
+        '--retention.resolution-raw=' + tc.config.retentionResolutionRaw,
+        '--retention.resolution-5m=' + tc.config.retentionResolution5m,
+        '--retention.resolution-1h=' + tc.config.retentionResolution1h,
+        '--delete-delay=' + tc.config.deleteDelay,
+        '--compact.concurrency=' + tc.config.compactConcurrency,
+        '--downsample.concurrency=' + tc.config.downsampleConcurrency,
+      ] + (
+        if tc.config.disableDownsampling then ['--downsampling.disable'] else []
+      ) + (
+        if std.length(tc.config.deduplicationReplicaLabels) > 0 then
+          [
+            '--deduplication.replica-label=' + l
+            for l in tc.config.deduplicationReplicaLabels
+          ] else []
+      ) + (
+        if std.length(tc.config.tracing) > 0 then [
+          '--tracing.config=' + std.manifestYamlDoc(
+            { config+: { service_name: defaults.name } } + tc.config.tracing
+          ),
+        ] else []
+      ),
+      env: [
+        { name: 'OBJSTORE_CONFIG', valueFrom: { secretKeyRef: {
+          key: tc.config.objectStorageConfig.key,
+          name: tc.config.objectStorageConfig.name,
+        } } },
+        {
+          // Inject the host IP to make configuring tracing convenient.
+          name: 'HOST_IP_ADDRESS',
+          valueFrom: {
+            fieldRef: {
+              fieldPath: 'status.hostIP',
+            },
+          },
+        },
+      ] + (
+        if std.length(tc.config.extraEnv) > 0 then tc.config.extraEnv else []
+      ),
+      ports: [
+        { name: name, containerPort: tc.config.ports[name] }
+        for name in std.objectFields(tc.config.ports)
+      ],
+      livenessProbe: { failureThreshold: 4, periodSeconds: 30, httpGet: {
+        scheme: 'HTTP',
+        port: tc.config.ports.http,
+        path: '/-/healthy',
+      } },
+      readinessProbe: { failureThreshold: 20, periodSeconds: 5, httpGet: {
+        scheme: 'HTTP',
+        port: tc.config.ports.http,
+        path: '/-/ready',
+      } },
+      volumeMounts: [{
+        name: 'data',
+        mountPath: '/var/thanos/compact',
+        readOnly: false,
+      }] + (
+        if std.objectHas(tc.config.objectStorageConfig, 'tlsSecretName') && std.length(tc.config.objectStorageConfig.tlsSecretName) > 0 then [
+          { name: 'tls-secret', mountPath: tc.config.objectStorageConfig.tlsSecretMountPath },
+        ] else []
+      ),
+      resources: if tc.config.resources != {} then tc.config.resources else {},
+      terminationMessagePolicy: 'FallbackToLogsOnError',
+    };
+
+    {
+      apiVersion: 'apps/v1',
+      kind: 'StatefulSet',
+      metadata: {
+        name: tc.config.name,
+        namespace: tc.config.namespace,
+        labels: tc.config.commonLabels,
+      },
+      spec: {
+        replicas: 1,
+        selector: { matchLabels: tc.config.podLabelSelector },
+        serviceName: tc.service.metadata.name,
+        template: {
+          metadata: {
+            labels: tc.config.commonLabels,
+          },
+          spec: {
+            serviceAccountName: tc.serviceAccount.metadata.name,
+            securityContext: tc.config.securityContext,
+            containers: [c],
+            volumes: if std.objectHas(tc.config.objectStorageConfig, 'tlsSecretName') && std.length(tc.config.objectStorageConfig.tlsSecretName) > 0 then [{
+              name: 'tls-secret',
+              secret: { secretName: tc.config.objectStorageConfig.tlsSecretName },
+            }] else [],
+            terminationGracePeriodSeconds: 120,
+            nodeSelector: {
+              'kubernetes.io/os': 'linux',
+            },
+            affinity: { podAntiAffinity: {
+              preferredDuringSchedulingIgnoredDuringExecution: [{
+                podAffinityTerm: {
+                  namespaces: [tc.config.namespace],
+                  topologyKey: 'kubernetes.io/hostname',
+                  labelSelector: { matchExpressions: [{
+                    key: 'app.kubernetes.io/name',
+                    operator: 'In',
+                    values: [tc.statefulSet.metadata.labels['app.kubernetes.io/name']],
+                  }, {
+                    key: 'app.kubernetes.io/instance',
+                    operator: 'In',
+                    values: [tc.statefulSet.metadata.labels['app.kubernetes.io/instance']],
+                  }] },
+                },
+                weight: 100,
+              }],
+            } },
+          },
+        },
+        volumeClaimTemplates: if std.length(tc.config.volumeClaimTemplate) > 0 then [tc.config.volumeClaimTemplate {
+          metadata+: {
+            name: 'data',
+            labels+: tc.config.podLabelSelector,
+          },
+        }] else [],
+      },
+    },
+
+  serviceMonitor: if tc.config.serviceMonitor == true then {
+    apiVersion: 'monitoring.coreos.com/v1',
+    kind: 'ServiceMonitor',
+    metadata+: {
+      name: tc.config.name,
+      namespace: tc.config.namespace,
+      labels: tc.config.commonLabels,
+    },
+    spec: {
+      selector: {
+        matchLabels: tc.config.podLabelSelector,
+      },
+      endpoints: [
+        {
+          port: 'http',
+          relabelings: [{
+            action: 'replace',
+            sourceLabels: ['namespace', 'pod'],
+            separator: '/',
+            targetLabel: 'instance',
+          }],
+        },
+      ],
+    },
+  },
+}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-query-frontend.libsonnet
@@ -1,0 +1,293 @@
+// These are the defaults for this components configuration.
+// When calling the function to generate the component's manifest,
+// you can pass an object structured like the default to overwrite default values.
+local defaults = {
+  local defaults = self,
+  name: 'thanos-query-frontend',
+  namespace: error 'must provide namespace',
+  version: error 'must provide version',
+  image: error 'must provide image',
+  imagePullPolicy: 'IfNotPresent',
+  replicas: error 'must provide replicas',
+  downstreamURL: error 'must provide downstreamURL',
+  splitInterval: '24h',
+  maxRetries: 5,
+  logQueriesLongerThan: '0',
+  fifoCache+:: {
+    config+: {
+      max_size: '0',  // Don't limit maximum item size.
+      max_size_items: 2048,
+      validity: '6h',
+    },
+  },
+  queryRangeCache: {},
+  queryUrl: '',
+  labelsCache: {},
+  logLevel: 'info',
+  logFormat: 'logfmt',
+  resources: {},
+  serviceMonitor: false,
+  ports: {
+    http: 9090,
+  },
+  tracing: {},
+  extraEnv: [],
+
+  memcachedDefaults+:: {
+    config+: {
+      // List of memcached addresses, that will get resolved with the DNS service discovery provider.
+      // For DNS service discovery reference https://thanos.io/service-discovery.md/#dns-service-discovery
+      addresses+: error 'must provide memcached addresses',
+      timeout: '500ms',
+      max_idle_connections: 100,
+      max_async_concurrency: 20,
+      max_async_buffer_size: 10000,
+      max_get_multi_concurrency: 100,
+      max_get_multi_batch_size: 0,
+      dns_provider_update_interval: '10s',
+    },
+  },
+
+  commonLabels:: {
+    'app.kubernetes.io/name': 'thanos-query-frontend',
+    'app.kubernetes.io/instance': defaults.name,
+    'app.kubernetes.io/version': defaults.version,
+    'app.kubernetes.io/component': 'query-cache',
+  },
+
+  podLabelSelector:: {
+    [labelName]: defaults.commonLabels[labelName]
+    for labelName in std.objectFields(defaults.commonLabels)
+    if labelName != 'app.kubernetes.io/version'
+  },
+
+  securityContext:: {
+    fsGroup: 65534,
+    runAsUser: 65534,
+    runAsGroup: 65532,
+    runAsNonRoot: true,
+    seccompProfile: { type: 'RuntimeDefault' },
+  },
+
+  securityContextContainer:: {
+    runAsUser: defaults.securityContext.runAsUser,
+    runAsGroup: defaults.securityContext.runAsGroup,
+    runAsNonRoot: defaults.securityContext.runAsNonRoot,
+    seccompProfile: defaults.securityContext.seccompProfile,
+    allowPrivilegeEscalation: false,
+    readOnlyRootFilesystem: true,
+    capabilities: { drop: ['ALL'] },
+  },
+
+  serviceAccountAnnotations:: {},
+};
+
+function(params) {
+  local tqf = self,
+
+  // Combine the defaults and the passed params to make the component's config.
+  config:: defaults + params + {
+    queryRangeCache+:
+      if std.objectHas(params, 'queryRangeCache')
+         && std.objectHas(params.queryRangeCache, 'type')
+         && std.asciiUpper(params.queryRangeCache.type) == 'MEMCACHED' then
+
+        defaults.memcachedDefaults + params.queryRangeCache
+      else if std.objectHas(params, 'queryRangeCache')
+              && std.objectHas(params.queryRangeCache, 'type')
+              && std.asciiUpper(params.queryRangeCache.type) == 'IN-MEMORY' then
+
+        defaults.fifoCache + params.queryRangeCache
+      else {},
+    labelsCache+:
+      if std.objectHas(params, 'labelsCache')
+         && std.objectHas(params.labelsCache, 'type')
+         && std.asciiUpper(params.labelsCache.type) == 'MEMCACHED' then
+
+        defaults.memcachedDefaults + params.labelsCache
+      else if std.objectHas(params, 'labelsCache')
+              && std.objectHas(params.labelsCache, 'type')
+              && std.asciiUpper(params.labelsCache.type) == 'IN-MEMORY' then
+
+        defaults.fifoCache + params.labelsCache
+      else {},
+  },
+  // Safety checks for combined config of defaults and params
+  assert std.isNumber(tqf.config.replicas) && tqf.config.replicas >= 0 : 'thanos query frontend replicas has to be number >= 0',
+  assert std.isObject(tqf.config.resources),
+  assert std.isBoolean(tqf.config.serviceMonitor),
+  assert std.isNumber(tqf.config.maxRetries) && tqf.config.maxRetries >= 0 : 'thanos query frontend maxRetries has to be number >= 0',
+
+  service: {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+      name: tqf.config.name,
+      namespace: tqf.config.namespace,
+      labels: tqf.config.commonLabels,
+    },
+    spec: {
+      selector: tqf.config.podLabelSelector,
+      ports: [
+        {
+          assert std.isString(name),
+          assert std.isNumber(tqf.config.ports[name]),
+
+          name: name,
+          port: tqf.config.ports[name],
+          targetPort: tqf.config.ports[name],
+        }
+        for name in std.objectFields(tqf.config.ports)
+      ],
+    },
+  },
+
+  serviceAccount: {
+    apiVersion: 'v1',
+    kind: 'ServiceAccount',
+    metadata: {
+      name: tqf.config.name,
+      namespace: tqf.config.namespace,
+      labels: tqf.config.commonLabels,
+      annotations: tqf.config.serviceAccountAnnotations,
+    },
+  },
+
+  deployment:
+    local c = {
+      name: 'thanos-query-frontend',
+      image: tqf.config.image,
+      imagePullPolicy: tqf.config.imagePullPolicy,
+      args: [
+        'query-frontend',
+        '--log.level=' + tqf.config.logLevel,
+        '--log.format=' + tqf.config.logFormat,
+        '--query-frontend.compress-responses',
+        '--http-address=0.0.0.0:%d' % tqf.config.ports.http,
+        '--query-frontend.downstream-url=%s' % tqf.config.downstreamURL,
+        '--query-range.split-interval=%s' % tqf.config.splitInterval,
+        '--labels.split-interval=%s' % tqf.config.splitInterval,
+        '--query-range.max-retries-per-request=%d' % tqf.config.maxRetries,
+        '--labels.max-retries-per-request=%d' % tqf.config.maxRetries,
+        '--query-frontend.log-queries-longer-than=%s' % tqf.config.logQueriesLongerThan,
+      ] + (
+        if std.length(tqf.config.queryRangeCache) > 0 then [
+          '--query-range.response-cache-config=' + std.manifestYamlDoc(
+            tqf.config.queryRangeCache
+          ),
+        ] else []
+      ) + (
+        if std.length(tqf.config.labelsCache) > 0 then [
+          '--labels.response-cache-config=' + std.manifestYamlDoc(
+            tqf.config.labelsCache
+          ),
+        ] else []
+      ) + (
+        if std.length(tqf.config.tracing) > 0 then [
+          '--tracing.config=' + std.manifestYamlDoc(
+            { config+: { service_name: defaults.name } } + tqf.config.tracing
+          ),
+        ] else []
+      ) + (
+        if tqf.config.queryUrl != '' then [
+          '--alert.query-url=' + tqf.config.queryUrl,
+        ] else []
+      ),
+      env: [
+        {
+          // Inject the host IP to make configuring tracing convenient.
+          name: 'HOST_IP_ADDRESS',
+          valueFrom: {
+            fieldRef: {
+              fieldPath: 'status.hostIP',
+            },
+          },
+        },
+      ] + (
+        if std.length(tqf.config.extraEnv) > 0 then tqf.config.extraEnv else []
+      ),
+      ports: [
+        { name: name, containerPort: tqf.config.ports[name] }
+        for name in std.objectFields(tqf.config.ports)
+      ],
+      livenessProbe: { failureThreshold: 4, periodSeconds: 30, httpGet: {
+        scheme: 'HTTP',
+        port: tqf.config.ports.http,
+        path: '/-/healthy',
+      } },
+      readinessProbe: { failureThreshold: 20, periodSeconds: 5, httpGet: {
+        scheme: 'HTTP',
+        port: tqf.config.ports.http,
+        path: '/-/ready',
+      } },
+      resources: if tqf.config.resources != {} then tqf.config.resources else {},
+      securityContext: tqf.config.securityContextContainer,
+      terminationMessagePolicy: 'FallbackToLogsOnError',
+    };
+
+    {
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      metadata: {
+        name: tqf.config.name,
+        namespace: tqf.config.namespace,
+        labels: tqf.config.commonLabels,
+      },
+      spec: {
+        replicas: tqf.config.replicas,
+        selector: { matchLabels: tqf.config.podLabelSelector },
+        template: {
+          metadata: { labels: tqf.config.commonLabels },
+          spec: {
+            containers: [c],
+            serviceAccountName: tqf.serviceAccount.metadata.name,
+            securityContext: tqf.config.securityContext,
+            terminationGracePeriodSeconds: 120,
+            nodeSelector: {
+              'kubernetes.io/os': 'linux',
+            },
+            affinity: { podAntiAffinity: {
+              preferredDuringSchedulingIgnoredDuringExecution: [{
+                podAffinityTerm: {
+                  namespaces: [tqf.config.namespace],
+                  topologyKey: 'kubernetes.io/hostname',
+                  labelSelector: { matchExpressions: [{
+                    key: 'app.kubernetes.io/name',
+                    operator: 'In',
+                    values: [tqf.deployment.metadata.labels['app.kubernetes.io/name']],
+                  }] },
+                },
+                weight: 100,
+              }],
+            } },
+          },
+        },
+      },
+    },
+
+  serviceMonitor: if tqf.config.serviceMonitor == true then {
+    apiVersion: 'monitoring.coreos.com/v1',
+    kind: 'ServiceMonitor',
+    metadata+: {
+      name: tqf.config.name,
+      namespace: tqf.config.namespace,
+      labels: tqf.config.commonLabels,
+    },
+    spec: {
+      selector: {
+        matchLabels: tqf.config.podLabelSelector,
+      },
+      endpoints: [
+        {
+          port: 'http',
+          relabelings: [{
+            action: 'replace',
+            sourceLabels: ['namespace', 'pod'],
+            separator: '/',
+            targetLabel: 'instance',
+          }],
+        },
+      ],
+    },
+  },
+}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-query.libsonnet
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-query.libsonnet
@@ -1,0 +1,294 @@
+// These are the defaults for this components configuration.
+// When calling the function to generate the component's manifest,
+// you can pass an object structured like the default to overwrite default values.
+local defaults = {
+  local defaults = self,
+  name: 'thanos-query',
+  namespace: error 'must provide namespace',
+  version: error 'must provide version',
+  image: error 'must provide image',
+  imagePullPolicy: 'IfNotPresent',
+  replicas: error 'must provide replicas',
+  replicaLabels: error 'must provide replicaLabels',
+  stores: ['dnssrv+_grpc._tcp.thanos-store.%s' % defaults.namespace],
+  rules: [],  // TODO(bwplotka): This is deprecated, switch to endpoints while ready.
+  externalPrefix: '',
+  queryUrl: '',
+  prefixHeader: '',
+  autoDownsampling: true,
+  useThanosEngine: false,
+  resources: {},
+  queryTimeout: '',
+  lookbackDelta: '',
+  ports: {
+    grpc: 10901,
+    http: 9090,
+  },
+  serviceMonitor: false,
+  logLevel: 'info',
+  logFormat: 'logfmt',
+  tracing: {},
+  extraEnv: [],
+  telemetryDurationQuantiles: '',
+  telemetrySamplesQuantiles: '',
+  telemetrySeriesQuantiles: '',
+
+  commonLabels:: {
+    'app.kubernetes.io/name': 'thanos-query',
+    'app.kubernetes.io/instance': defaults.name,
+    'app.kubernetes.io/version': defaults.version,
+    'app.kubernetes.io/component': 'query-layer',
+  },
+
+  podLabelSelector:: {
+    [labelName]: defaults.commonLabels[labelName]
+    for labelName in std.objectFields(defaults.commonLabels)
+    if labelName != 'app.kubernetes.io/version'
+  },
+
+  securityContext:: {
+    fsGroup: 65534,
+    runAsUser: 65534,
+    runAsGroup: 65532,
+    runAsNonRoot: true,
+    seccompProfile: { type: 'RuntimeDefault' },
+  },
+
+  securityContextContainer:: {
+    runAsUser: defaults.securityContext.runAsUser,
+    runAsGroup: defaults.securityContext.runAsGroup,
+    runAsNonRoot: defaults.securityContext.runAsNonRoot,
+    seccompProfile: defaults.securityContext.seccompProfile,
+    allowPrivilegeEscalation: false,
+    readOnlyRootFilesystem: true,
+    capabilities: { drop: ['ALL'] },
+  },
+
+  serviceAccountAnnotations:: {},
+};
+
+function(params) {
+  local tq = self,
+
+  // Combine the defaults and the passed params to make the component's config.
+  config:: defaults + params,
+  // Safety checks for combined config of defaults and params
+  assert std.isNumber(tq.config.replicas) && tq.config.replicas >= 0 : 'thanos query replicas has to be number >= 0',
+  assert std.isArray(tq.config.replicaLabels),
+  assert std.isObject(tq.config.resources),
+  assert std.isString(tq.config.externalPrefix),
+  assert std.isString(tq.config.queryTimeout),
+  assert std.isBoolean(tq.config.serviceMonitor),
+  assert std.isBoolean(tq.config.autoDownsampling),
+  assert std.isBoolean(tq.config.useThanosEngine),
+
+  service: {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+      name: tq.config.name,
+      namespace: tq.config.namespace,
+      labels: tq.config.commonLabels,
+    },
+    spec: {
+      ports: [
+        {
+          assert std.isString(name),
+          assert std.isNumber(tq.config.ports[name]),
+
+          name: name,
+          port: tq.config.ports[name],
+          targetPort: tq.config.ports[name],
+        }
+        for name in std.objectFields(tq.config.ports)
+      ],
+      selector: tq.config.podLabelSelector,
+    },
+  },
+
+  serviceAccount: {
+    apiVersion: 'v1',
+    kind: 'ServiceAccount',
+    metadata: {
+      name: tq.config.name,
+      namespace: tq.config.namespace,
+      labels: tq.config.commonLabels,
+      annotations: tq.config.serviceAccountAnnotations,
+    },
+  },
+
+  deployment:
+    local c = {
+      name: 'thanos-query',
+      image: tq.config.image,
+      imagePullPolicy: tq.config.imagePullPolicy,
+      args:
+        [
+          'query',
+          '--grpc-address=0.0.0.0:%d' % tq.config.ports.grpc,
+          '--http-address=0.0.0.0:%d' % tq.config.ports.http,
+          '--log.level=' + tq.config.logLevel,
+          '--log.format=' + tq.config.logFormat,
+        ] + [
+          '--query.replica-label=%s' % labelName
+          for labelName in tq.config.replicaLabels
+        ] + [
+          '--endpoint=%s' % store
+          for store in tq.config.stores
+        ] + [
+          '--rule=%s' % store
+          for store in tq.config.rules
+        ] +
+        (
+          if tq.config.externalPrefix != '' then [
+            '--web.external-prefix=' + tq.config.externalPrefix,
+          ] else []
+        ) +
+        (
+          if tq.config.prefixHeader != '' then [
+            '--web.prefix-header=' + tq.config.prefixHeader,
+          ] else []
+        ) +
+        (
+          if tq.config.queryTimeout != '' then [
+            '--query.timeout=' + tq.config.queryTimeout,
+          ] else []
+        ) +
+        (
+          if tq.config.lookbackDelta != '' then [
+            '--query.lookback-delta=' + tq.config.lookbackDelta,
+          ] else []
+        ) + (
+          if std.length(tq.config.tracing) > 0 then [
+            '--tracing.config=' + std.manifestYamlDoc(
+              { config+: { service_name: defaults.name } } + tq.config.tracing
+            ),
+          ] else []
+        ) + (
+          if tq.config.autoDownsampling then [
+            '--query.auto-downsampling',
+          ] else []
+        ) + (
+          if tq.config.useThanosEngine then [
+            '--query.promql-engine=thanos',
+          ] else []
+        ) + (
+          if tq.config.telemetryDurationQuantiles != '' then [
+            '--query.telemetry.request-duration-seconds-quantiles=' + std.stripChars(quantile, ' ')
+            for quantile in std.split(tq.config.telemetryDurationQuantiles, ',')
+          ] else []
+        ) + (
+          if tq.config.telemetrySamplesQuantiles != '' then [
+            '--query.telemetry.request-samples-quantiles=' + std.stripChars(quantile, ' ')
+            for quantile in std.split(tq.config.telemetrySamplesQuantiles, ',')
+          ] else []
+        ) + (
+          if tq.config.telemetrySeriesQuantiles != '' then [
+            '--query.telemetry.request-series-seconds-quantiles=' + std.stripChars(quantile, ' ')
+            for quantile in std.split(tq.config.telemetrySeriesQuantiles, ',')
+          ] else []
+        ) + (
+          if tq.config.queryUrl != '' then [
+            '--alert.query-url=' + tq.config.queryUrl,
+          ] else []
+        ),
+      env: [
+        {
+          // Inject the host IP to make configuring tracing convenient.
+          name: 'HOST_IP_ADDRESS',
+          valueFrom: {
+            fieldRef: {
+              fieldPath: 'status.hostIP',
+            },
+          },
+        },
+      ] + (
+        if std.length(tq.config.extraEnv) > 0 then tq.config.extraEnv else []
+      ),
+      ports: [
+        { name: port.name, containerPort: port.port }
+        for port in tq.service.spec.ports
+      ],
+      livenessProbe: { failureThreshold: 4, periodSeconds: 30, httpGet: {
+        scheme: 'HTTP',
+        port: tq.service.spec.ports[1].port,
+        path: '/-/healthy',
+      } },
+      readinessProbe: { failureThreshold: 20, periodSeconds: 5, httpGet: {
+        scheme: 'HTTP',
+        port: tq.service.spec.ports[1].port,
+        path: '/-/ready',
+      } },
+      resources: if tq.config.resources != {} then tq.config.resources else {},
+      securityContext: tq.config.securityContextContainer,
+      terminationMessagePolicy: 'FallbackToLogsOnError',
+    };
+
+    {
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      metadata: {
+        name: tq.config.name,
+        namespace: tq.config.namespace,
+        labels: tq.config.commonLabels,
+      },
+      spec: {
+        replicas: tq.config.replicas,
+        selector: { matchLabels: tq.config.podLabelSelector },
+        template: {
+          metadata: {
+            labels: tq.config.commonLabels,
+          },
+          spec: {
+            containers: [c],
+            securityContext: tq.config.securityContext,
+            serviceAccountName: tq.serviceAccount.metadata.name,
+            terminationGracePeriodSeconds: 120,
+            nodeSelector: {
+              'kubernetes.io/os': 'linux',
+            },
+            affinity: { podAntiAffinity: {
+              preferredDuringSchedulingIgnoredDuringExecution: [{
+                podAffinityTerm: {
+                  namespaces: [tq.config.namespace],
+                  topologyKey: 'kubernetes.io/hostname',
+                  labelSelector: { matchExpressions: [{
+                    key: 'app.kubernetes.io/name',
+                    operator: 'In',
+                    values: [tq.deployment.metadata.labels['app.kubernetes.io/name']],
+                  }] },
+                },
+                weight: 100,
+              }],
+            } },
+          },
+        },
+      },
+    },
+
+  serviceMonitor: if tq.config.serviceMonitor == true then {
+    apiVersion: 'monitoring.coreos.com/v1',
+    kind: 'ServiceMonitor',
+    metadata+: {
+      name: tq.config.name,
+      namespace: tq.config.namespace,
+      labels: tq.config.commonLabels,
+    },
+    spec: {
+      selector: {
+        matchLabels: tq.config.podLabelSelector,
+      },
+      endpoints: [
+        {
+          port: 'http',
+          relabelings: [{
+            action: 'replace',
+            sourceLabels: ['namespace', 'pod'],
+            separator: '/',
+            targetLabel: 'instance',
+          }],
+        },
+      ],
+    },
+  },
+}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-receive-default-params.libsonnet
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-receive-default-params.libsonnet
@@ -1,0 +1,72 @@
+// These are the defaults for this components configuration.
+// When calling the function to generate the component's manifest,
+// you can pass an object structured like the default to overwrite default values.
+{
+  local defaults = self,
+  name: 'thanos-receive',
+  namespace: error 'must provide namespace',
+  version: error 'must provide version',
+  image: error 'must provide image',
+  imagePullPolicy: 'IfNotPresent',
+  replicas: error 'must provide replicas',
+  minReadySeconds: 0,
+  replicationFactor: error 'must provide replication factor',
+  objectStorageConfig: error 'must provide objectStorageConfig',
+  podDisruptionBudgetMaxUnavailable: (std.floor(defaults.replicationFactor / 2)),
+  hashringConfigMapName: '',
+  enableLocalEndpoint: true,
+  volumeClaimTemplate: {},
+  retention: '15d',
+  logLevel: 'info',
+  logFormat: 'logfmt',
+  resources: {},
+  serviceMonitor: false,
+  ports: {
+    grpc: 10901,
+    http: 10902,
+    'remote-write': 19291,
+  },
+  tracing: {},
+  labels: [
+    'replica="$(NAME)"',
+    'receive="true"',
+  ],
+  tenantLabelName: null,
+  tenantHeader: null,
+  extraEnv: [],
+  receiveLimitsConfigFile: {},
+  storeLimits: {},
+
+  commonLabels:: {
+    'app.kubernetes.io/name': 'thanos-receive',
+    'app.kubernetes.io/instance': defaults.name,
+    'app.kubernetes.io/version': defaults.version,
+    'app.kubernetes.io/component': 'database-write-hashring',
+  },
+
+  podLabelSelector:: {
+    [labelName]: defaults.commonLabels[labelName]
+    for labelName in std.objectFields(defaults.commonLabels)
+    if labelName != 'app.kubernetes.io/version'
+  },
+
+  securityContext:: {
+    fsGroup: 65534,
+    runAsUser: 65534,
+    runAsGroup: 65532,
+    runAsNonRoot: true,
+    seccompProfile: { type: 'RuntimeDefault' },
+  },
+
+  securityContextContainer:: {
+    runAsUser: defaults.securityContext.runAsUser,
+    runAsGroup: defaults.securityContext.runAsGroup,
+    runAsNonRoot: defaults.securityContext.runAsNonRoot,
+    seccompProfile: defaults.securityContext.seccompProfile,
+    allowPrivilegeEscalation: false,
+    readOnlyRootFilesystem: true,
+    capabilities: { drop: ['ALL'] },
+  },
+
+  serviceAccountAnnotations:: {},
+}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-receive-hashrings.libsonnet
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-receive-hashrings.libsonnet
@@ -1,0 +1,109 @@
+local receiveConfigDefaults = import 'kube-thanos/kube-thanos-receive-default-params.libsonnet';
+local receive = import 'kube-thanos/kube-thanos-receive.libsonnet';
+
+// These are the defaults for this components configuration.
+// When calling the function to generate the component's manifest,
+// you can pass an object structured like the default to overwrite default values.
+local defaults = receiveConfigDefaults {
+  hashrings: [{
+    hashring: 'default',
+    tenants: [],
+  }],
+};
+
+function(params)
+  // Combine the defaults and the passed params to make the component's config.
+  local config = defaults + params;
+
+  // Safety checks for combined config of defaults and params
+  assert std.isArray(config.hashrings) : 'thanos receive hashrings has to be an array';
+
+  { config:: config } + {
+    local allHashrings = self,
+
+    serviceAccount: {
+      apiVersion: 'v1',
+      kind: 'ServiceAccount',
+      metadata: {
+        name: config.name,
+        namespace: config.namespace,
+        labels: config.commonLabels,
+        annotations: config.serviceAccountAnnotations,
+      },
+    },
+    hashrings: {
+      [h.hashring]: receive(config {
+        name+: '-' + h.hashring,
+        commonLabels+:: {
+          'controller.receive.thanos.io/hashring': h.hashring,
+        },
+      }) {
+        local receiver = self,
+
+        serviceAccount: null,  // one service account for all receivers
+        serviceMonitor: null,  // one service monitor for all receivers
+
+        statefulSet+: {
+          metadata+: {
+            labels+: {
+              'controller.receive.thanos.io': 'thanos-receive-controller',
+            },
+          },
+          spec+: {
+            template+: {
+              spec+: {
+                serviceAccountName: allHashrings.serviceAccount.metadata.name,
+                containers: [
+                  if c.name == 'thanos-receive' then c {
+                    env+: if std.objectHas(receiver.config, 'debug') && receiver.config.debug != '' then [
+                      { name: 'DEBUG', value: receiver.config.debug },
+                    ] else [],
+                  }
+                  else c
+                  for c in super.containers
+                ],
+              },
+            },
+          },
+        },
+      }
+      for h in config.hashrings
+    },
+  } + {
+    serviceMonitor: if config.serviceMonitor == true then {
+      apiVersion: 'monitoring.coreos.com/v1',
+      kind: 'ServiceMonitor',
+      metadata+: {
+        name: config.name,
+        namespace: config.namespace,
+        labels: config.commonLabels,
+      },
+      spec: {
+        selector: {
+          matchLabels: {
+            [key]: config.podLabelSelector[key]
+            for key in std.objectFields(config.podLabelSelector)
+            if key != 'app.kubernetes.io/instance'
+          },
+        },
+        endpoints: [
+          {
+            port: 'http',
+            relabelings: [
+              {
+                action: 'replace',
+                sourceLabels: ['namespace', 'pod'],
+                separator: '/',
+                targetLabel: 'instance',
+              },
+              {
+                action: 'replace',
+                sourceLabels: ['__meta_kubernetes_service_label_controller_receive_thanos_io_shard'],
+                targetLabel: 'hashring',
+              },
+            ],
+          },
+        ],
+      },
+    },
+  }

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-receive-ingestor.libsonnet
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-receive-ingestor.libsonnet
@@ -1,0 +1,46 @@
+local receiveConfigDefaults = import 'kube-thanos/kube-thanos-receive-default-params.libsonnet';
+local receiveHashring = import 'kube-thanos/kube-thanos-receive-hashrings.libsonnet';
+
+local defaults = receiveConfigDefaults {
+  hashrings: [{
+    hashring: 'default',
+    tenants: [],
+  }],
+  hashringConfigMapName: 'hashring-config',
+  routerReplicas: 1,
+};
+
+function(params) {
+  local tr = self,
+  // Combine the defaults and the passed params to make the component's config.
+  config:: defaults + params,
+
+  local ingestors = receiveHashring(tr.config { name: tr.config.name + '-ingestor' }),
+
+  ingestors: {
+    [name]: ingestors.hashrings[name]
+    for name in std.objectFields(ingestors.hashrings)
+  },
+
+  storeEndpoints:: [
+    'dnssrv+_grpc._tcp.%s.%s:%d' % [ingestors.hashrings[name.hashring].service.metadata.name, tr.config.namespace, tr.config.ports.grpc]
+    for name in tr.config.hashrings
+  ],
+
+  endpoints:: {
+    [name.hashring]: [
+      '%s-%d.%s.%s:%d' % [
+        ingestors.hashrings[name.hashring].service.metadata.name,
+        i,
+        ingestors.hashrings[name.hashring].service.metadata.name,
+        tr.config.namespace,
+        tr.config.ports.grpc,
+      ]
+      // Replica specification is 1-based, but statefulSets are named 0-based.
+      for i in std.range(0, tr.config.replicas - 1)
+    ]
+    for name in tr.config.hashrings
+  },
+  serviceAccount: ingestors.serviceAccount,
+  serviceMonitor: if tr.config.serviceMonitor then ingestors.serviceMonitor,
+}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-receive-router.libsonnet
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-receive-router.libsonnet
@@ -1,0 +1,164 @@
+local receiveConfigDefaults = import 'kube-thanos/kube-thanos-receive-default-params.libsonnet';
+
+local defaults = receiveConfigDefaults {
+  hashrings: [{
+    hashring: 'default',
+    tenants: [],
+  }],
+  hashringConfigMapName: 'hashring-config',
+  routerReplicas: 1,
+  endpoints: error 'must provide ingestor endpoints object',
+};
+
+function(params) {
+  local tr = self,
+  // Combine the defaults and the passed params to make the component's config.
+  config:: defaults + params,
+
+  routerLabels:: tr.config.commonLabels {
+    'app.kubernetes.io/component': tr.config.name + '-router',
+  },
+
+  podLabelSelector:: {
+    [labelName]: tr.routerLabels[labelName]
+    for labelName in std.objectFields(tr.routerLabels)
+    if labelName != 'app.kubernetes.io/version'
+  },
+
+  service: {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+      name: tr.config.name + '-router',
+      namespace: tr.config.namespace,
+      labels: tr.routerLabels,
+    },
+    spec: {
+      ports: [
+        {
+          assert std.isString(name),
+          assert std.isNumber(tr.config.ports[name]),
+
+          name: name,
+          port: tr.config.ports[name],
+          targetPort: tr.config.ports[name],
+        }
+        for name in std.objectFields(tr.config.ports)
+      ],
+      selector: tr.routerLabels,
+    },
+  },
+
+  serviceAccount: {
+    apiVersion: 'v1',
+    kind: 'ServiceAccount',
+    metadata: {
+      name: tr.config.name + '-router',
+      namespace: tr.config.namespace,
+      labels: tr.routerLabels,
+      annotations: tr.config.serviceAccountAnnotations,
+    },
+  },
+
+  configmap: {
+    apiVersion: 'v1',
+    kind: 'ConfigMap',
+    metadata: {
+      name: tr.config.hashringConfigMapName,
+      namespace: tr.config.namespace,
+    },
+    data: {
+      'hashrings.json': std.toString([hashring { endpoints: tr.config.endpoints[hashring.hashring] } for hashring in tr.config.hashrings]),
+    },
+  },
+
+  // Create the deployment that acts as a router to the ingestor backends
+  deployment: {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+      name: tr.config.name + '-router',
+      namespace: tr.config.namespace,
+      labels: tr.routerLabels,
+    },
+    spec: {
+      replicas: tr.config.routerReplicas,
+      selector: { matchLabels: tr.podLabelSelector },
+      template: {
+        metadata: {
+          labels: tr.routerLabels,
+        },
+        spec: {
+          serviceAccountName: tr.serviceAccount.metadata.name,
+          securityContext: tr.config.securityContext,
+          containers: [{
+            name: 'thanos-receive',
+            image: tr.config.image,
+            imagePullPolicy: tr.config.imagePullPolicy,
+            args: [
+              'receive',
+              '--log.level=' + tr.config.logLevel,
+              '--log.format=' + tr.config.logFormat,
+              '--grpc-address=0.0.0.0:%d' % tr.config.ports.grpc,
+              '--http-address=0.0.0.0:%d' % tr.config.ports.http,
+              '--remote-write.address=0.0.0.0:%d' % tr.config.ports['remote-write'],
+              '--receive.replication-factor=%d' % tr.config.replicationFactor,
+              '--receive.hashrings-file=/var/lib/thanos-receive/hashrings.json',
+            ] + [
+              '--label=%s' % label
+              for label in tr.config.labels
+            ] + (
+              if tr.config.tenantLabelName != null then [
+                '--receive.tenant-label-name=%s' % tr.config.tenantLabelName,
+              ] else []
+            ) + (
+              if std.length(tr.config.tracing) > 0 then [
+                '--tracing.config=' + std.manifestYamlDoc(
+                  { config+: { service_name: defaults.name } } + tr.config.tracing
+                ),
+              ] else []
+            ),
+            env: [
+              { name: 'NAME', valueFrom: { fieldRef: { fieldPath: 'metadata.name' } } },
+              { name: 'NAMESPACE', valueFrom: { fieldRef: { fieldPath: 'metadata.namespace' } } },
+              {
+                // Inject the host IP to make configuring tracing convenient.
+                name: 'HOST_IP_ADDRESS',
+                valueFrom: {
+                  fieldRef: {
+                    fieldPath: 'status.hostIP',
+                  },
+                },
+              },
+            ] + (
+              if std.length(tr.config.extraEnv) > 0 then tr.config.extraEnv else []
+            ),
+            ports: [{ name: name, containerPort: tr.config.ports[name] } for name in std.objectFields(tr.config.ports)],
+            volumeMounts: [{ name: 'hashring-config', mountPath: '/var/lib/thanos-receive' }],
+            livenessProbe: { failureThreshold: 8, periodSeconds: 30, httpGet: {
+              scheme: 'HTTP',
+              port: tr.config.ports.http,
+              path: '/-/healthy',
+            } },
+            readinessProbe: { failureThreshold: 20, periodSeconds: 5, httpGet: {
+              scheme: 'HTTP',
+              port: tr.config.ports.http,
+              path: '/-/ready',
+            } },
+            resources: if tr.config.resources != {} then tr.config.resources else {},
+            securityContext: tr.config.securityContextContainer,
+            terminationMessagePolicy: 'FallbackToLogsOnError',
+          }],
+          volumes: [{
+            name: 'hashring-config',
+            configMap: { name: tr.config.hashringConfigMapName },
+          }],
+          terminationGracePeriodSeconds: 30,
+          nodeSelector: {
+            'kubernetes.io/os': 'linux',
+          },
+        },
+      },
+    },
+  },
+}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -1,0 +1,295 @@
+local defaults = import 'kube-thanos/kube-thanos-receive-default-params.libsonnet';
+
+function(params) {
+  local tr = self,
+
+  // Combine the defaults and the passed params to make the component's config.
+  config:: defaults + params,
+  // Safety checks for combined config of defaults and params
+  assert std.isNumber(tr.config.replicas) && tr.config.replicas >= 0 : 'thanos receive replicas has to be number >= 0',
+  assert std.isArray(tr.config.replicaLabels),
+  assert std.isObject(tr.config.resources),
+  assert std.isBoolean(tr.config.serviceMonitor),
+  assert std.isObject(tr.config.volumeClaimTemplate),
+  assert !std.objectHas(tr.config.volumeClaimTemplate, 'spec') || std.assertEqual(tr.config.volumeClaimTemplate.spec.accessModes, ['ReadWriteOnce']) : 'thanos receive PVC accessMode can only be ReadWriteOnce',
+  assert std.isNumber(tr.config.minReadySeconds),
+  assert std.isObject(tr.config.receiveLimitsConfigFile),
+  assert std.isObject(tr.config.storeLimits),
+
+  service: {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+      name: tr.config.name,
+      namespace: tr.config.namespace,
+      labels: tr.config.commonLabels,
+    },
+    spec: {
+      clusterIP: 'None',
+      ports: [
+        {
+          assert std.isString(name),
+          assert std.isNumber(tr.config.ports[name]),
+
+          name: name,
+          port: tr.config.ports[name],
+          targetPort: tr.config.ports[name],
+        }
+        for name in std.objectFields(tr.config.ports)
+      ],
+      selector: tr.config.podLabelSelector,
+    },
+  },
+
+  serviceAccount: {
+    apiVersion: 'v1',
+    kind: 'ServiceAccount',
+    metadata: {
+      name: tr.config.name,
+      namespace: tr.config.namespace,
+      labels: tr.config.commonLabels,
+      annotations: tr.config.serviceAccountAnnotations,
+    },
+  },
+
+  statefulSet:
+    local localEndpointFlag = '--receive.local-endpoint=$(NAME).%s.$(NAMESPACE):%d' % [
+      tr.config.name,
+      tr.config.ports.grpc,
+    ];
+
+    local c = {
+      name: 'thanos-receive',
+      image: tr.config.image,
+      imagePullPolicy: tr.config.imagePullPolicy,
+      args: [
+        'receive',
+        '--log.level=' + tr.config.logLevel,
+        '--log.format=' + tr.config.logFormat,
+        '--grpc-address=0.0.0.0:%d' % tr.config.ports.grpc,
+        '--http-address=0.0.0.0:%d' % tr.config.ports.http,
+        '--remote-write.address=0.0.0.0:%d' % tr.config.ports['remote-write'],
+        '--receive.replication-factor=%d' % tr.config.replicationFactor,
+        '--tsdb.path=/var/thanos/receive',
+        '--tsdb.retention=' + tr.config.retention,
+      ] + [
+        '--label=%s' % label
+        for label in tr.config.labels
+      ] + (
+        if tr.config.objectStorageConfig != null then [
+          '--objstore.config=$(OBJSTORE_CONFIG)',
+        ] else []
+      ) + (
+        if tr.config.enableLocalEndpoint then [
+          localEndpointFlag,
+        ] else []
+      ) + (
+        if tr.config.tenantLabelName != null then [
+          '--receive.tenant-label-name=%s' % tr.config.tenantLabelName,
+        ] else []
+      ) + (
+        if tr.config.tenantHeader != null then [
+          '--receive.tenant-header=%s' % tr.config.tenantHeader,
+        ] else []
+      ) + (
+        if tr.config.hashringConfigMapName != '' then [
+          '--receive.hashrings-file=/var/lib/thanos-receive/hashrings.json',
+        ] else []
+      ) + (
+        if std.objectHas(tr.config.storeLimits, 'requestSamples') then [
+          '--store.limits.request-samples=%s' % tr.config.storeLimits.requestSamples,
+        ] else []
+      ) + (
+        if std.objectHas(tr.config.storeLimits, 'requestSeries') then [
+          '--store.limits.request-series=%s' % tr.config.storeLimits.requestSeries,
+        ] else []
+      ) + (
+        if std.length(tr.config.tracing) > 0 then [
+          '--tracing.config=' + std.manifestYamlDoc(
+            { config+: { service_name: defaults.name } } + tr.config.tracing
+          ),
+        ] else []
+      ) + (
+        if tr.config.receiveLimitsConfigFile != {} then [
+          '--receive.limits-config-file=/etc/thanos/config/' + tr.config.receiveLimitsConfigFile.name + '/' + tr.config.receiveLimitsConfigFile.key,
+        ]
+        else []
+      ),
+      env: [
+        { name: 'NAME', valueFrom: { fieldRef: { fieldPath: 'metadata.name' } } },
+        { name: 'NAMESPACE', valueFrom: { fieldRef: { fieldPath: 'metadata.namespace' } } },
+        {
+          // Inject the host IP to make configuring tracing convenient.
+          name: 'HOST_IP_ADDRESS',
+          valueFrom: {
+            fieldRef: {
+              fieldPath: 'status.hostIP',
+            },
+          },
+        },
+      ] + (
+        if tr.config.objectStorageConfig != null then [{
+          name: 'OBJSTORE_CONFIG',
+          valueFrom: { secretKeyRef: {
+            key: tr.config.objectStorageConfig.key,
+            name: tr.config.objectStorageConfig.name,
+          } },
+        }] else []
+      ) + (
+        if std.length(tr.config.extraEnv) > 0 then tr.config.extraEnv else []
+      ),
+      ports: [
+        { name: name, containerPort: tr.config.ports[name] }
+        for name in std.objectFields(tr.config.ports)
+      ],
+      volumeMounts: [{
+        name: 'data',
+        mountPath: '/var/thanos/receive',
+        readOnly: false,
+      }] + (
+        if tr.config.hashringConfigMapName != '' then [
+          { name: 'hashring-config', mountPath: '/var/lib/thanos-receive' },
+        ] else []
+      ) + (
+        if tr.config.objectStorageConfig != null && std.objectHas(tr.config.objectStorageConfig, 'tlsSecretName') && std.length(tr.config.objectStorageConfig.tlsSecretName) > 0 then [
+          { name: 'tls-secret', mountPath: tr.config.objectStorageConfig.tlsSecretMountPath },
+        ] else []
+      ) + (
+        if tr.config.receiveLimitsConfigFile != {} then [
+          { name: tr.config.receiveLimitsConfigFile.name, mountPath: '/etc/thanos/config/' + tr.config.receiveLimitsConfigFile.name, readOnly: true },
+        ] else []
+      ),
+      livenessProbe: { failureThreshold: 8, periodSeconds: 30, httpGet: {
+        scheme: 'HTTP',
+        port: tr.config.ports.http,
+        path: '/-/healthy',
+      } },
+      readinessProbe: { failureThreshold: 20, periodSeconds: 5, httpGet: {
+        scheme: 'HTTP',
+        port: tr.config.ports.http,
+        path: '/-/ready',
+      } },
+      resources: if tr.config.resources != {} then tr.config.resources else {},
+      terminationMessagePolicy: 'FallbackToLogsOnError',
+    };
+
+    {
+      apiVersion: 'apps/v1',
+      kind: 'StatefulSet',
+      metadata: {
+        name: tr.config.name,
+        namespace: tr.config.namespace,
+        labels: tr.config.commonLabels,
+      },
+      spec: {
+        replicas: tr.config.replicas,
+        minReadySeconds: tr.config.minReadySeconds,
+        selector: { matchLabels: tr.config.podLabelSelector },
+        serviceName: tr.service.metadata.name,
+        template: {
+          metadata: {
+            labels: tr.config.commonLabels,
+          },
+          spec: {
+            serviceAccountName: tr.serviceAccount.metadata.name,
+            securityContext: tr.config.securityContext,
+            containers: [c],
+            volumes: (
+              if tr.config.hashringConfigMapName != '' then [{
+                name: 'hashring-config',
+                configMap: { name: tr.config.hashringConfigMapName },
+              }] else []
+            ) + (
+              if tr.config.objectStorageConfig != null && std.objectHas(tr.config.objectStorageConfig, 'tlsSecretName') && std.length(tr.config.objectStorageConfig.tlsSecretName) > 0 then [{
+                name: 'tls-secret',
+                secret: { secretName: tr.config.objectStorageConfig.tlsSecretName },
+              }] else []
+            ) + (
+              if tr.config.receiveLimitsConfigFile != {} then [{
+                name: tr.config.receiveLimitsConfigFile.name,
+                configMap: { name: tr.config.receiveLimitsConfigFile.name },
+              }] else []
+            ),
+            terminationGracePeriodSeconds: 900,
+            nodeSelector: {
+              'kubernetes.io/os': 'linux',
+            },
+            affinity: { podAntiAffinity: {
+              local labelSelector = { matchExpressions: [{
+                key: 'app.kubernetes.io/name',
+                operator: 'In',
+                values: [tr.statefulSet.metadata.labels['app.kubernetes.io/name']],
+              }, {
+                key: 'app.kubernetes.io/instance',
+                operator: 'In',
+                values: [tr.statefulSet.metadata.labels['app.kubernetes.io/instance']],
+              }] },
+              preferredDuringSchedulingIgnoredDuringExecution: [
+                {
+                  podAffinityTerm: {
+                    namespaces: [tr.config.namespace],
+                    topologyKey: 'kubernetes.io/hostname',
+                    labelSelector: labelSelector,
+                  },
+                  weight: 100,
+                },
+                {
+                  podAffinityTerm: {
+                    namespaces: [tr.config.namespace],
+                    topologyKey: 'topology.kubernetes.io/zone',
+                    labelSelector: labelSelector,
+                  },
+                  weight: 100,
+                },
+              ],
+            } },
+          },
+        },
+        volumeClaimTemplates: if std.length(tr.config.volumeClaimTemplate) > 0 then [tr.config.volumeClaimTemplate {
+          metadata+: {
+            name: 'data',
+            labels+: tr.config.podLabelSelector,
+          },
+        }] else [],
+      },
+    },
+
+  serviceMonitor: if tr.config.serviceMonitor == true then {
+    apiVersion: 'monitoring.coreos.com/v1',
+    kind: 'ServiceMonitor',
+    metadata+: {
+      name: tr.config.name,
+      namespace: tr.config.namespace,
+      labels: tr.config.commonLabels,
+    },
+    spec: {
+      selector: {
+        matchLabels: tr.config.podLabelSelector,
+      },
+      endpoints: [
+        {
+          port: 'http',
+          relabelings: [{
+            action: 'replace',
+            sourceLabels: ['namespace', 'pod'],
+            separator: '/',
+            targetLabel: 'instance',
+          }],
+        },
+      ],
+    },
+  },
+
+  podDisruptionBudget: if tr.config.podDisruptionBudgetMaxUnavailable >= 1 then {
+    apiVersion: 'policy/v1',
+    kind: 'PodDisruptionBudget',
+    metadata: {
+      name: tr.config.name,
+      namespace: tr.config.namespace,
+    },
+    spec: {
+      maxUnavailable: tr.config.podDisruptionBudgetMaxUnavailable,
+      selector: { matchLabels: tr.config.podLabelSelector },
+    },
+  } else null,
+}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-rule.libsonnet
@@ -1,0 +1,403 @@
+// These are the defaults for this components configuration.
+// When calling the function to generate the component's manifest,
+// you can pass an object structured like the default to overwrite default values.
+local defaults = {
+  local defaults = self,
+  name: 'thanos-rule',
+  namespace: error 'must provide namespace',
+  version: error 'must provide version',
+  image: error 'must provide image',
+  imagePullPolicy: 'IfNotPresent',
+  replicas: error 'must provide replicas',
+  reloaderImage: error 'must provide reloader image',
+  reloaderImagePullPolicy: 'IfNotPresent',
+  objectStorageConfig: error 'must provide objectStorageConfig',
+  ruleFiles: [],
+  rulesConfig: [],
+  remoteWriteConfigFile: {},
+  alertmanagersURLs: [],
+  alertmanagerConfigFile: {},
+  extraVolumeMounts: [],
+  queriers: [],
+  logLevel: 'info',
+  logFormat: 'logfmt',
+  resources: {},
+  retention: '48h',
+  blockDuration: '2h',
+  serviceMonitor: false,
+  ports: {
+    grpc: 10901,
+    http: 10902,
+    reloader: 9533,
+  },
+  tracing: {},
+  extraEnv: [],
+
+  commonLabels:: {
+    'app.kubernetes.io/name': 'thanos-rule',
+    'app.kubernetes.io/instance': defaults.name,
+    'app.kubernetes.io/version': defaults.version,
+    'app.kubernetes.io/component': 'rule-evaluation-engine',
+  },
+
+  podLabelSelector:: {
+    [labelName]: defaults.commonLabels[labelName]
+    for labelName in std.objectFields(defaults.commonLabels)
+    if labelName != 'app.kubernetes.io/version'
+  },
+
+  securityContext:: {
+    fsGroup: 65534,
+    runAsUser: 65534,
+    runAsGroup: 65532,
+    runAsNonRoot: true,
+    seccompProfile: { type: 'RuntimeDefault' },
+  },
+
+  securityContextContainer:: {
+    runAsUser: defaults.securityContext.runAsUser,
+    runAsGroup: defaults.securityContext.runAsGroup,
+    runAsNonRoot: defaults.securityContext.runAsNonRoot,
+    seccompProfile: defaults.securityContext.seccompProfile,
+    allowPrivilegeEscalation: false,
+    readOnlyRootFilesystem: true,
+    capabilities: { drop: ['ALL'] },
+  },
+
+  serviceAccountAnnotations:: {},
+};
+
+function(params) {
+  local tr = self,
+
+  // Combine the defaults and the passed params to make the component's config.
+  config:: defaults + params,
+  // Safety checks for combined config of defaults and params
+  assert std.isNumber(tr.config.replicas) && tr.config.replicas >= 0 : 'thanos rule replicas has to be number >= 0',
+  assert std.isArray(tr.config.ruleFiles),
+  assert std.isArray(tr.config.rulesConfig),
+  assert std.isObject(tr.config.remoteWriteConfigFile),
+  assert std.isArray(tr.config.alertmanagersURLs),
+  assert std.isObject(tr.config.alertmanagerConfigFile),
+  assert std.isArray(tr.config.extraVolumeMounts),
+  assert std.isObject(tr.config.resources),
+  assert std.isBoolean(tr.config.serviceMonitor),
+  assert std.isObject(tr.config.volumeClaimTemplate),
+  assert !std.objectHas(tr.config.volumeClaimTemplate, 'spec') || std.assertEqual(tr.config.volumeClaimTemplate.spec.accessModes, ['ReadWriteOnce']) : 'thanos rule PVC accessMode can only be ReadWriteOnce',
+
+
+  service: {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+      name: tr.config.name,
+      namespace: tr.config.namespace,
+      labels: tr.config.commonLabels,
+    },
+    spec: {
+      ports: [
+        {
+          assert std.isString(name),
+          assert std.isNumber(tr.config.ports[name]),
+
+          name: name,
+          port: tr.config.ports[name],
+          targetPort: tr.config.ports[name],
+        }
+        for name in std.objectFields(tr.config.ports)
+      ],
+      clusterIP: 'None',
+      selector: tr.config.podLabelSelector,
+    },
+  },
+
+  serviceAccount: {
+    apiVersion: 'v1',
+    kind: 'ServiceAccount',
+    metadata: {
+      name: tr.config.name,
+      namespace: tr.config.namespace,
+      labels: tr.config.commonLabels,
+      annotations: tr.config.serviceAccountAnnotations,
+    },
+  },
+
+  statefulSet:
+    local c = {
+      name: 'thanos-rule',
+      image: tr.config.image,
+      imagePullPolicy: tr.config.imagePullPolicy,
+      args:
+        [
+          'rule',
+          '--log.level=' + tr.config.logLevel,
+          '--log.format=' + tr.config.logFormat,
+          '--grpc-address=0.0.0.0:%d' % tr.config.ports.grpc,
+          '--http-address=0.0.0.0:%d' % tr.config.ports.http,
+          '--objstore.config=$(OBJSTORE_CONFIG)',
+          '--data-dir=/var/thanos/rule',
+          '--label=rule_replica="$(NAME)"',
+          '--alert.label-drop=rule_replica',
+          '--tsdb.retention=' + tr.config.retention,
+          '--tsdb.block-duration=' + tr.config.blockDuration,
+        ] +
+        (['--query=%s' % querier for querier in tr.config.queriers]) +
+        (['--rule-file=%s' % path for path in tr.config.ruleFiles]) +
+        (['--alertmanagers.url=%s' % url for url in tr.config.alertmanagersURLs]) +
+        (
+          if tr.config.alertmanagerConfigFile != {} then [
+            '--alertmanagers.config-file=/etc/thanos/config/' + tr.config.alertmanagerConfigFile.name + '/' + tr.config.alertmanagerConfigFile.key,
+          ]
+          else []
+        ) + (
+          if std.length(tr.config.rulesConfig) > 0 then [
+            '--rule-file=/etc/thanos/rules/' + ruleConfig.name + '/' + ruleConfig.key
+            for ruleConfig in tr.config.rulesConfig
+          ]
+          else []
+        ) + (
+          if std.length(tr.config.tracing) > 0 then [
+            '--tracing.config=' + std.manifestYamlDoc(
+              { config+: { service_name: defaults.name } } + tr.config.tracing
+            ),
+          ] else []
+        ) + (
+          if tr.config.remoteWriteConfigFile != {} then [
+            '--remote-write.config-file=/etc/thanos/config/' + tr.config.remoteWriteConfigFile.name + '/' + tr.config.remoteWriteConfigFile.key,
+          ]
+          else []
+        ),
+      env: [
+        { name: 'NAME', valueFrom: { fieldRef: { fieldPath: 'metadata.name' } } },
+        { name: 'OBJSTORE_CONFIG', valueFrom: { secretKeyRef: {
+          key: tr.config.objectStorageConfig.key,
+          name: tr.config.objectStorageConfig.name,
+        } } },
+        {
+          // Inject the host IP to make configuring tracing convenient.
+          name: 'HOST_IP_ADDRESS',
+          valueFrom: {
+            fieldRef: {
+              fieldPath: 'status.hostIP',
+            },
+          },
+        },
+      ] + (
+        if std.length(tr.config.extraEnv) > 0 then tr.config.extraEnv else []
+      ),
+      ports: [
+        { name: name, containerPort: tr.config.ports[name] }
+        for name in std.objectFields(tr.config.ports)
+      ],
+      volumeMounts: [{
+        name: 'data',
+        mountPath: '/var/thanos/rule',
+        readOnly: false,
+      }] + (
+        if std.length(tr.config.rulesConfig) > 0 then [
+          { name: ruleConfig.name, mountPath: '/etc/thanos/rules/' + ruleConfig.name }
+          for ruleConfig in tr.config.rulesConfig
+        ] else []
+      ) + (
+        if tr.config.alertmanagerConfigFile != {} then [
+          { name: tr.config.alertmanagerConfigFile.name, mountPath: '/etc/thanos/config/' + tr.config.alertmanagerConfigFile.name, readOnly: true },
+        ] else []
+      ) + (
+        if std.length(tr.config.extraVolumeMounts) > 0 then [
+          { name: volumeMount.name, mountPath: volumeMount.mountPath }
+          for volumeMount in tr.config.extraVolumeMounts
+        ] else []
+      ) + (
+        if tr.config.objectStorageConfig != null && std.objectHas(tr.config.objectStorageConfig, 'tlsSecretName') && std.length(tr.config.objectStorageConfig.tlsSecretName) > 0 then [
+          { name: 'tls-secret', mountPath: tr.config.objectStorageConfig.tlsSecretMountPath },
+        ] else []
+      ) + (
+        if tr.config.remoteWriteConfigFile != {} then [
+          { name: tr.config.remoteWriteConfigFile.name, mountPath: '/etc/thanos/config/' + tr.config.remoteWriteConfigFile.name, readOnly: true },
+        ] else []
+      ),
+      livenessProbe: { failureThreshold: 24, periodSeconds: 5, httpGet: {
+        scheme: 'HTTP',
+        port: tr.config.ports.http,
+        path: '/-/healthy',
+      } },
+      readinessProbe: { failureThreshold: 18, periodSeconds: 5, initialDelaySeconds: 10, httpGet: {
+        scheme: 'HTTP',
+        port: tr.config.ports.http,
+        path: '/-/ready',
+
+      } },
+      resources: if tr.config.resources != {} then tr.config.resources else {},
+      securityContext: tr.config.securityContextContainer,
+      terminationMessagePolicy: 'FallbackToLogsOnError',
+    };
+
+    local reloadContainer = {
+      name: 'configmap-reloader',
+      image: tr.config.reloaderImage,
+      imagePullPolicy: tr.config.reloaderImagePullPolicy,
+      args:
+        [
+          '-webhook-url=http://localhost:' + tr.service.spec.ports[1].port + '/-/reload',
+        ] +
+        (
+          if std.length(tr.config.rulesConfig) > 0 then [
+            '-volume-dir=/etc/thanos/rules/' + ruleConfig.name
+            for ruleConfig in tr.config.rulesConfig
+          ] else []
+        ) + (
+          if tr.config.alertmanagerConfigFile != {} then [
+            '-volume-dir=/etc/thanos/config/' + tr.config.alertmanagerConfigFile.name,
+          ] else []
+        ) + (
+          if std.length(tr.config.extraVolumeMounts) > 0 then [
+            '-volume-dir=' + volumeMount.mountPath
+            for volumeMount in tr.config.extraVolumeMounts
+          ] else []
+        ) + (
+          if tr.config.remoteWriteConfigFile != {} then [
+            '-volume-dir=/etc/thanos/config/' + tr.config.remoteWriteConfigFile.name,
+          ] else []
+        ),
+      volumeMounts: [
+        { name: ruleConfig.name, mountPath: '/etc/thanos/rules/' + ruleConfig.name }
+        for ruleConfig in tr.config.rulesConfig
+      ] + (
+        if tr.config.alertmanagerConfigFile != {} then [
+          { name: tr.config.alertmanagerConfigFile.name, mountPath: '/etc/thanos/config/' + tr.config.alertmanagerConfigFile.name },
+        ] else []
+      ) + (
+        if std.length(tr.config.extraVolumeMounts) > 0 then [
+          { name: volumeMount.name, mountPath: volumeMount.mountPath }
+          for volumeMount in tr.config.extraVolumeMounts
+        ] else []
+      ) + (
+        if tr.config.remoteWriteConfigFile != {} then [
+          { name: tr.config.remoteWriteConfigFile.name, mountPath: '/etc/thanos/config/' + tr.config.remoteWriteConfigFile.name },
+        ] else []
+      ),
+    };
+
+    {
+      apiVersion: 'apps/v1',
+      kind: 'StatefulSet',
+      metadata: {
+        name: tr.config.name,
+        namespace: tr.config.namespace,
+        labels: tr.config.commonLabels,
+      },
+      spec: {
+        replicas: tr.config.replicas,
+        selector: { matchLabels: tr.config.podLabelSelector },
+        serviceName: tr.service.metadata.name,
+        template: {
+          metadata: {
+            labels: tr.config.commonLabels,
+          },
+          spec: {
+            serviceAccountName: tr.serviceAccount.metadata.name,
+            securityContext: tr.config.securityContext,
+            containers: [c] +
+                        (
+                          if std.length(tr.config.rulesConfig) > 0 || std.length(tr.config.extraVolumeMounts) > 0 || tr.config.alertmanagerConfigFile != {} || tr.config.remoteWriteConfigFile != {} then [
+                            reloadContainer,
+                          ] else []
+                        ),
+            volumes:
+              [] +
+              (
+                if std.length(tr.config.rulesConfig) > 0 then [
+                  { name: ruleConfig.name, configMap: { name: ruleConfig.name } }
+                  for ruleConfig in tr.config.rulesConfig
+                ] else []
+              ) + (
+                if tr.config.alertmanagerConfigFile != {} then [{
+                  name: tr.config.alertmanagerConfigFile.name,
+                  configMap: { name: tr.config.alertmanagerConfigFile.name },
+                }] else []
+              ) + (
+                if tr.config.remoteWriteConfigFile != {} then [{
+                  name: tr.config.remoteWriteConfigFile.name,
+                  configMap: { name: tr.config.remoteWriteConfigFile.name },
+                }] else []
+              ) + (
+                if std.length(tr.config.extraVolumeMounts) > 0 then [
+                  { name: volumeMount.name } +
+                  (
+                    if volumeMount.type == 'configMap' then {
+                      configMap: { name: volumeMount.name },
+                    }
+                    else {
+                      secret: { name: volumeMount.name },
+                    }
+                  )
+                  for volumeMount in tr.config.extraVolumeMounts
+                ] else []
+              ) + (
+                if tr.config.objectStorageConfig != null && std.objectHas(tr.config.objectStorageConfig, 'tlsSecretName') && std.length(tr.config.objectStorageConfig.tlsSecretName) > 0 then [{
+                  name: 'tls-secret',
+                  secret: { secretName: tr.config.objectStorageConfig.tlsSecretName },
+                }] else []
+              ),
+            nodeSelector: {
+              'kubernetes.io/os': 'linux',
+            },
+            affinity: { podAntiAffinity: {
+              local labelSelector = { matchExpressions: [{
+                key: 'app.kubernetes.io/name',
+                operator: 'In',
+                values: [tr.statefulSet.metadata.labels['app.kubernetes.io/name']],
+              }, {
+                key: 'app.kubernetes.io/instance',
+                operator: 'In',
+                values: [tr.statefulSet.metadata.labels['app.kubernetes.io/instance']],
+              }] },
+              preferredDuringSchedulingIgnoredDuringExecution: [
+                {
+                  podAffinityTerm: {
+                    namespaces: [tr.config.namespace],
+                    topologyKey: 'kubernetes.io/hostname',
+                    labelSelector: labelSelector,
+                  },
+                  weight: 100,
+                },
+              ],
+            } },
+          },
+        },
+        volumeClaimTemplates: if std.length(tr.config.volumeClaimTemplate) > 0 then [tr.config.volumeClaimTemplate {
+          metadata+: {
+            name: 'data',
+            labels+: tr.config.podLabelSelector,
+          },
+        }] else [],
+      },
+    },
+
+  serviceMonitor: if tr.config.serviceMonitor == true then {
+    apiVersion: 'monitoring.coreos.com/v1',
+    kind: 'ServiceMonitor',
+    metadata+: {
+      name: tr.config.name,
+      namespace: tr.config.namespace,
+      labels: tr.config.commonLabels,
+    },
+    spec: {
+      selector: {
+        matchLabels: tr.config.podLabelSelector,
+      },
+      endpoints: [
+        {
+          port: 'http',
+          relabelings: [{
+            action: 'replace',
+            sourceLabels: ['namespace', 'pod'],
+            separator: '/',
+            targetLabel: 'instance',
+          }],
+        },
+        { port: 'reloader' },
+      ],
+    },
+  },
+}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-sidecar.libsonnet
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-sidecar.libsonnet
@@ -1,0 +1,83 @@
+// These are the defaults for this components configuration.
+// When calling the function to generate the component's manifest,
+// you can pass an object structured like the default to overwrite default values.
+local defaults = {
+  local defaults = self,
+  name: 'thanos-sidecar',
+  namespace: error 'must provide namespace',
+  version: error 'must provide version',
+  serviceMonitor: false,
+  ports: {
+    grpc: 10901,
+    http: 10902,
+  },
+
+  commonLabels:: {
+    'app.kubernetes.io/name': 'thanos-sidecar',
+    'app.kubernetes.io/instance': defaults.name,
+    'app.kubernetes.io/version': defaults.version,
+    'app.kubernetes.io/component': 'prometheus-sidecar',
+  },
+
+  podLabelSelector:: error 'must provide podLabelSelector',
+
+  serviceLabelSelector:: {
+    [labelName]: defaults.commonLabels[labelName]
+    for labelName in std.objectFields(defaults.commonLabels)
+    if !std.setMember(labelName, ['app.kubernetes.io/version'])
+  },
+};
+
+function(params) {
+  local tsc = self,
+  config:: defaults + params,
+
+  service: {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+      name: tsc.config.name,
+      namespace: tsc.config.namespace,
+      labels: tsc.config.commonLabels,
+    },
+    spec: {
+      clusterIP: 'None',
+      selector: tsc.config.podLabelSelector,
+      ports: [
+        {
+          assert std.isString(name),
+          assert std.isNumber(tsc.config.ports[name]),
+
+          name: name,
+          port: tsc.config.ports[name],
+          targetPort: tsc.config.ports[name],
+        }
+        for name in std.objectFields(tsc.config.ports)
+      ],
+    },
+  },
+
+  serviceMonitor: if tsc.config.serviceMonitor == true then {
+    apiVersion: 'monitoring.coreos.com/v1',
+    kind: 'ServiceMonitor',
+    metadata+: {
+      name: tsc.config.name,
+      namespace: tsc.config.namespace,
+      labels: tsc.config.commonLabels,
+    },
+    spec: {
+      selector: {
+        matchLabels: tsc.config.serviceLabelSelector,
+      },
+      endpoints: [{
+        port: 'http',
+        relabelings: [{
+          action: 'replace',
+          sourceLabels: ['namespace', 'pod'],
+          separator: '/',
+          targetLabel: 'instance',
+        }],
+      }],
+    },
+  },
+}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-store-default-params.libsonnet
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-store-default-params.libsonnet
@@ -1,0 +1,101 @@
+// These are the defaults for this components configuration.
+// When calling the function to generate the component's manifest,
+// you can pass an object structured like the default to overwrite default values.
+{
+  local defaults = self,
+  name: 'thanos-store',
+  namespace: error 'must provide namespace',
+  version: error 'must provide version',
+  image: error 'must provide image',
+  imagePullPolicy: 'IfNotPresent',
+  replicas: error 'must provide replicas',
+  limits: {
+    seriesTouched: 0,
+    seriesSample: 0,
+    downloadedBytes: 0,
+  },
+  objectStorageConfig: error 'must provide objectStorageConfig',
+  ignoreDeletionMarksDelay: '24h',
+  logLevel: 'info',
+  logFormat: 'logfmt',
+  resources: {},
+  volumeClaimTemplate: {},
+  serviceMonitor: false,
+  bucketCache: {},
+  indexCache: {},
+  ports: {
+    grpc: 10901,
+    http: 10902,
+  },
+  livenessProbe: {
+    timeoutSeconds: 1,
+    failureThreshold: 8,
+    periodSeconds: 30,
+  },
+  tracing: {},
+  minTime: '',
+  maxTime: '',
+  extraEnv: [],
+
+  memcachedDefaults+:: {
+    config+: {
+      // List of memcached addresses, that will get resolved with the DNS service discovery provider.
+      // For DNS service discovery reference https://thanos.io/service-discovery.md/#dns-service-discovery
+      addresses+: error 'must provide memcached addresses',
+      timeout: '500ms',
+      max_idle_connections: 100,
+      max_async_concurrency: 20,
+      max_async_buffer_size: 10000,
+      max_item_size: '1MiB',
+      max_get_multi_concurrency: 100,
+      max_get_multi_batch_size: 0,
+      dns_provider_update_interval: '10s',
+    },
+  },
+
+  indexCacheDefaults+:: {},
+
+  bucketCacheMemcachedDefaults+:: {
+    chunk_subrange_size: 16000,
+    max_chunks_get_range_requests: 3,
+    chunk_object_attrs_ttl: '24h',
+    chunk_subrange_ttl: '24h',
+    blocks_iter_ttl: '5m',
+    metafile_exists_ttl: '2h',
+    metafile_doesnt_exist_ttl: '15m',
+    metafile_content_ttl: '24h',
+    metafile_max_size: '1MiB',
+  },
+
+  commonLabels:: {
+    'app.kubernetes.io/name': 'thanos-store',
+    'app.kubernetes.io/instance': defaults.name,
+    'app.kubernetes.io/version': defaults.version,
+    'app.kubernetes.io/component': 'object-store-gateway',
+  },
+
+  podLabelSelector:: {
+    [labelName]: defaults.commonLabels[labelName]
+    for labelName in std.objectFields(defaults.commonLabels)
+    if labelName != 'app.kubernetes.io/version'
+  },
+
+  securityContext:: {
+    fsGroup: 65534,
+    runAsUser: 65534,
+    runAsGroup: 65532,
+    runAsNonRoot: true,
+    seccompProfile: { type: 'RuntimeDefault' },
+  },
+  securityContextContainer:: {
+    runAsUser: defaults.securityContext.runAsUser,
+    runAsGroup: defaults.securityContext.runAsGroup,
+    runAsNonRoot: defaults.securityContext.runAsNonRoot,
+    seccompProfile: defaults.securityContext.seccompProfile,
+    allowPrivilegeEscalation: false,
+    readOnlyRootFilesystem: true,
+    capabilities: { drop: ['ALL'] },
+  },
+
+  serviceAccountAnnotations:: {},
+}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-store-shards.libsonnet
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-store-shards.libsonnet
@@ -1,0 +1,108 @@
+local storeConfigDefaults = import 'kube-thanos/kube-thanos-store-default-params.libsonnet';
+local store = import 'kube-thanos/kube-thanos-store.libsonnet';
+
+// These are the defaults for this components configuration.
+// When calling the function to generate the component's manifest,
+// you can pass an object structured like the default to overwrite default values.
+local defaults = storeConfigDefaults {
+  shards: 1,
+};
+
+function(params)
+  // Combine the defaults and the passed params to make the component's config.
+  local config = defaults + params;
+
+  // Safety checks for combined config of defaults and params
+  assert std.isNumber(config.shards) && config.shards >= 0 : 'thanos store shards has to be number >= 0';
+
+  { config:: config } + {
+    local allShards = self,
+
+    serviceAccount: {
+      apiVersion: 'v1',
+      kind: 'ServiceAccount',
+      metadata: {
+        name: config.name,
+        namespace: config.namespace,
+        labels: config.commonLabels,
+        annotations: config.serviceAccountAnnotations,
+      },
+    },
+
+    shards: {
+      ['shard' + i]: store(config {
+        name+: '-%d' % i,
+        commonLabels+:: { 'store.thanos.io/shard': 'shard-' + i },
+      }) {
+        serviceAccount: null,  // one service account for all stores
+        serviceMonitor: null,  // one service monitor foal all stores
+
+        statefulSet+: {
+          spec+: {
+            template+: {
+              spec+: {
+                serviceAccountName: allShards.serviceAccount.metadata.name,
+                containers: [
+                  if c.name == 'thanos-store' then c {
+                    args+: [
+                      |||
+                        --selector.relabel-config=
+                          - action: hashmod
+                            source_labels: ["__block_id"]
+                            target_label: shard
+                            modulus: %d
+                          - action: keep
+                            source_labels: ["shard"]
+                            regex: %d
+                      ||| % [config.shards, i],
+                    ],
+                  } else c
+                  for c in super.containers
+                ],
+              },
+            },
+          },
+        },
+      }
+      for i in std.range(0, config.shards - 1)
+    },
+  } + {
+    serviceMonitor: if config.serviceMonitor == true then {
+      apiVersion: 'monitoring.coreos.com/v1',
+      kind: 'ServiceMonitor',
+      metadata+: {
+        name: config.name,
+        namespace: config.namespace,
+        labels: config.commonLabels,
+      },
+      spec: {
+        selector: {
+          matchLabels: {
+            [key]: config.podLabelSelector[key]
+            for key in std.objectFields(config.podLabelSelector)
+            if key != 'app.kubernetes.io/instance'
+          },
+        },
+        endpoints: [
+          {
+            port: 'http',
+            relabelings: [
+              {
+                action: 'replace',
+                sourceLabels: ['namespace', 'pod'],
+                separator: '/',
+                targetLabel: 'instance',
+              },
+              {
+                action: 'replace',
+                sourceLabels: ['__meta_kubernetes_service_label_store_thanos_io_shard'],
+                regex: 'shard\\-(\\d+)',
+                replacement: '$1',
+                targetLabel: 'shard',
+              },
+            ],
+          },
+        ],
+      },
+    },
+  }

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -1,0 +1,257 @@
+local defaults = import 'kube-thanos/kube-thanos-store-default-params.libsonnet';
+
+function(params) {
+  local ts = self,
+
+  // Combine the defaults and the passed params to make the component's config.
+  config:: defaults + params + {
+    // If indexCache is given and of type memcached, merge defaults with params
+    indexCache+:
+      if std.objectHas(params, 'indexCache')
+         && std.objectHas(params.indexCache, 'type')
+         && std.asciiUpper(params.indexCache.type) == 'MEMCACHED' then
+        defaults.memcachedDefaults + defaults.indexCacheDefaults + params.indexCache
+      else {},
+    bucketCache+:
+      if std.objectHas(params, 'bucketCache')
+         && std.objectHas(params.bucketCache, 'type')
+         && std.asciiUpper(params.bucketCache.type) == 'MEMCACHED' then
+        defaults.memcachedDefaults + defaults.bucketCacheMemcachedDefaults + params.bucketCache
+      else {},
+  },
+
+  // Safety checks for combined config of defaults and params
+  assert std.isNumber(ts.config.replicas) && ts.config.replicas >= 0 : 'thanos store replicas has to be number >= 0',
+  assert std.isObject(ts.config.limits) : 'thanos store limits has to be an object',
+  assert std.isNumber(ts.config.limits.seriesTouched) && ts.config.limits.seriesTouched >= 0 : 'thanos store series touched limit has to be number >= 0',
+  assert std.isNumber(ts.config.limits.seriesSample) && ts.config.limits.seriesSample >= 0 : 'thanos store series sample limit has to be number >= 0',
+  assert std.isNumber(ts.config.limits.downloadedBytes) && ts.config.limits.downloadedBytes >= 0 : 'thanos store series download bytes limit has to be number >= 0',
+  assert std.isObject(ts.config.resources),
+  assert std.isBoolean(ts.config.serviceMonitor),
+  assert std.isObject(ts.config.volumeClaimTemplate),
+  assert !std.objectHas(ts.config.volumeClaimTemplate, 'spec') || std.assertEqual(ts.config.volumeClaimTemplate.spec.accessModes, ['ReadWriteOnce']) : 'thanos store PVC accessMode can only be ReadWriteOnce',
+
+  service: {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+      name: ts.config.name,
+      namespace: ts.config.namespace,
+      labels: ts.config.commonLabels,
+    },
+    spec: {
+      clusterIP: 'None',
+      selector: ts.config.podLabelSelector,
+      ports: [
+        {
+          assert std.isString(name),
+          assert std.isNumber(ts.config.ports[name]),
+
+          name: name,
+          port: ts.config.ports[name],
+          targetPort: ts.config.ports[name],
+        }
+        for name in std.objectFields(ts.config.ports)
+      ],
+    },
+  },
+
+  serviceAccount: {
+    apiVersion: 'v1',
+    kind: 'ServiceAccount',
+    metadata: {
+      name: ts.config.name,
+      namespace: ts.config.namespace,
+      labels: ts.config.commonLabels,
+      annotations: ts.config.serviceAccountAnnotations,
+    },
+  },
+
+  statefulSet:
+    local c = {
+      name: 'thanos-store',
+      image: ts.config.image,
+      imagePullPolicy: ts.config.imagePullPolicy,
+      args: [
+        'store',
+        '--log.level=' + ts.config.logLevel,
+        '--log.format=' + ts.config.logFormat,
+        '--data-dir=/var/thanos/store',
+        '--grpc-address=0.0.0.0:%d' % ts.config.ports.grpc,
+        '--http-address=0.0.0.0:%d' % ts.config.ports.http,
+        '--objstore.config=$(OBJSTORE_CONFIG)',
+        '--ignore-deletion-marks-delay=' + ts.config.ignoreDeletionMarksDelay,
+      ] + (
+        if std.length(ts.config.indexCache) > 0 then [
+          '--index-cache.config=' + std.manifestYamlDoc(ts.config.indexCache),
+        ] else []
+      ) + (
+        if std.length(ts.config.bucketCache) > 0 then [
+          '--store.caching-bucket.config=' + std.manifestYamlDoc(ts.config.bucketCache),
+        ] else []
+      ) + (
+        if std.length(ts.config.minTime) > 0 then [
+          '--min-time=' + ts.config.minTime,
+        ] else []
+      ) + (
+        if ts.config.limits.seriesTouched > 0 then [
+          '--store.grpc.touched-series-limit=' + ts.config.limits.seriesTouched,
+        ] else []
+      ) + (
+        if ts.config.limits.seriesSample > 0 then [
+          '--store.grpc.series-sample-limit=' + ts.config.limits.seriesSample,
+        ] else []
+      ) + (
+        if ts.config.limits.downloadedBytes > 0 then [
+          '--store.grpc.downloaded-bytes-limit=' + ts.config.limits.downloadedBytes,
+        ] else []
+      ) + (
+        if std.length(ts.config.maxTime) > 0 then [
+          '--max-time=' + ts.config.maxTime,
+        ] else []
+      ) + (
+        if std.length(ts.config.tracing) > 0 then [
+          '--tracing.config=' + std.manifestYamlDoc(
+            { config+: { service_name: defaults.name } } + ts.config.tracing
+          ),
+        ] else []
+      ),
+      env: [
+        {
+          name: 'OBJSTORE_CONFIG',
+          valueFrom: {
+            secretKeyRef: {
+              key: ts.config.objectStorageConfig.key,
+              name: ts.config.objectStorageConfig.name,
+            },
+          },
+        },
+        {
+          // Inject the host IP to make configuring tracing convenient.
+          name: 'HOST_IP_ADDRESS',
+          valueFrom: {
+            fieldRef: {
+              fieldPath: 'status.hostIP',
+            },
+          },
+        },
+      ] + (
+        if std.length(ts.config.extraEnv) > 0 then ts.config.extraEnv else []
+      ),
+      ports: [
+        { name: name, containerPort: ts.config.ports[name] }
+        for name in std.objectFields(ts.config.ports)
+      ],
+      volumeMounts: [{
+        name: 'data',
+        mountPath: '/var/thanos/store',
+        readOnly: false,
+      }] + (
+        if std.objectHas(ts.config.objectStorageConfig, 'tlsSecretName') && std.length(ts.config.objectStorageConfig.tlsSecretName) > 0 then [
+          { name: 'tls-secret', mountPath: ts.config.objectStorageConfig.tlsSecretMountPath },
+        ] else []
+      ),
+      livenessProbe: {
+        failureThreshold: ts.config.livenessProbe.failureThreshold,
+        periodSeconds: ts.config.livenessProbe.periodSeconds,
+        timeoutSeconds: ts.config.livenessProbe.timeoutSeconds,
+        httpGet: {
+          scheme: 'HTTP',
+          port: ts.config.ports.http,
+          path: '/-/healthy',
+        },
+      },
+      readinessProbe: { failureThreshold: 20, periodSeconds: 5, httpGet: {
+        scheme: 'HTTP',
+        port: ts.config.ports.http,
+        path: '/-/ready',
+      } },
+      resources: if ts.config.resources != {} then ts.config.resources else {},
+      securityContext: ts.config.securityContextContainer,
+      terminationMessagePolicy: 'FallbackToLogsOnError',
+    };
+
+    {
+      apiVersion: 'apps/v1',
+      kind: 'StatefulSet',
+      metadata: {
+        name: ts.config.name,
+        namespace: ts.config.namespace,
+        labels: ts.config.commonLabels,
+      },
+      spec: {
+        replicas: ts.config.replicas,
+        selector: { matchLabels: ts.config.podLabelSelector },
+        serviceName: ts.service.metadata.name,
+        template: {
+          metadata: {
+            labels: ts.config.commonLabels,
+          },
+          spec: {
+            serviceAccountName: ts.serviceAccount.metadata.name,
+            securityContext: ts.config.securityContext,
+            containers: [c],
+            volumes: if std.objectHas(ts.config.objectStorageConfig, 'tlsSecretName') && std.length(ts.config.objectStorageConfig.tlsSecretName) > 0 then [{
+              name: 'tls-secret',
+              secret: { secretName: ts.config.objectStorageConfig.tlsSecretName },
+            }] else [],
+            terminationGracePeriodSeconds: 120,
+            nodeSelector: {
+              'kubernetes.io/os': 'linux',
+            },
+            affinity: { podAntiAffinity: {
+              preferredDuringSchedulingIgnoredDuringExecution: [{
+                podAffinityTerm: {
+                  namespaces: [ts.config.namespace],
+                  topologyKey: 'kubernetes.io/hostname',
+                  labelSelector: { matchExpressions: [{
+                    key: 'app.kubernetes.io/name',
+                    operator: 'In',
+                    values: [ts.statefulSet.metadata.labels['app.kubernetes.io/name']],
+                  }, {
+                    key: 'app.kubernetes.io/instance',
+                    operator: 'In',
+                    values: [ts.statefulSet.metadata.labels['app.kubernetes.io/instance']],
+                  }] },
+                },
+                weight: 100,
+              }],
+            } },
+          },
+        },
+        volumeClaimTemplates: if std.length(ts.config.volumeClaimTemplate) > 0 then [ts.config.volumeClaimTemplate {
+          metadata+: {
+            name: 'data',
+            labels+: ts.config.podLabelSelector,
+          },
+        }] else [],
+      },
+    },
+
+  serviceMonitor: if ts.config.serviceMonitor == true then {
+    apiVersion: 'monitoring.coreos.com/v1',
+    kind: 'ServiceMonitor',
+    metadata+: {
+      name: ts.config.name,
+      namespace: ts.config.namespace,
+      labels: ts.config.commonLabels,
+    },
+    spec: {
+      selector: {
+        matchLabels: ts.config.podLabelSelector,
+      },
+      endpoints: [
+        {
+          port: 'http',
+          relabelings: [{
+            action: 'replace',
+            sourceLabels: ['namespace', 'pod'],
+            separator: '/',
+            targetLabel: 'instance',
+          }],
+        },
+      ],
+    },
+  },
+  storeEndpoint:: 'dnssrv+_grpc._tcp.%s.%s:%d' % [ts.service.metadata.name, ts.config.namespace, ts.config.ports.grpc],
+}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/thanos.libsonnet
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/github.com/thanos-io/kube-thanos/jsonnet/kube-thanos/thanos.libsonnet
@@ -1,0 +1,16 @@
+{
+  bucket: (import 'kube-thanos-bucket.libsonnet'),
+  bucketReplicate: (import 'kube-thanos-bucket-replicate.libsonnet'),
+  compact: (import 'kube-thanos-compact.libsonnet'),
+  compactShards: (import 'kube-thanos-compact-shards.libsonnet'),
+  query: (import 'kube-thanos-query.libsonnet'),
+  receive: (import 'kube-thanos-receive.libsonnet'),
+  receiveIngestor: (import 'kube-thanos-receive-ingestor.libsonnet'),
+  receiveRouter: (import 'kube-thanos-receive-router.libsonnet'),
+  receiveHashrings: (import 'kube-thanos-receive-hashrings.libsonnet'),
+  rule: (import 'kube-thanos-rule.libsonnet'),
+  sidecar: (import 'kube-thanos-sidecar.libsonnet'),
+  store: (import 'kube-thanos-store.libsonnet'),
+  storeShards: (import 'kube-thanos-store-shards.libsonnet'),
+  queryFrontend: (import 'kube-thanos-query-frontend.libsonnet'),
+}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/kube-thanos
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/thanos/vendor/kube-thanos
@@ -1,0 +1,1 @@
+github.com/thanos-io/kube-thanos/jsonnet/kube-thanos


### PR DESCRIPTION
## Summary

- Prometheus 直近 (sidecar) と Garage S3 上の長期ブロックを Grafana から透過的に読めるように、Thanos Querier / Store Gateway / Compactor を `monitoring` namespace に追加する。
- 配布物は [thanos-io/kube-thanos](https://github.com/thanos-io/kube-thanos) の公式 jsonnet を `vendor/` した上で、本クラスタ用パラメータを当てた `main.jsonnet` として保持。ArgoCD は `directory.jsonnet` で評価して manifest を生成する。
- Renovate (`config:recommended` の `jsonnet-bundler` manager) が `jsonnetfile.lock.json` の更新 PR を出す形で上流追従を機械化する。

## 背景

`prometheus-prometheus-kube-prometheus-prometheus-0` の PVC が満杯になり TSDB WAL リプレイで panic、CrashLoopBackOff に陥った件の恒久対策の一環。**直近対応は 300Gi → 400Gi にオンライン拡張済み** (Synology iSCSI + btrfs) で復旧済み。今回はそこから先の構造改善で、Thanos Querier 経由の透過化が入れば Prometheus ローカルの retention を縮小できる余地が出る (現在 180d / 270GB)。

## 何を入れるか

| ファイル | 役割 |
|---|---|
| `apps/cluster-wide-apps/app-of-other-apps/thanos.yaml` | ArgoCD Application。\`directory.jsonnet\` で \`main.jsonnet\` を評価。\`include: 'main.jsonnet'\` を付けて \`vendor/\` 配下や \`jsonnetfile.json\` が manifest として誤読されないようにしている |
| \`apps/thanos/main.jsonnet\` | Querier / Store / Compactor をこの環境向けに render するエントリポイント |
| \`apps/thanos/jsonnetfile.json\` / \`jsonnetfile.lock.json\` | kube-thanos 依存定義 (Renovate がここを追う) |
| \`apps/thanos/vendor/\` | \`jb install\` で取得した kube-thanos 一式 (~136K, 19 ファイル) |
| \`apps/thanos/README.md\` | 構成と運用手順 |

### 環境特化の主な値

- \`namespace: monitoring\`
- \`image: quay.io/thanos/thanos:v0.41.0\` (既存 sidecar と同一)
- \`objectStorageConfig: { name: garage-thanos-credentials, key: objstore.yml }\` (既存 sidecar と共有)
- Store / Compact の PVC: \`synology-iscsi-storage\` 50Gi
- Querier の \`--endpoint\`: sidecar discovery (\`prometheus-kube-prometheus-thanos-discovery.monitoring\`) と Store (\`thanos-store.monitoring\`)
- ServiceMonitor に \`release: prometheus\` ラベルを後付け (kube-prometheus-stack の \`serviceMonitorSelector\` に拾わせるため)

### kube-thanos jsonnet を採用した理由

- 公式 (thanos-io 直系) の配布物で、上流追従が Renovate の \`jsonnet-bundler\` manager で機械化できる。
- bitnami chart は使わない方針、stevehipwell/thanos は個人 maintainer 依存、render 済み YAML を手でコピーするのは保守責任が不明確、というすべての選択肢を消去した結果。
- ArgoCD は jsonnet を first-class で実行できる ([公式 doc](https://argo-cd.readthedocs.io/en/stable/user-guide/jsonnet/)) ため、Tanka や CMP sidecar のような追加レイヤを repo に持ち込む必要が無い。

## 切替後の手順 (本 PR には含まれない)

1. Grafana datasource \`Prometheus\` の URL を \`http://prometheus-kube-prometheus-prometheus:9090\` から \`http://thanos-query.monitoring.svc.cluster.local:9090\` に変更。
2. Prometheus の \`retention\` / \`retentionSize\` を縮小 (180d / 270GB → 例えば 30d / 80GB)。

## Test plan

- [ ] Argo CD UI で \`thanos\` Application が同期され、4 リソース x 3 component (Service/ServiceAccount/ServiceMonitor/Workload) = 12 リソース全てが Healthy になる
- [ ] \`thanos-query\` Pod の起動ログで sidecar と store の StoreAPI が discovery されている (\`level=info component=storeAPIs ... msg=\"adding new storeAPI to query storeset\"\`)
- [ ] \`thanos-store\` Pod が Garage 上の object store からブロック一覧を取得できる (起動ログに \`msg=\"successfully synchronized block metadata\"\`)
- [ ] \`thanos-compact\` Pod が起動し続ける (CrashLoopBackOff にならない)
- [ ] Grafana の Prometheus datasource を \`thanos-query.monitoring:9090\` に手動で一時切替して、過去 1 時間と過去 3 ヶ月 (Thanos 経由) のメトリクスが両方引ける
- [ ] ServiceMonitor が Prometheus に拾われている (\`prometheus_target_scrape_pool_targets\` で \`thanos-query\` / \`thanos-store\` / \`thanos-compact\` が現れる)

🤖 Generated with [Claude Code](https://claude.com/claude-code)