### PR TITLE
fix: rebootCommand の apt をホストの network namespace で実行する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
@@ -54,17 +54,25 @@ spec:
           # drain 完了後に実行される。node-runtime-updater がステージした containerd / runc を
           # apply.sh (rename のみ) で先に適用し、kubelet を unhold -> パッチ更新 -> hold
           # してから再起動する。すべての更新が drain 済み・再起動直前に適用される。
+          #
+          # kured の nsenter はホストの mount namespace にしか入らないため、apt は
+          # ホストの resolv.conf (systemd-resolved の 127.0.0.53) を読みながら Pod の
+          # network namespace で実行され、名前解決に失敗する (2026-07-17 の窓で
+          # kubelet の .deb 取得が全ノード "Temporary failure resolving" で失敗した実績)。
+          # そのためネットワークを要する apt 部分のみ nsenter --net でホストの
+          # network namespace に入れて実行する (kured は privileged + hostPID なので可能)。
+          #
           # 再起動窓 (05:00-07:00) は unattended-upgrades の実行時間帯と重なり apt lock を
           # 取り合う可能性があるため Lock::Timeout を設定し、apply や apt が失敗しても reboot は
           # 必ず実行する (ノードが drain されたまま残らないようにする。sentinel が残るため翌日リトライされる)
           rebootCommand: >-
             sh -c '{ [ ! -x /var/lib/node-runtime-updater/apply.sh ]
             || /var/lib/node-runtime-updater/apply.sh; } || true;
-            export DEBIAN_FRONTEND=noninteractive;
+            nsenter --net=/proc/1/ns/net -- sh -c "export DEBIAN_FRONTEND=noninteractive;
             apt-mark unhold kubelet;
             apt-get -qq -o DPkg::Lock::Timeout=600 update;
             apt-get -qq -y -o DPkg::Lock::Timeout=600 --only-upgrade install kubelet;
-            apt-mark hold kubelet;
+            apt-mark hold kubelet";
             systemctl reboot'
         # tolerations はチャートのデフォルトで control-plane の NoSchedule を含むため未指定のままにする
         service:


### PR DESCRIPTION
kured の nsenter はホストの mount namespace にしか入らないため、apt は ホストの resolv.conf (systemd-resolved の 127.0.0.53) を読みながら Pod の network namespace で実行され、名前解決に失敗していた。2026-07-17 の窓では cp-3 / wk-1 / wk-2 で containerd / runc の適用と再起動は成功した一方、 kubelet の .deb 取得が全て "Temporary failure resolving 'pkgs.k8s.io'" で 失敗し、kubelet 1.36.0 のまま置き去りになった。

ネットワークを要する apt 部分のみ nsenter --net=/proc/1/ns/net で ホストの network namespace に入れて実行する。kured Pod 自体を
hostNetwork にする案は、チャートに dnsPolicy の設定が無く Prometheus の クラスタ DNS 名解決 (アラートゲート) が壊れるため採らない。