### PR TITLE
fix(garage-backup-to-pbs): dump 用 PVC を 600Gi に拡張

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/pvc.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   storageClassName: topolvm-provisioner
   resources:
     requests:
-      storage: 400Gi
+      storage: 600Gi


### PR DESCRIPTION
## 概要
`backup--garage-to-pbs` (Argo CronWorkflow, 毎日10:00 JST) が常態的に Failed していた問題への暫定対応。dump 用ステージング PVC `garage-backup-dump` を **400Gi → 600Gi** に拡張する。

## 原因
全 Garage バケットを `aws s3 sync` で永続 PVC `/data/garage-dump` にフルダンプしてから PBS へ送る設計だが、対象バケットの総量が **約 511 GiB** に増加し 400Gi PVC が満杯に。`run-backup` ステップが `[Errno 28] No space left on device` で exit 1 し、PBS 送信に到達できていなかった。

| bucket | size |
|---|---|
| loki | 340.8 GiB |
| thanos | 119.3 GiB |
| mc-worlds | 31.3 GiB |
| mariadb-backups | 19.5 GiB |
| その他 | ~0.7 GiB |
| **合計** | **約 511 GiB** |

調査時点で PVC は 399.7G/399.8G (100%) 使用。

## 反映
- ArgoCD (auto-sync + self-heal) によりマージ後に自動同期。
- topolvm は `allowVolumeExpansion=true`、束縛先 wk-1 に 590GiB 空きがあり拡張可能。ブロック拡張は即時、FS リサイズは次回 backup 実行時のマウントで反映。

## 注意（恒久対応）
600Gi は現状 +約90GiB の余裕にとどまる暫定措置。loki(ログ) は増加が続くため、いずれ再不足する。恒久的にはバックアップ設計の見直し（バケット単位の逐次 sync→送信→削除、loki/thanos の扱い見直し等）が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)