### PR TITLE
fix(seichi-gateway-operator): bump ref to pick up mirror.gcr.io for kube-rbac-proxy

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/seichi-gateway-operator/kustomization.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/seichi-gateway-operator/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - github.com/GiganticMinecraft/seichi-gateway-operator/config/default?ref=5b88cb3239e41d41c33d4350d1c6e291f3c34a05
+  - github.com/GiganticMinecraft/seichi-gateway-operator/config/default?ref=206b1f0ba5722703d89e6d9bfe4f04723b709ccf
 
 images:
   - name: controller


### PR DESCRIPTION
## Summary

- `seichi-onp-k8s/.../seichi-gateway-operator/kustomization.yaml` の `?ref=` を `5b88cb3` → `206b1f0` に更新
- これにより、上流 [seichi-gateway-operator#46](https://github.com/GiganticMinecraft/seichi-gateway-operator/pull/46) でマージ済みの kube-rbac-proxy image registry 修正 (`gcr.io` → `mirror.gcr.io`) を ArgoCD に反映する

## 背景

`seichi-gateway-operator` の main では `manager_auth_proxy_patch.yaml` の image が `mirror.gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1` に更新されていたが、本リポジトリの kustomization は SHA でピン留めされており、ArgoCD application `cluster-wide-apps-seichi-gateway-operator` 上では旧 `gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1` のままになっていた。

なお、`seichi-gateway-operator` リポジトリにはまだ git tag / GitHub Release がないため、Renovate (kustomize manager) では追従できず、当面は手動でこの ref を上げる必要がある。

## Test plan

- [ ] CI 通過を確認
- [ ] マージ後、ArgoCD `cluster-wide-apps-seichi-gateway-operator` を Sync
- [ ] `seichi-gateway-operator-controller-manager` Deployment の `kube-rbac-proxy` コンテナ image が `mirror.gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1` になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)