### PR TITLE
fix: change Loki ring kvstore from inmemory to memberlist for SingleBinary

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/loki.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/loki.yaml
@@ -65,10 +65,6 @@ spec:
                 ring:
                   kvstore:
                     store: memberlist
-            distributor:
-              ring:
-                kvstore:
-                  store: memberlist
             compactor:
               compactor_ring:
                 kvstore:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/loki.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/loki.yaml
@@ -57,23 +57,26 @@ spec:
           ruler:
             enable_api: true
           structuredConfig:
+            memberlist:
+              join_members:
+                - loki-memberlist
             ingester:
               lifecycler:
                 ring:
                   kvstore:
-                    store: inmemory
+                    store: memberlist
             distributor:
               ring:
                 kvstore:
-                  store: inmemory
+                  store: memberlist
             compactor:
               compactor_ring:
                 kvstore:
-                  store: inmemory
+                  store: memberlist
             common:
               ring:
                 kvstore:
-                  store: inmemory
+                  store: memberlist
 
         minio:
           enabled: false


### PR DESCRIPTION
## 概要
Loki SingleBinary モードで `ratestore.go` から `"error getting ingester clients" err="empty ring"` が継続的に発生していた問題を修正します。

## 原因
distributor 内の ratestore が ingester ring からインスタンスを取得しようとしますが、SingleBinary モードでの `inmemory` ring では起動時のタイミング競合により ring が空と判定され、エラーが継続していました。

## 修正内容
ring の kvstore を `inmemory` から `memberlist` に変更し、`join_members` に `loki-memberlist` を指定しました。memberlist は gossip プロトコルベースで ring 状態を解決するため、起動タイミング競合が発生しません。

## 参考
- Loki 設定ドキュメント: memberlist を設定すると全コンポーネントの ring に自動適用される
- https://github.com/grafana/loki/blob/main/pkg/distributor/ratestore.go#L110
