### PR TITLE
feat: add kured and node-problem-detector

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/descheduler.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/descheduler.yaml
@@ -12,7 +12,84 @@ spec:
     helm:
       releaseName: descheduler
       values: |
-        schedule: "30 19 * * Tue"
+        # JST 水曜 04:30 に週1回実行(従来の "30 19 * * Tue" (UTC) と同時刻)
+        schedule: "30 4 * * 3"
+        timeZone: "Asia/Tokyo"
+        # チャートのデフォルトポリシーをベースに、Pod の退避(=再起動)が
+        # プレイヤー切断に直結する namespace を退避対象から除外する
+        deschedulerPolicy:
+          # 一度の実行で大量退避が起きないようにする安全弁
+          maxNoOfPodsToEvictPerNode: 10
+          profiles:
+            - name: default
+              pluginConfig:
+                - name: DefaultEvictor
+                  args:
+                    # 退避先ノードが確保できない Pod は退避しない
+                    nodeFit: true
+                    podProtections:
+                      defaultDisabled:
+                        - "PodsWithLocalStorage"
+                      extraEnabled:
+                        - "PodsWithPVC"
+                - name: RemoveDuplicates
+                  args:
+                    namespaces:
+                      exclude: &player-facing-namespaces
+                        - seichi-minecraft
+                        - seichi-debug-minecraft
+                        - seichi-gateway
+                        - seichi-debug-gateway
+                - name: RemovePodsHavingTooManyRestarts
+                  args:
+                    podRestartThreshold: 100
+                    includingInitContainers: true
+                    namespaces:
+                      exclude: *player-facing-namespaces
+                - name: RemovePodsViolatingNodeAffinity
+                  args:
+                    nodeAffinityType:
+                      - requiredDuringSchedulingIgnoredDuringExecution
+                    namespaces:
+                      exclude: *player-facing-namespaces
+                - name: RemovePodsViolatingNodeTaints
+                  args:
+                    namespaces:
+                      exclude: *player-facing-namespaces
+                - name: RemovePodsViolatingInterPodAntiAffinity
+                  args:
+                    namespaces:
+                      exclude: *player-facing-namespaces
+                - name: RemovePodsViolatingTopologySpreadConstraint
+                  args:
+                    namespaces:
+                      exclude: *player-facing-namespaces
+                - name: LowNodeUtilization
+                  args:
+                    thresholds:
+                      cpu: 20
+                      memory: 20
+                      pods: 20
+                    targetThresholds:
+                      cpu: 50
+                      memory: 50
+                      pods: 50
+                    # LowNodeUtilization は namespaces を受け付けないので
+                    # evictableNamespaces で除外する
+                    evictableNamespaces:
+                      exclude: *player-facing-namespaces
+              plugins:
+                balance:
+                  enabled:
+                    - RemoveDuplicates
+                    - RemovePodsViolatingTopologySpreadConstraint
+                    - LowNodeUtilization
+                deschedule:
+                  enabled:
+                    - RemovePodsHavingTooManyRestarts
+                    - RemovePodsViolatingNodeTaints
+                    - RemovePodsViolatingNodeAffinity
+                    - RemovePodsViolatingInterPodAntiAffinity
   destination:
     server: https://kubernetes.default.svc
     namespace: kube-system

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
@@ -1,0 +1,49 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kured
+  namespace: argocd
+spec:
+  project: cluster-wide-apps
+  source:
+    chart: kured
+    repoURL: https://kubereboot.github.io/charts
+    targetRevision: 6.1.0
+    helm:
+      releaseName: kured
+      values: |
+        configuration:
+          timeZone: "Asia/Tokyo"
+          # 04:00 からの Minecraft バックアップ(kubectl patch による replicas 操作)と
+          # 07:00-08:00 の ArgoCD selfHeal ウィンドウを避けた時間帯のみ再起動を許可する
+          startTime: "05:00"
+          endTime: "07:00"
+          # ロックにより同時に再起動するノードは 1 台のみ
+          concurrency: 1
+          # 再起動中にノードが死んだ場合にロックが残留しないようにする
+          lockTtl: 30m
+          drainGracePeriod: "60"
+          drainTimeout: 10m
+          period: 10m
+          annotateNodes: true
+          # 重要なアラートが firing している間は再起動を保留する。
+          # 常時 firing しがちな警告(TargetDown 等)は除外しないと永久にブロックされるため列挙している
+          prometheusUrl: "http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090"
+          alertFiringOnly: true
+          alertFilterRegexp: "^(Watchdog|InfoInhibitor|TargetDown|KubeJobFailed|CPUThrottlingHigh|PrometheusNotConnectedToAlertmanagers|KubePodCrashLooping|KubePodNotReady|KubeDeploymentReplicasMismatch)$"
+        # tolerations はチャートのデフォルトで control-plane の NoSchedule を含むため未指定のままにする
+        service:
+          create: true
+        metrics:
+          create: true
+          labels:
+            release: prometheus
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/node-problem-detector.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/node-problem-detector.yaml
@@ -1,0 +1,40 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: node-problem-detector
+  namespace: argocd
+spec:
+  project: cluster-wide-apps
+  source:
+    chart: node-problem-detector
+    repoURL: ghcr.io/deliveryhero/helm-charts
+    targetRevision: 2.4.1
+    helm:
+      releaseName: node-problem-detector
+      values: |
+        image:
+          # チャートデフォルトのイメージはクラスタの Kubernetes バージョンより古いため明示する
+          tag: v1.36.0
+        metrics:
+          serviceMonitor:
+            enabled: true
+            additionalLabels:
+              release: prometheus
+        settings:
+          log_monitors:
+            # KernelDeadlock / ReadonlyFilesystem などの NodeCondition を設定する。
+            # これらは medik8s NodeHealthCheck の unhealthyConditions からも参照される。
+            # containerd 環境のため docker-monitor.json は含めない
+            - /config/kernel-monitor.json
+            - /config/readonly-monitor.json
+        # tolerations はチャートのデフォルト(operator: Exists, effect: NoSchedule)で
+        # control-plane を含む全ノードにスケジュールされる
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/medik8s/kustomization.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/medik8s/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - subscriptions.yaml
+  - nodehealthcheck.yaml

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/medik8s/nodehealthcheck.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/medik8s/nodehealthcheck.yaml
@@ -1,0 +1,37 @@
+apiVersion: remediation.medik8s.io/v1alpha1
+kind: NodeHealthCheck
+metadata:
+  name: worker-nodes
+  annotations:
+    # NodeHealthCheck CRD は OLM がオペレータをインストールした後に生えるため、
+    # 初回 sync 時の dry-run 失敗をスキップする(ApplicationSet の無限リトライで収束する)
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  # control-plane の自動 remediation は事故時の etcd quorum への影響が大きいため
+  # worker のみを対象とする(upstream も CP/worker 混在の selector を強く非推奨としている)
+  selector:
+    matchExpressions:
+      - key: node-role.kubernetes.io/control-plane
+        operator: DoesNotExist
+  remediationTemplate:
+    apiVersion: self-node-remediation.medik8s.io/v1alpha1
+    kind: SelfNodeRemediationTemplate
+    # SNR がインストール時に自動生成するデフォルトテンプレート
+    namespace: operators
+    name: self-node-remediation-automatic-strategy-template
+  # 3 worker 構成では常に 2 台以上健全であることを要求する
+  # (kured の再起動は drain 済みかつ数分で復帰するため 300s には達しない想定)
+  minHealthy: 51%
+  unhealthyConditions:
+    - type: Ready
+      status: "False"
+      duration: 300s
+    - type: Ready
+      status: Unknown
+      duration: 300s
+    # node-problem-detector の kernel-monitor が付与する NodeCondition。
+    # カーネルデッドロックは再起動でしか回復しないため対象に含める。
+    # ReadonlyFilesystem はディスク障害由来で再起動ループになり得るため対象外(アラートのみ)
+    - type: KernelDeadlock
+      status: "True"
+      duration: 120s

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/medik8s/subscriptions.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/medik8s/subscriptions.yaml
@@ -1,0 +1,29 @@
+# medik8s のオペレータ 2 つを OLM の operatorhub.io カタログから導入する。
+# NHC は remediator を自動では入れないため、SNR も明示的に Subscribe する必要がある。
+# startingCSV で初期バージョンを明示しているが、installPlanApproval: Automatic のため
+# 以降のアップグレードはカタログの更新に追従する(Git ではなくカタログ駆動)。
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: node-healthcheck-operator
+  namespace: operators
+spec:
+  channel: stable
+  name: node-healthcheck-operator
+  source: operatorhubio-catalog
+  sourceNamespace: olm
+  installPlanApproval: Automatic
+  startingCSV: node-healthcheck-operator.v0.12.0
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: self-node-remediation
+  namespace: operators
+spec:
+  channel: stable
+  name: self-node-remediation
+  source: operatorhubio-catalog
+  sourceNamespace: olm
+  installPlanApproval: Automatic
+  startingCSV: self-node-remediation.v0.13.0

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/olm/kustomization.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/olm/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# medik8s (node-healthcheck-operator / self-node-remediation) は OLM 経由でしか
+# 配布されていないため、OLM 本体をここで導入する。
+# バージョンを上げるときは 2 つの URL を同時に更新すること(Renovate は追従しない)
+resources:
+  - https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.45.0/crds.yaml
+  - https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.45.0/olm.yaml
+patches:
+  # self-node-remediation の agent DaemonSet は privileged Pod を必要とするため、
+  # オペレータがインストールされる operators namespace を PSA privileged にする
+  - patch: |-
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: operators
+        labels:
+          pod-security.kubernetes.io/enforce: privileged
+          pod-security.kubernetes.io/audit: privileged
+          pod-security.kubernetes.io/warn: privileged

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/reloader/kustomization.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/reloader/kustomization.yaml
@@ -4,3 +4,18 @@ namespace: cluster-wide-apps
 resources:
   # reloader
   - github.com/stakater/Reloader/deployments/kubernetes?ref=v1.4.19
