### PR TITLE
feat(thanos): add ArgoCD Application referencing thanos-config repo

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/thanos.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/thanos.yaml
@@ -14,7 +14,7 @@ spec:
     #   - thanos-config の release: release-please bot が tag を切る
     #   - 本ファイルの targetRevision: Renovate ArgoCD manager が tag を bump
     repoURL: https://github.com/GiganticMinecraft/thanos-config
-    targetRevision: v0.1.0
+    targetRevision: v1.0.0
     path: '.'
     directory:
       # repo のルートにある main.jsonnet 以外 (LICENSE, README.md, renovate.json5)

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/thanos.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/thanos.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: thanos
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io # cascade deletion on this App deletion
+spec:
+  project: cluster-wide-apps
+  source:
+    # Querier / Store / Compactor のマニフェストは GiganticMinecraft/thanos-config で管理。
+    # 上流追従は thanos-config 側の Renovate (quay.io/thanos/thanos の image tag) で機械化。
+    repoURL: https://github.com/GiganticMinecraft/thanos-config
+    targetRevision: main
+    path: '.'
+    directory:
+      # repo のルートにある main.jsonnet 以外 (LICENSE, README.md, renovate.json5)
+      # を ArgoCD の manifest scanner に拾わせない
+      include: main.jsonnet
+      jsonnet: {}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/thanos.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/thanos.yaml
@@ -9,9 +9,12 @@ spec:
   project: cluster-wide-apps
   source:
     # Querier / Store / Compactor のマニフェストは GiganticMinecraft/thanos-config で管理。
-    # 上流追従は thanos-config 側の Renovate (quay.io/thanos/thanos の image tag) で機械化。
+    # 上流追従:
+    #   - thanos-config 内: Renovate (quay.io/thanos/thanos の image tag)
+    #   - thanos-config の release: release-please bot が tag を切る
+    #   - 本ファイルの targetRevision: Renovate ArgoCD manager が tag を bump
     repoURL: https://github.com/GiganticMinecraft/thanos-config
-    targetRevision: main
+    targetRevision: v0.1.0
     path: '.'
     directory:
       # repo のルートにある main.jsonnet 以外 (LICENSE, README.md, renovate.json5)


### PR DESCRIPTION
## Summary

- Thanos **Querier / Store Gateway / Compactor** を `monitoring` namespace に追加。Prometheus 直近 (sidecar) と Garage S3 上の長期ブロックを Grafana から透過的に読めるようにするのが目的。
- マニフェスト本体は別リポジトリ [`GiganticMinecraft/thanos-config`](https://github.com/GiganticMinecraft/thanos-config) で管理し、本 PR は **ArgoCD Application を 1 ファイル追加** するだけ。
- thanos-config 側の対応 PR: [thanos-config#1](https://github.com/GiganticMinecraft/thanos-config/pull/1) (merged) / [thanos-config#2](https://github.com/GiganticMinecraft/thanos-config/pull/2) (merged) / [thanos-config#3 release 1.0.0](https://github.com/GiganticMinecraft/thanos-config/pull/3) (open, release-please bot 生成)

## なぜ別リポジトリか

経緯:

1. 当初 `thanos-io/kube-thanos` を vendor して seichi_infra 内で完結させようとしたが、kube-thanos の最新 release が 2022-11 (`v0.29.0`)、main も commit 頻度が極めて低く、上流追従コストを丸抱えする構造になることが判明 (現行の Thanos sidecar v0.41.0 との 11 minor 差を kube-thanos が吸収していない)。
2. かわりに、必要最小限の Querier/Store/Compactor 構成を **kube-thanos に依存しない自前 jsonnet** として書き、Renovate の docker manager (custom regex) で `quay.io/thanos/thanos` の image tag だけを追跡対象にした。これを seichi_infra 内に置くと jsonnet 文化を新規導入することになるため、Thanos 専用の小さい repo として切り出した。

## 上流追従の自動化レイヤ

| レイヤ | 担当 | 自動化方式 |
|---|---|---|
| Thanos image bump (`quay.io/thanos/thanos:vX.Y.Z`) | thanos-config 内の Renovate | docker datasource + custom regex manager |
| thanos-config の release tag 切り | release-please bot | conventional commits → release PR → merge で tag |
| 本ファイルの `targetRevision` bump | seichi_infra の Renovate | ArgoCD manager + github-tags datasource |

人間が判断する merge gate は **thanos-config の release PR を merge する瞬間 1 回だけ**。それ以外はすべて bot 経由。

## 何が変わるか

| ファイル | 役割 |
|---|---|
| `apps/cluster-wide-apps/app-of-other-apps/thanos.yaml` | ArgoCD Application 1 個。`directory.jsonnet` で thanos-config の `main.jsonnet` を tag pin (`v1.0.0`) で評価して monitoring namespace に apply |

apply される 12 リソース:

- ServiceAccount / Service / Deployment / ServiceMonitor x **thanos-query**
- ServiceAccount / Service / StatefulSet / ServiceMonitor x **thanos-store**
- ServiceAccount / Service / StatefulSet / ServiceMonitor x **thanos-compact**

## マージ順

1. [thanos-config#3](https://github.com/GiganticMinecraft/thanos-config/pull/3) (release-please の release PR) を merge → `v1.0.0` tag が切られる
2. 本 PR を merge → ArgoCD が同期して 12 リソースが Healthy になることを確認
3. (本 PR には含まれない) Grafana datasource `Prometheus` の URL を `http://thanos-query.monitoring.svc.cluster.local:9090` に切替え、Prometheus の `retention` / `retentionSize` を縮小

## Test plan

- [ ] `v1.0.0` tag が thanos-config に存在することを確認してから本 PR を merge
- [ ] ArgoCD で `cluster-wide-apps-thanos` (もしくは類似の名前) Application が同期し、12 リソースが Healthy になる
- [ ] `thanos-query` Pod の起動ログで sidecar / store の StoreAPI が discovery される
- [ ] `thanos-store` Pod が Garage 上の object store からブロック一覧を取得できる
- [ ] `thanos-compact` Pod が起動し続ける
- [ ] ServiceMonitor が Prometheus に拾われる (`thanos-query` / `-store` / `-compact` が target に出る)

🤖 Generated with [Claude Code](https://claude.com/claude-code)