### PR TITLE
fix: Update tracing sink port in garage.yaml

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/garage.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/garage.yaml
@@ -73,7 +73,7 @@ spec:
               interval: 30s
               scrapeTimeout: 10s
           tracing:
-            sink: "http://k8s-monitoring-alloy-receiver.monitoring.svc.cluster.local:4317"
+            sink: "http://k8s-monitoring-alloy-receiver.monitoring.svc.cluster.local:4318"
   destination:
     server: https://kubernetes.default.svc
     namespace: garage


### PR DESCRIPTION
プロトコルとポートの不一致
- http:// スキーム + port 4317 を指定していますが、4317 は gRPC 用の標準ポートです
- 同じクラスタ内の garage-admin-api は port 4318 (HTTP/protobuf) を正常に使用しています
- エラーメッセージ tcp connect error: Operation timed out (os error 110) は、Alloy receiver が gRPC(4317) を listen していない、または HTTP/protobuf リクエストを gRPC ポートに送っているため接続タイムアウトしていることを示唆しています