### PR TITLE
feat(seichi-gateway-operator): bump to modernized v4.14 scaffold (kube-rbac-proxy removed)

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/seichi-gateway-operator/kustomization.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/seichi-gateway-operator/kustomization.yaml
@@ -2,9 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - github.com/GiganticMinecraft/seichi-gateway-operator/config/default?ref=206b1f0ba5722703d89e6d9bfe4f04723b709ccf
+  - github.com/GiganticMinecraft/seichi-gateway-operator/config/default?ref=5281f03968e7f429b0a65477c9a739773d952f05
 
 images:
   - name: controller
     newName: ghcr.io/giganticminecraft/seichi-gateway-operator
-    newTag: sha-5b88cb3
+    newTag: sha-5281f03


### PR DESCRIPTION
## Summary

`seichi-gateway-operator` を [GiganticMinecraft/seichi-gateway-operator#50](https://github.com/GiganticMinecraft/seichi-gateway-operator/pull/50) (merged) の最新コミット `5281f03968e7f429b0a65477c9a739773d952f05` に bump する。kustomize の `?ref=` と controller image tag (`sha-5281f03`) を同時に更新。

応急処置で merge 済みの #5069 (`mirror.gcr.io` 経由) からさらに前進する形。

## 含まれる変更 (上流 #50)

- kube-rbac-proxy サイドカー廃止 → controller-runtime の `filters.WithAuthenticationAndAuthorization` でメトリクス authn/authz を内蔵
- kubebuilder v4.14 scaffold への完全 regeneration (project-v3-builder 名残や PROJECT 上の kind 名乖離も解消)
- controller-runtime v0.24 / k8s.io/* v0.36 / Go 1.26 への揃え
- deprecated `client.Apply` patch type → Writer.Apply (Server-Side Apply via client-go applyconfigurations) への書き換え
- Pod SecurityContext を Restricted profile 準拠に (`seccompProfile: RuntimeDefault`, `readOnlyRootFilesystem`)
- `.golangci.yml` + lint/test/test-e2e workflow の追加 (CI でテストが走るように)

## ⚠️ Sync 前に手動操作が必要

新 scaffold で **Deployment.spec.selector に `app.kubernetes.io/name: seichi-gateway-operator` が追加される**ため、Kubernetes の immutable field 制約で in-place 更新できない。kind 実機検証で確認済みのエラー:

```
The Deployment "seichi-gateway-operator-controller-manager" is invalid:
spec.selector: Invalid value: ...: field is immutable
```

ArgoCD application `cluster-wide-apps-seichi-gateway-operator` は **auto-sync が時間帯限定で有効** (`projects.yaml` の cluster-wide-apps 設定に従い、JST 7-8 時のみ enable / それ以外 disable)。マージ → sync は以下の順で行う:

1. 該当 application の auto-sync (および self-heal) が有効になっていないことを確認 (or 一時的に明示無効化)
2. 旧 Deployment を削除:
   ```
   kubectl -n seichi-gateway-operator-system delete deployment seichi-gateway-operator-controller-manager
   ```
3. ArgoCD で手動 sync (新 Deployment が新 selector で作成される)
4. auto-sync を元のスケジュールに戻す

self-heal が有効なまま delete すると旧 desired state で即再作成され selector immutable のループに陥るので、必ず 1 を先に。

Operator は単一 Pod 構成なので削除〜再作成の間 reconcile は止まるが、ロジックは冪等なため状態は壊れない (数秒の reconcile 停止のみ)。既存 CR (`bungeeconfigtemplates.seichi.click`, `seichiassistdebugenvrequests.seichi.click`) は新 CRD で valid のまま reconcile される (kind 実機検証済み)。

## 関連

- Refs #5069 (merged、応急処置として `mirror.gcr.io` 切り替え。本 PR でその上に最新 modernization を載せる)
- Refs GiganticMinecraft/seichi-gateway-operator#50
- Refs GiganticMinecraft/seichi-gateway-operator#47, #48 (kube-rbac-proxy deprecation warning。本 PR の sync で発生源ごと消滅、close 済み)

## Test plan

- [ ] CI 通過を確認
- [ ] マージ前に ArgoCD application の auto-sync/self-heal が無効になっていることを確認
- [ ] マージ後 `kubectl delete deployment seichi-gateway-operator-controller-manager -n seichi-gateway-operator-system`
- [ ] ArgoCD で手動 sync、新 Deployment が `Healthy` になる (Pod 1/1 Running、leader election 取得、両 Reconciler 起動) ことを確認
- [ ] 既存 CR が再 reconcile されて status が `Applied`、ConfigMap が新 fieldOwner=`manager` (SSA) で更新されていることを確認
- [ ] auto-sync を元のスケジュールに戻す

🤖 Generated with [Claude Code](https://claude.com/claude-code)