### PR TITLE
fix(argocd): thanos と kyverno の恒常的な OutOfSync 表示を解消

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kyverno.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kyverno.yaml
@@ -46,3 +46,13 @@ spec:
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
+  # チャート 3.8 系の policies.kyverno.io 系 CRD は metadata.labels /
+  # metadata.annotations を空マップ({})でレンダリングする一方、API サーバーは
+  # 空マップを保存しないため「{} vs 無し」の差分が永遠に残り OutOfSync 表示になる。
+  # 空マップの場合に限って無視する(実値が入った場合の差分は今までどおり検知される)
+  ignoreDifferences:
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      jqPathExpressions:
+        - .metadata.labels | select(. == {})
+        - .metadata.annotations | select(. == {})

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/thanos.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/thanos.yaml
@@ -30,10 +30,12 @@ spec:
       selfHeal: true
     syncOptions:
       - ServerSideApply=true
-  # StatefulSet volumeClaimTemplates.spec.volumeMode is defaulted by the API
-  # server, while thanos-config omits it. Ignore that default-only diff here.
+  # StatefulSet の volumeClaimTemplates は API サーバーが apiVersion/kind/
+  # volumeMode/status を自動補完するため常に差分が出る(volumeMode だけの
+  # 無視では不十分だった)。vct は作成後 immutable で diff を見る意味が
+  # ないため、garage.yaml と同様に丸ごと無視する。
   ignoreDifferences:
     - group: apps
       kind: StatefulSet
-      jqPathExpressions:
-        - .spec.volumeClaimTemplates[].spec.volumeMode
+      jsonPointers:
+        - /spec/volumeClaimTemplates


### PR DESCRIPTION
- thanos: volumeClaimTemplates への API サーバー自動補完 (apiVersion/kind/volumeMode/status)が差分扱いされ続けていた。 既存の volumeMode 単体の無視では不足していたため、immutable な vct を丸ごと ignoreDifferences に変更(garage.yaml と同じパターン)
- kyverno: チャート 3.8 系が policies.kyverno.io 系 CRD 11 個の metadata.labels / annotations を空マップでレンダリングし、API サーバーが 空マップを落とすため「{} vs 無し」の差分が永続していた。 空マップの場合に限り無視する jq 式で対処(実値の差分は検知を維持)

いずれも表示ノイズで実害はないが、OutOfSync 一覧が常に埋まっていると
本物の drift を見落とすため対処する。