### PR TITLE
fix(garage-backup-to-pbs): loki バケットをバックアップ対象から除外

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/argo-workflows-backup.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/argo-workflows-backup.yaml
@@ -62,12 +62,32 @@ spec:
           DUMP_DIR="/data/garage-dump"
           mkdir -p "$DUMP_DIR"
 
-          # バケット一覧を取得してそれぞれ sync
-          BUCKETS=$(aws $S3_OPTS s3 ls | awk '{print $3}')
+          # バックアップ対象から除外するバケット（肥大化が激しく PBS バックアップに
+          # 不向きなログ系。除外したバケットの dump ディレクトリは下の prune 処理で削除される）
+          EXCLUDE_BUCKETS="loki"
+
+          # バケット一覧を取得し、除外対象を除いてそれぞれ sync
+          ALL_BUCKETS=$(aws $S3_OPTS s3 ls | awk '{print $3}')
+          BUCKETS=""
+          for b in $ALL_BUCKETS; do
+            excluded=0
+            for ex in $EXCLUDE_BUCKETS; do
+              if [ "$b" = "$ex" ]; then
+                excluded=1
+                break
+              fi
+            done
+            if [ "$excluded" = 1 ]; then
+              echo "Excluding bucket from backup: $b"
+              continue
+            fi
+            BUCKETS="$BUCKETS $b"
+          done
           echo "Found buckets: $BUCKETS"
 
-          # 永続 PVC 上で Garage から削除済みバケットのディレクトリが残ると
-          # 不要なデータを PBS に送り続けることになるため、sync 前に掃除する
+          # 永続 PVC 上に Garage から削除済み、またはバックアップ対象外となった
+          # バケットのディレクトリが残ると不要なデータを PBS に送り続けることになるため、
+          # sync 前に掃除する（BUCKETS に無いディレクトリ＝loki 等の除外バケットも削除される）
           echo "=== Pruning orphaned bucket directories ==="
           for dir in "$DUMP_DIR"/*/; do
             [ -d "$dir" ] || continue


### PR DESCRIPTION
## 概要
`backup--garage-to-pbs` (Argo CronWorkflow) が常態的に Failed していた問題への対応。容量拡張(#5294)ではなく、**最も肥大化している `loki`(ログ) をバックアップ対象から除外**する方針に変更。

## 原因
全 Garage バケットを `aws s3 sync` で単一の永続 PVC `/data/garage-dump`(400Gi) にフルダンプしてから PBS へ送る設計。対象総量が **約 511GiB** に増加して PVC が満杯になり、`run-backup` ステップが `[Errno 28] No space left on device` で exit 1、PBS 送信に到達できていなかった。

| bucket | size | 対応 |
|---|---|---|
| **loki** | **340.8 GiB** | **除外** |
| thanos | 119.3 GiB | 継続 |
| mc-worlds | 31.3 GiB | 継続 |
| mariadb-backups | 19.5 GiB | 継続 |
| seichi-plugins / seichiassist | ~0.7 GiB | 継続 |

## 変更内容
バケット一覧から `EXCLUDE_BUCKETS`(=`loki`) を除外して sync する。除外バケットの dump ディレクトリは、既存の prune 処理(`BUCKETS` に無いディレクトリを `rm -rf`)により自動削除される。

- 除外後の対象総量 ≒ **170GiB** → 既存 400Gi PVC に十分収まる（拡張不要）
- 現在 dump 上に残る約 250GiB の loki も次回実行時の prune で解放される

## トレードオフ
- `loki`(ログ) は PBS へのオフサイトバックアップ対象外になる（ログは重要度が相対的に低く、サイズが大きいため除外を選択）。
- 将来 thanos 等の増加で再び不足する可能性はあるが、当面は解消される。

## 反映
ArgoCD (auto-sync + self-heal, targetRevision=main) によりマージ後に自動同期。次回 10:00 JST の定期実行、または手動 submit で復旧を確認可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)