### PR TITLE
fix: KubeletTooManyPods を kured のアラート除外リストに追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
@@ -33,7 +33,13 @@ spec:
           # KubeStatefulSetReplicasMismatch: pyroscope や debug 環境の redis が常時 firing しがちで、
           # 2026-07-15/16 の窓で全ノードの再起動を 2 日間ブロックした実績があるため、
           # 同クラスの KubeDeploymentReplicasMismatch / KubePodNotReady と同様に除外する
-          alertFilterRegexp: "^(Watchdog|InfoInhibitor|TargetDown|KubeJobFailed|CPUThrottlingHigh|PrometheusNotConnectedToAlertmanagers|KubePodCrashLooping|KubePodNotReady|KubeDeploymentReplicasMismatch|KubeStatefulSetReplicasMismatch)$"
+          # KubeletTooManyPods (severity: info): kured が 1 台ずつ drain するたびに退避先の
+          # ノードへ Pod が集中し、その偏りを解消できる唯一の手段 (= 過密ノードの drain) を
+          # このアラート自身がブロックするデッドロックになるため除外する (2026-07-19 の窓で
+          # wk-1 が 107/110 Pod になり全ノードの再起動が止まった実績)。Pod 数だけの偏りは
+          # CPU/メモリ requests が高い本クラスタでは descheduler の LowNodeUtilization でも
+          # 解消できない (全リソースが閾値未満のノードが存在しないため移動先候補が出ない)
+          alertFilterRegexp: "^(Watchdog|InfoInhibitor|TargetDown|KubeJobFailed|CPUThrottlingHigh|PrometheusNotConnectedToAlertmanagers|KubePodCrashLooping|KubePodNotReady|KubeDeploymentReplicasMismatch|KubeStatefulSetReplicasMismatch|KubeletTooManyPods)$"
           # kubelet のパッチ更新も kured の drain + 再起動に相乗りさせる。
           # pkgs.k8s.io はマイナーごとの repo (core:/stable:/v1.3x) なので、apt で入るのは
           # 同一マイナー内のパッチのみ。マイナーアップグレードは従来どおり kubeadm で手動実施し、


### PR DESCRIPTION
kured が 1 台ずつ drain するたびに退避先ノードへ Pod が集中し、
2026-07-19 の窓では wk-1 が 107/110 Pod となって KubeletTooManyPods (severity: info) が firing、全ノードの再起動がブロックされた。

この偏りを解消できる唯一の手段が過密ノード自身の drain であり、
それをこのアラートがブロックするデッドロックになるため除外する。
CPU/メモリ requests が高い本クラスタでは Pod 数だけの偏りを
descheduler の LowNodeUtilization では解消できない (全リソースが
閾値未満の「過疎ノード」が存在せず移動先候補が出ない) ことも確認済み。