### PR TITLE
fix(mcserver--s5): MALLOC_ARENA_MAX=2 で glibc arena の断片化蓄積を抑える

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
@@ -83,6 +83,15 @@ spec:
             - name: EULA
               value: "TRUE"
 
+            # glibc の malloc arena の数を制限する。
+            # arena の上限はデフォルトで「CPU コア数 × 8」だが、glibc は cgroup を認識しないため
+            # ここでの CPU コア数は limits.cpu ではなくノードの物理コア数になり、arena が大量に作られうる。
+            # チャンク圧縮 (zlib) などの多スレッドからの細かい malloc/free で断片化した arena は
+            # free 済みでも OS にメモリを返さないため、RSS が戻らずに増え続ける一因になる。
+            # (2026-07-19 の計測: GC 側の対策後も賑わい時間帯に ~0.5GiB/h のラチェット式増加が残存)
+            - name: MALLOC_ARENA_MAX
+              value: "2"
+
             - name: JVM_OPTS
               # base image 側で JVM_OPTS に対して jmx exporter の設定を追加しているが、上書きが必要なためここで設定する
               # SeichiAssistによるワールドマイグレーションをするとメモリリークが発生するため、Papermc公式が推奨しているJVM Optionを追加する


### PR DESCRIPTION
## 概要

#5486 / #5488 の G1PeriodicGCInterval 導入で、無人時間帯のメモリ増加は平衡に達した(旧: ~1.2GiB/h の単調増加 → 新: 深夜帯 3 時間以上フラット、OOMKill なしで朝の定期再起動まで到達)。一方で、プレイヤーがいる時間帯に **~0.5GiB/h のラチェット式増加(増えたまま戻らない)** が残っており、土日など終日賑わう日には 24 時間の稼働で limit 12Gi の余白(正当な定常フットプリント ~9.3GiB に対し ~2.7GiB)を食い潰すおそれがある。

この残増加への対策として、glibc の malloc arena 数を 2 に制限する。

- GC でネイティブメモリ(zlib の作業バッファ等)が free されても、glibc は断片化した arena 内に領域を抱え込み OS へ返さないため、RSS がラチェット式に増える
- glibc は cgroup を認識しないため、arena 上限のデフォルト(CPU コア数 × 8)は `limits.cpu: 4` ではなく**ノードの物理コア数**を参照して決まり、意図せず大量の arena が作られうる
- チャンク圧縮(zlib)は多スレッドから細かい malloc/free を大量に行うため、断片化の影響を受けやすい

## 確認事項

- 適用後、賑わい時間帯の working set の傾き(現状 ~0.5GiB/h)が下がるかを Grafana の Container Memory パネルで確認する。下がれば arena 断片化が残増加の主因と確定、変わらなければ真のネイティブリークとして発生源特定(NMT)に進む
- Heap / Non-Heap は計測済みで健全(Heap 使用 1〜3.5GiB / 8G、Non-Heap は上限設定内の ~460MiB で頭打ち)。今回の変更はこれらに影響しない
- MALLOC_ARENA_MAX=2 は JVM ワークロードの定番設定で、arena 競合によるわずかなスループット低下の可能性はあるが、Minecraft の負荷では実用上観測されない水準

## 補足

- 効果が確認できたら、#5486 / #5488 の JVM フラグとあわせて他の mcserver への横展開を予定
- それでも 24 時間の budget が際どい場合の次の手はヒープ縮小(8G → 6G、実測ヒープ使用は最大 3.5GiB)

🤖 Generated with Claude Code