+  - service.yaml
+  - service-monitor.yaml
+patches:
+  # デフォルトの env-vars 戦略は pod template に環境変数を注入するため、
+  # ArgoCD の selfHeal と競合する。annotation ベースの戦略に切り替え、
+  # argocd-cm 側の resource.customizations.ignoreDifferences で
+  # reloader.stakater.com/last-reloaded-from を diff 対象から除外している。
+  - target:
+      kind: Deployment
+      name: reloader-reloader
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args
+        value:
+          - --reload-strategy=annotations

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/reloader/service-monitor.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/reloader/service-monitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: reloader-reloader
+  labels:
+    # kube-prometheus-stack の serviceMonitorSelector に一致させる
+    release: prometheus
+spec:
+  selector:
+    matchLabels:
+      app: reloader-reloader
+  endpoints:
+    - port: http
+      path: /metrics

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/reloader/service.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/reloader/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: reloader-reloader
+  labels:
+    app: reloader-reloader
+spec:
+  selector:
+    app: reloader-reloader
+  ports:
+    - name: http
+      port: 9090
+      targetPort: http

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/apps.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/apps.yaml
@@ -44,7 +44,7 @@ spec:
           kind: CSIDriver
           jqPathExpressions:
             - .spec.seLinuxMount
-        - group: ""
+        - group: apps
           kind: Deployment
           jqPathExpressions:
             - .spec.template.spec.containers[].env[].valueFrom.resourceFieldRef.divisor

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/projects.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/projects.yaml
@@ -70,6 +70,11 @@ spec:
       server: https://kubernetes.default.svc
     - namespace: "opencost"
       server: https://kubernetes.default.svc
