### PR TITLE
fix(image-updater): ImageUpdater CR から schema 外の spec.namespace を削除

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/garage-admin-image-updater.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/garage-admin-image-updater.yaml
@@ -4,7 +4,6 @@ metadata:
   name: garage-admin
   namespace: argocd
 spec:
-  namespace: argocd
   writeBackConfig:
     method: argocd
   applicationRefs:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/mcserver--lobby-image-updater.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/mcserver--lobby-image-updater.yaml
@@ -4,7 +4,6 @@ metadata:
   name: mcserver--lobby
   namespace: argocd
 spec:
-  namespace: argocd
   writeBackConfig:
     method: argocd
   applicationRefs:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/seichi-game-data-publisher-image-updater.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/seichi-game-data-publisher-image-updater.yaml
@@ -4,7 +4,6 @@ metadata:
   name: seichi-game-data-publisher
   namespace: argocd
 spec:
-  namespace: argocd
   writeBackConfig:
     method: argocd
   applicationRefs:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/seichi-game-data-server-image-updater.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/seichi-game-data-server-image-updater.yaml
@@ -4,7 +4,6 @@ metadata:
   name: seichi-game-data-server
   namespace: argocd
 spec:
-  namespace: argocd
   writeBackConfig:
     method: argocd
   applicationRefs:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/truenas-exporter-image-updater.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/truenas-exporter-image-updater.yaml
@@ -4,7 +4,6 @@ metadata:
   name: truenas-exporter
   namespace: argocd
 spec:
-  namespace: argocd
   writeBackConfig:
     method: argocd
   applicationRefs:


### PR DESCRIPTION
## 概要

`cluster-wide-apps-app-of-other-apps` (App-of-Apps) が `ComparisonError` で sync 不能になっていた問題を修正します。

```
ComparisonError: Failed to compare desired state to live state: failed to calculate diff:
error calculating structured merge diff: error building typed value from config resource:
.spec.namespace: field not declared in schema
```

この影響で親 App が diff を計算できず、配下の全 Application (tempo / loki の grafana-community 移行を含む) が sync されない状態でした。

## 原因

`ImageUpdater` CRD (`imageupdaters.argocd-image-updater.argoproj.io`) の spec schema は `applicationRefs` / `commonUpdateSettings` / `writeBackConfig` のみを宣言しており、`spec.namespace` は未定義 (`x-kubernetes-preserve-unknown-fields` も無し)。

- API server は live リソースから `spec.namespace` を pruning する (実際 live の CR には存在しない)
- 一方 git のマニフェストには `spec.namespace: argocd` が残っている
- ServerSideApply の structured merge diff 計算時、desired (git) に schema 外フィールドがあるため diff 構築が失敗 → 親 App が ComparisonError

## 変更内容

以下 5 つの `ImageUpdater` CR から `spec.namespace: argocd` を削除します。CR の配置先である `metadata.namespace: argocd` は維持します。

- `garage-admin-image-updater.yaml`
- `mcserver--lobby-image-updater.yaml`
- `seichi-game-data-publisher-image-updater.yaml`
- `seichi-game-data-server-image-updater.yaml`
- `truenas-exporter-image-updater.yaml`

## 確認事項

- live の `ImageUpdater` には既に `spec.namespace` が無い (pruned 済み) ため、削除しても挙動は変わらない
- CRD schema に `spec.namespace` が宣言されていないことを `kubectl get crd imageupdaters.argocd-image-updater.argoproj.io` で確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)