### PR TITLE
chore(monitoring): tempo/loki の Helm chart を grafana-community repo へ移行

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-tempo.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-tempo.yaml
@@ -12,7 +12,7 @@ spec:
   project: cluster-wide-apps
   source:
     chart: tempo
-    repoURL: https://grafana.github.io/helm-charts
+    repoURL: https://grafana-community.github.io/helm-charts
     targetRevision: 1.24.4
     helm:
       values: |

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/loki.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/loki.yaml
@@ -12,7 +12,7 @@ spec:
   project: cluster-wide-apps
   source:
     chart: loki
-    repoURL: https://grafana.github.io/helm-charts
+    repoURL: https://grafana-community.github.io/helm-charts
     targetRevision: 7.0.0
     helm:
       values: |


### PR DESCRIPTION
## 概要

Grafana は 2026-01-30 に汎用 Helm chart 群を `grafana.github.io/helm-charts` から `grafana-community.github.io/helm-charts` へ移行しました。旧 repo は移行済み chart の更新を今後行いません。リポジトリ内で `grafana.github.io/helm-charts` を参照している 4 つの ArgoCD Application のうち、移行先に存在する tempo と loki の `repoURL` を新 repo へ差し替えます。

## 変更内容

| chart | targetRevision | repoURL |
|---|---|---|
| `tempo` | 1.24.4 (据え置き) | grafana → **grafana-community** |
| `loki` | 7.0.0 (据え置き) | grafana → **grafana-community** |

`grafana-community` の `index.yaml` を取得して、pin 中の tempo 1.24.4 / loki 7.0.0 が同一バージョンで存在することを確認済み。よって chart バージョンは変えず `repoURL` のみ差し替えています。

## 据え置いた chart

`pyroscope` (2.0.2) と `k8s-monitoring` (4.1.3) は `grafana-community` に存在せず、旧 `grafana` repo にしか無いため今回は変更しません。

`grafana-community` 側で配布されている chart: `grafana / loki / tempo / tempo-distributed / tempo-vulture / grafana-mcp / synthetic-monitoring-agent`

## 確認事項

- ArgoCD Application 以外で旧 URL を Helm repo として登録している箇所が無いことを確認済み

## 参考

- https://github.com/grafana/helm-charts/issues/4087
- https://grafana-community.github.io/helm-charts/

🤖 Generated with [Claude Code](https://claude.com/claude-code)