+    # OLM 本体(cluster-wide-apps/olm)と medik8s オペレータ(cluster-wide-apps/medik8s)用
+    - namespace: "olm"
+      server: https://kubernetes.default.svc
+    - namespace: "operators"
+      server: https://kubernetes.default.svc
   clusterResourceWhitelist:
     - group: "*"
       kind: "*"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/argocd-helm-chart-values.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/argocd-helm-chart-values.yaml
@@ -60,6 +60,26 @@ configs:
     accounts.mcp-service: apiKey
     accounts.backup-workflow: apiKey
     accounts.kubechecks: apiKey
+    # Reloader (--reload-strategy=annotations) がローリング再起動のために
+    # pod template へ付与する annotation を diff として扱わない。
+    # これがないと selfHeal が annotation を剥がそうとして Reloader と競合する。
+    resource.customizations.ignoreDifferences.apps_Deployment: |
+      jqPathExpressions:
+        - .spec.template.metadata.annotations."reloader.stakater.com/last-reloaded-from"
+    resource.customizations.ignoreDifferences.apps_StatefulSet: |
+      jqPathExpressions:
+        - .spec.template.metadata.annotations."reloader.stakater.com/last-reloaded-from"
+    resource.customizations.ignoreDifferences.apps_DaemonSet: |
+      jqPathExpressions:
+        - .spec.template.metadata.annotations."reloader.stakater.com/last-reloaded-from"
+  repositories:
+    # node-problem-detector の Helm チャート取得先。OCI レジストリは
+    # enableOCI 付きでリポジトリ登録しないと Application の repoURL として解決できない
+    deliveryhero-helm-oci:
+      url: ghcr.io/deliveryhero/helm-charts
+      name: deliveryhero
+      type: helm
+      enableOCI: "true"
   rbac:
     create: true
     # policy.csv is an file containing user-defined RBAC policies and role definitions (optional).


### PR DESCRIPTION
- kured 6.1.0 (app v1.23.0, k8s 1.35-1.37 対応): Ubuntu の /var/run/reboot-required を検知して 05:00-07:00 JST のみ 1 台ずつ drain + 再起動する。04:00 のバックアップと 07:00-08:00 の ArgoCD selfHeal ウィンドウを避けた時間帯。重要アラート firing 中は 再起動を保留(常時 firing しがちな警告は除外済み)
- node-problem-detector 2.4.1 (v1.36.0): kernel-monitor と readonly-monitor で KernelDeadlock / ReadonlyFilesystem 等の NodeCondition を設定。後続で導入する medik8s NodeHealthCheck の unhealthyConditions から参照する想定