### PR TITLE
fix(garage-backup-to-pbs): prune の rm を堅牢化（巨大ディレクトリ ENOTEMPTY 対策・非致命化）

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/argo-workflows-backup.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/argo-workflows-backup.yaml
@@ -101,7 +101,22 @@ spec:
             done
             if [ "$found" = 0 ]; then
               echo "Removing orphaned directory: $dir"
-              rm -rf "$dir"
+              # 巨大ディレクトリ(例: Loki の数十万エントリ)では rm -rf が
+              # ENOTEMPTY(Directory not empty) で失敗することがある。これは rm が
+              # getdents64 によるディレクトリ読み出しと unlink を交互に行う過程で、
+              # ext4 htree のハッシュベースのカーソルが削除によってずれ、一部
+              # エントリを読み飛ばしたまま end-of-directory に達し、最後の rmdir 時に
+              # 中身が残っているために起きる(POSIX 的にも readdir 中の更新は unspecified)。
+              # 縮んだディレクトリを読み直せば残りを消せるため、空になるまでリトライする。
+              # また prune は best-effort な後始末なので、消し切れなくても
+              # バックアップ本体は止めない(rm を && の左に置くことで set -e でも中断しない)。
+              n=0
+              while [ -d "$dir" ] && [ "$n" -lt 10 ]; do
+                n=$((n + 1))
+                rm -rf "$dir" && break
+                echo "  prune retry $n: $dir"
+              done
+              [ -d "$dir" ] && echo "  WARNING: $dir を完全に削除できませんでした(次回実行時に再試行されます)"
             fi
           done
 


### PR DESCRIPTION
## 背景
loki をバックアップ対象から除外した #5295 の手動検証で、prune ステップの `rm -rf` が失敗してバックアップ全体が落ちる別の問題が顕在化した。本 PR はその prune 処理を堅牢化する（#5295 自体の機能には影響しない後始末ロジックの改善）。

実際の失敗ログ:
```
=== Pruning orphaned bucket directories ===
Removing orphaned directory: /data/garage-dump/loki/
rm: cannot remove '/data/garage-dump/loki/fake/3cb644989f2a2ab2': Directory not empty
Error: exit status 1
```

## 原因（2つ）

### 1. 巨大ディレクトリで `rm -rf` が `ENOTEMPTY` を返す
Linux のディレクトリは「名前→inode」の対応表を中身に持つファイルで、ext4 は大きくなると **htree（ハッシュ木）** で索引化する。`rm -rf` はカーネルに対して概ね次を繰り返す:

1. `openat(dir, O_DIRECTORY)` … ディレクトリを開く
2. `getdents64(fd, buf, size)` … 中身表を**バッファに収まる分だけ**読む（1回で全部は返らない。次の読み出し位置 `d_off` をしおりとして返す）
3. 読めたエントリを `unlinkat(fd, 名前)` で1個ずつ削除
4. 表を読み切る（`getdents64` が 0 を返す）まで 2〜3 を繰り返す
5. 最後に `rmdir(dir)` … **空のときだけ成功**、中身が残ると errno `ENOTEMPTY`

問題は **2 の読み出しと 3 の削除を同じディレクトリに交互に行う**点。ext4 htree の `d_off`（しおり）は**バイト位置ではなくファイル名のハッシュ値ベース**で、`unlinkat` のたびに htree 索引が組み替わる。すると次の `getdents64` がしおりから再開する際に**着地点がずれて一部エントリを読み飛ばす**ことがある。rm は「全部読んだ」と思い込んで `rmdir` するが、飛ばされた分が残っていて `ENOTEMPTY` になる。

- POSIX も「`readdir` 中のディレクトリ増減で全エントリを見られる保証はない（unspecified）」と明記しており、**エントリが数十万規模のときだけ顕在化**する（小さいと `getdents64` 1〜2回で読み切れて干渉しない）。
- 実機の痕跡: 詰まった `3cb644989f2a2ab2` の**ディレクトリ inode が 4.2MB**（ext4 はディレクトリを一度膨らむと縮めない＝過去に膨大なエントリを抱えていた証拠）。rm はそこを ~1900 個残して `rmdir` に失敗していた。
- 検証: 大半が削られて小さくなった後に手動 `rm -rf` したら**1パスで成功**。→ **読み直せば確実に消せる**。

### 2. 後始末の失敗が致命傷になっていた
スクリプトは先頭で `set -e`。prune はただの best-effort なお掃除なのに、`rm` の非ゼロ終了でスクリプト全体が即終了し、**本体のバックアップごと道連れ**になっていた。

## 修正
prune の削除を「空になるまでの rm リトライ（最大10回）」に変更し、消し切れなくてもバックアップは止めない:

```sh
n=0
while [ -d "$dir" ] && [ "$n" -lt 10 ]; do
  n=$((n + 1))
  rm -rf "$dir" && break
  echo "  prune retry $n: $dir"
done
[ -d "$dir" ] && echo "  WARNING: ... 完全に削除できませんでした(次回実行時に再試行されます)"
```

- **リトライ**: 縮んだ（＝索引が落ち着いた）ディレクトリを読み直すことで、読み飛ばされた残りも確実に削除 → いずれ空になり `rmdir` が通る。
- **set -e 安全**: `rm -rf "$dir" && break` の `rm` は `&&` の左側＝「失敗を判定に使うコマンド」なので、失敗しても errexit は発動せず**スクリプトは中断しない**（`while`/`if` 条件や `&&`/`||` 左辺は errexit 例外）。最悪10回で消えなくても WARNING を出して継続。
- （代替として `find "$dir" -delete`（深さ優先で全削除→rmdir）でも同じ目的を達成できるが、最小変更を優先してリトライ方式を採用。）

## 検証
- YAML 構文チェック（ruby / yq）✅
- Argo CRD サーバーサイド dry-run ✅
- `set -e` 下でのループ挙動をシェルで再現テスト（`rm` 失敗→リトライ→継続、中断しないこと）✅
- なお #5295 の本体修正は手動実行で end-to-end 成功済み（PBS バックアップ完了、約54分、exit 0）。本 PR はその際に判明した prune の堅牢性のみを改善する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)