### PR TITLE
fix(mcserver--s5): 無人時の GC 停止によるネイティブメモリ蓄積で OOMKilled される問題に対処

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
@@ -87,10 +87,16 @@ spec:
               # base image 側で JVM_OPTS に対して jmx exporter の設定を追加しているが、上書きが必要なためここで設定する
               # SeichiAssistによるワールドマイグレーションをするとメモリリークが発生するため、Papermc公式が推奨しているJVM Optionを追加する
               # ref: https://docs.papermc.io/paper/aikars-flags
+              #
+              # ただし Aikar's flags のうち DisableExplicitGC は ExplicitGCInvokesConcurrent に置き換えている。
+              # MaxDirectMemorySize の上限に達したとき、JVM は System.gc() を呼んで direct buffer の
+              # 回収を試みるが、DisableExplicitGC だとこの経路が塞がれて OutOfMemoryError になりうる。
+              # ExplicitGCInvokesConcurrent なら System.gc() が STW の Full GC ではなく concurrent cycle に
+              # 変換されるため、プラグインの System.gc() 呼び出しでラグらせないという元の目的も保たれる。
               value: >-
                 -javaagent:/jmx-exporter/jmx_prometheus_javaagent.jar=18321:/jmx-exporter/jmx-exporter-config.yaml
                 -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=200
-                -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:+AlwaysPreTouch
+                -XX:+UnlockExperimentalVMOptions -XX:+ExplicitGCInvokesConcurrent -XX:+AlwaysPreTouch
                 -XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M
                 -XX:G1ReservePercent=20 -XX:G1HeapWastePercent=5 -XX:G1MixedGCCountTarget=4
                 -XX:InitiatingHeapOccupancyPercent=15 -XX:G1MixedGCLiveThresholdPercent=90

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
@@ -99,6 +99,15 @@ spec:
                 -Daikars.new.flags=true
 
             - name: JVM_XX_OPTS
+              # G1PeriodicGCInterval: 無人時間帯はヒープ割り当てが少なく GC がほぼ走らないため、
+              # Cleaner 経由で解放されるネイティブメモリ (Deflater 等) が回収されずに蓄積し、
+              # 約 1GiB/h のペースで増加して数時間で OOMKilled に至っていた (2026-07-18 の計測より)。
+              # アイドル時にも 5 分間隔で concurrent cycle を走らせて回収させる (JEP 346)。
+              # 賑わっている時間帯は GC が高頻度で走るためこのフラグは発動しない。
+              #
+              # MaxDirectMemorySize: 未設定だとデフォルトで Xmx と同じ 8G まで direct buffer が
+              # 伸びられるため、コンテナの memory limit を超えうる。実測ピークは ~450MiB のため
+              # 2 倍のマージンを取って 1G に制限する。
               value: >-
                 -XX:ErrorFile=/data/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError
                 -XX:HeapDumpPath=/data/ -XX:+CreateCoredumpOnCrash
@@ -107,6 +116,8 @@ spec:
                 -XX:+DebugNonSafepoints
                 -XX:ReservedCodeCacheSize=384m
                 -XX:MaxMetaspaceSize=384m
+                -XX:G1PeriodicGCInterval=300000
+                -XX:MaxDirectMemorySize=1g
 
             - name: ENABLE_JMX
               value: "true"


### PR DESCRIPTION
## 概要

s5 が起動から約 3.5 時間ごとに OOMKilled される問題(2026-07-18 だけで 3 回発生)への対処。Prometheus / Grafana の計測データから原因を以下のように特定した。

- ヒープ(実使用 1〜3.5 GiB / 8G)・direct buffer(ピーク ~450 MiB)・Metaspace・スレッド数はすべて健全で、JMX に現れないネイティブ領域だけが単調増加して limit 12Gi に到達していた
- 増加は**無人時間帯にのみ**約 1.2 GiB/h で進行し、プレイヤーが多い時間帯は Young GC が高頻度(約 3 秒に 1 回)で走ることで回収が追いつき平坦になる。無人時は Young GC が約 2 分に 1 回まで落ち、Old 世代の GC に至っては数時間で一度も走っていなかった
- 既存の `-XX:MaxTenuringThreshold=1`(Aikar's flags)により、ネイティブメモリを保持したオブジェクト(Deflater 等、Cleaner 経由で解放されるもの)が Young GC 1 回で Old 世代へ昇格し、以後回収機会が存在しなかった

対処として以下の 2 つの JVM フラグを s5 に追加する。

1. `-XX:G1PeriodicGCInterval=300000`(JEP 346): 直近 5 分間 GC が走っていない場合のみ concurrent cycle を強制する。無人時のネイティブメモリ蓄積を 1 サイクルあたり ~100 MiB で頭打ちにする。賑わっている時間帯は発動しないため性能影響はない
2. `-XX:MaxDirectMemorySize=1g`: 未設定だとデフォルトで Xmx と同額(8G)まで direct buffer が伸びられ、limit 超過の一因になりうるため上限を設ける(実測ピークの 2 倍マージン)

## 確認事項

- 計測に基づく切り分けを実施済み: Dynmap のレンダリング停止実験(`dynmap pause all` を再起動直後から適用)でも増加ペースが変わらないことを確認し、レンダリング起因説を棄却。無人/賑わいと GC 頻度・メモリ増加の相関は Grafana の CSV(working set / rss / GC 頻度 / 送信トラフィック)で確認した
- フラグ適用後の効果は未確認(本 PR の適用で初めて検証可能)。適用後、無人時間帯に working set が増加し続けないことを Grafana の Container Memory パネルで確認する

## 補足

- まず s5 のみに適用して効果を測定し、有効なら他の mcserver へ横展開する
- 適用には Pod 再起動が伴うが、現状約 3.5 時間ごとに突然死しているため、計画的な再起動 1 回のコストは相対的に小さい
- 根本の発生源(無人時にネイティブメモリを確保し続けている処理が何か)は未特定のまま。本対処は「回収されない」側を直すもので、発生源の特定は後続調査とする

🤖 Generated with Claude Code