### PR TITLE
fix: SrvStopper.jar の COPY 先を /plugins/ に修正

### DIFF
--- a/docker-images/mcservers/production/seichi-servers/common-image/Dockerfile
+++ b/docker-images/mcservers/production/seichi-servers/common-image/Dockerfile
@@ -11,7 +11,7 @@ FROM ghcr.io/giganticminecraft/seichi_minecraft_server_base:1.0.0-java17-jdk@sha
 ENV VERSION="1.18.2"
 
 # SrvStopper.jar を配置
-COPY --link --from=srv-stopper-downloader /root/SrvStopper.jar /plugins
+COPY --link --from=srv-stopper-downloader /root/SrvStopper.jar /plugins/
 
 # プラグインの設定ファイル
 COPY --link ./additional-plugin-configs /plugins

--- a/docker-images/mcservers/production/seichi-servers/common-image/Dockerfile
+++ b/docker-images/mcservers/production/seichi-servers/common-image/Dockerfile
@@ -11,7 +11,7 @@ FROM ghcr.io/giganticminecraft/seichi_minecraft_server_base:1.0.0-java17-jdk@sha
 ENV VERSION="1.18.2"
 
 # SrvStopper.jar を配置
-COPY --link --from=srv-stopper-downloader /root/SrvStopper.jar /plugins/
+COPY --link --from=srv-stopper-downloader /root/SrvStopper.jar /plugins/SrvStopper.jar
 
 # プラグインの設定ファイル
 COPY --link ./additional-plugin-configs /plugins


### PR DESCRIPTION
## 概要

#5000 で導入された `SrvStopper.jar` が、ビルド成功するにも関わらず最終 image に含まれない不具合を修正する。

## 原因

common-image Dockerfile:
```Dockerfile
COPY --link --from=srv-stopper-downloader /root/SrvStopper.jar /plugins   ← ①
COPY --link ./additional-plugin-configs /plugins                          ← ②
```

ベース image (`seichi_minecraft_server_base:1.0.0-java17-jdk`) には `/plugins` が存在しないため:

- **①** `COPY <単一ファイル> <末尾スラッシュなしの宛先>` は宛先を **ファイル** として扱う仕様 (Docker COPY 仕様)。`/plugins` という名前のファイル(中身は SrvStopper の JAR バイト)を持つレイヤーが生成される
- **②** ディレクトリの中身を `/plugins` にコピー。`/plugins` ディレクトリを持つレイヤーが生成される

通常の `COPY` (without `--link`) なら ② で `/plugins is a file` 衝突で失敗するはずだが、`--link` は各 COPY が独立レイヤーを作る (前のレイヤーを参照しない) ため build 成功扱いになる。最終 union 時に **後勝ち**: ②のディレクトリが①のファイルを完全に shadow し、JAR が消失していた。

## 観測との整合

本番 mc 鯖の `/plugins/` を確認:

| パス | 状態 |
|---|---|
| `/plugins/SrvStopper/config.yml` | ✓ 存在 (②由来) |
| `/plugins/SrvStopper.jar` | ✗ 存在しない |

全 `s1〜s7`, `votelistener` Pod のログに `SrvStopper` が一切現れず、プラグインが load されていない状態だった。

## 修正

末尾スラッシュ付与で宛先を明示的にディレクトリ化:

```Dockerfile
COPY --link --from=srv-stopper-downloader /root/SrvStopper.jar /plugins/
```

これにより `/plugins/SrvStopper.jar` として配置され、② の `additional-plugin-configs` と同居する。

## 影響範囲

- `seichi-servers/common-image` を使う本番イメージ: `s1, s2, s3, s5, s7, votelistener`
- `kagawa, lobby, one-day-to-reset` は別 Dockerfile で SrvStopper を持たないため影響なし
- SrvStopper の `force-stop: false` 設定なので、修正前も鯖停止には至っていない (機能が単に動いていなかった)

## Test plan

- [ ] `Build Minecraft Server Images` workflow で common-image / s1-s7 / votelistener が成功
- [ ] s1 等の Pod 内 `/plugins/SrvStopper.jar` が存在する
- [ ] mc 鯖ログに `[SrvStopper]` の出力が現れる (例: required-plugins チェック結果)

🤖 Generated with [Claude Code](https://claude.com/claude-code)