### PR TITLE
fix: Lokiシングルノードでmemberlist DNSエラーが発生する問題を修正

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/loki.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/loki.yaml
@@ -56,6 +56,24 @@ spec:
             max_line_size_truncate: true
           ruler:
             enable_api: true
+          structuredConfig:
+            ingester:
+              lifecycler:
+                ring:
+                  kvstore:
+                    store: inmemory
+            distributor:
+              ring:
+                kvstore:
+                  store: inmemory
+            compactor:
+              compactor_ring:
+                kvstore:
+                  store: inmemory
+            common:
+              ring:
+                kvstore:
+                  store: inmemory
 
         minio:
           enabled: false


### PR DESCRIPTION
## 概要

Loki 3.6.7 (SingleBinary replicas=1) の起動時に以下のエラーが発生する問題を修正:

- `Failed to resolve loki-memberlist.monitoring.svc.cluster.local: no such host`
- `error getting ingester clients` err=`empty ring`

## 原因

SingleBinary モードでも Helm chart v7.0.0 の memberlist テンプレートにより `join_members` が常に生成される。Loki はこれにより全 ring の kvstore を自動的に memberlist に設定する。1台構成では memberlist (gossip プロトコル) は本来不要で、loki-memberlist Service の DNS 解決に失敗し ring が形成されない。

## 修正内容

`loki.structuredConfig` で各コンポーネントの ring kvstore を `inmemory` に明示設定:

- `ingester.lifecycler.ring.kvstore.store: inmemory`
- `distributor.ring.kvstore.store: inmemory`
- `compactor.compactor_ring.kvstore.store: inmemory`
- `common.ring.kvstore.store: inmemory`
