### PR TITLE
fix(mcserver--s5): G1PeriodicGCInterval を 5 分から 1 分に短縮

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
@@ -105,11 +105,13 @@ spec:
                 -Daikars.new.flags=true
 
             - name: JVM_XX_OPTS
-              # G1PeriodicGCInterval: 無人時間帯はヒープ割り当てが少なく GC がほぼ走らないため、
-              # Cleaner 経由で解放されるネイティブメモリ (Deflater 等) が回収されずに蓄積し、
+              # G1PeriodicGCInterval: 無人時間帯は Old 世代の回収 (concurrent cycle) が一度も走らず、
+              # Cleaner 経由で解放されるネイティブメモリ (Deflater 等) が Old 世代へ昇格したまま蓄積し、
               # 約 1GiB/h のペースで増加して数時間で OOMKilled に至っていた (2026-07-18 の計測より)。
-              # アイドル時にも 5 分間隔で concurrent cycle を走らせて回収させる (JEP 346)。
-              # 賑わっている時間帯は GC が高頻度で走るためこのフラグは発動しない。
+              # このフラグは「指定時間、どの GC も走らなかったとき」に concurrent cycle を強制する (JEP 346)。
+              # 無人時でも Young GC は 2〜4 分に 1 回走ってタイマーをリセットするため、
+              # 間隔はそれより短い 1 分に設定する必要がある (5 分 = 300000 では一度も発動しなかった)。
+              # 賑わっている時間帯は GC 間隔が数秒のためこのフラグは発動しない。
               #
               # MaxDirectMemorySize: 未設定だとデフォルトで Xmx と同じ 8G まで direct buffer が
               # 伸びられるため、コンテナの memory limit を超えうる。実測ピークは ~450MiB のため
@@ -122,7 +124,7 @@ spec:
                 -XX:+DebugNonSafepoints
                 -XX:ReservedCodeCacheSize=384m
                 -XX:MaxMetaspaceSize=384m
-                -XX:G1PeriodicGCInterval=300000
+                -XX:G1PeriodicGCInterval=60000
                 -XX:MaxDirectMemorySize=1g
 
             - name: ENABLE_JMX


### PR DESCRIPTION
## 概要

#5486 で導入した `G1PeriodicGCInterval=300000` (5 分) が、適用後も一度も発動していなかったため、閾値を 1 分に短縮する。

- このフラグの発動条件は「指定時間、**どの GC も**走らなかったとき」である
- 無人時間帯でも Young GC が 2〜4 分に 1 回 (実測 68〜270 秒間隔) 走ってタイマーをリセットするため、5 分の閾値には永遠に到達しない
- 一方でその Young GC は、`MaxTenuringThreshold=1` により Old 世代へ昇格済みのネイティブ保持オブジェクトを回収できない。結果、無人時のメモリ増加 (~0.8 GiB/h) が適用後も止まっていなかった
- 閾値を無人時の Young GC 間隔より短い 1 分にすることで、Young GC の合間に periodic concurrent cycle が発動できるようになる

## 確認事項

- 発動していないことの確認: #5486 適用後のコンテナ (20:21 起動) で、22:11 の全プレイヤー退出後もメモリ増加が継続 (Grafana)。spark の GC 統計で起動約 2 時間・Young GC 760 回に対し **Old Generation collector: 0 collections** を確認
- 賑わい時に発動しない性質は維持される (GC 間隔が数秒のため 1 分の閾値に到達しない)
- 修正後の効果 (無人時に Old 側の GC カウンタが約 1 分間隔で増え、メモリ増加が頭打ちになること) は適用後に Grafana で確認する

## 補足

- 無人時の増加が「頭打ちになるが下がらない」場合は、glibc malloc arena の断片化が残りの容疑となるため、`MALLOC_ARENA_MAX=2` の追加を後続で検討する

🤖 Generated with Claude Code