### PR TITLE
fix(mcserver): ネイティブメモリ蓄積対策を s1, s2, s3, s7 へ横展開

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
@@ -83,14 +83,28 @@ spec:
             - name: EULA
               value: "TRUE"
 
+            # glibc の malloc arena の数を制限する。
+            # arena の上限はデフォルトで「CPU コア数 × 8」だが、glibc は cgroup を認識しないため
+            # ここでの CPU コア数は limits.cpu ではなくノードの物理コア数になり、arena が大量に作られうる。
+            # チャンク圧縮 (zlib) などの多スレッドからの細かい malloc/free で断片化した arena は
+            # free 済みでも OS にメモリを返さないため、RSS が戻らずに増え続ける一因になる。
+            - name: MALLOC_ARENA_MAX
+              value: "2"
+
             - name: JVM_OPTS
               # base image 側で JVM_OPTS に対して jmx exporter の設定を追加しているが、上書きが必要なためここで設定する
               # SeichiAssistによるワールドマイグレーションをするとメモリリークが発生するため、Papermc公式が推奨しているJVM Optionを追加する
               # ref: https://docs.papermc.io/paper/aikars-flags
+              #
+              # ただし Aikar's flags のうち DisableExplicitGC は ExplicitGCInvokesConcurrent に置き換えている。
+              # MaxDirectMemorySize の上限に達したとき、JVM は System.gc() を呼んで direct buffer の
+              # 回収を試みるが、DisableExplicitGC だとこの経路が塞がれて OutOfMemoryError になりうる。
+              # ExplicitGCInvokesConcurrent なら System.gc() が STW の Full GC ではなく concurrent cycle に
+              # 変換されるため、プラグインの System.gc() 呼び出しでラグらせないという元の目的も保たれる。
               value: >-
                 -javaagent:/jmx-exporter/jmx_prometheus_javaagent.jar=18321:/jmx-exporter/jmx-exporter-config.yaml
                 -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=200
-                -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:+AlwaysPreTouch
+                -XX:+UnlockExperimentalVMOptions -XX:+ExplicitGCInvokesConcurrent -XX:+AlwaysPreTouch
                 -XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M
                 -XX:G1ReservePercent=20 -XX:G1HeapWastePercent=5 -XX:G1MixedGCCountTarget=4
                 -XX:InitiatingHeapOccupancyPercent=15 -XX:G1MixedGCLiveThresholdPercent=90
@@ -99,6 +113,15 @@ spec:
                 -Daikars.new.flags=true
 
             - name: JVM_XX_OPTS
+              # G1PeriodicGCInterval: 無人時間帯は Old 世代の回収 (concurrent cycle) が一度も走らず、
+              # Cleaner 経由で解放されるネイティブメモリ (Deflater 等) が Old 世代へ昇格したまま蓄積して
+              # OOMKilled に至りうる (2026-07-18 の mcserver--s5 の障害調査より。詳細は #5486, #5488)。
+              # このフラグは「指定時間、どの GC も走らなかったとき」に concurrent cycle を強制する (JEP 346)。
+              # 無人時でも Young GC は数分に 1 回走ってタイマーをリセットするため、それより短い 1 分に設定する。
+              # 賑わっている時間帯は GC 間隔が数秒のためこのフラグは発動しない。
+              #
+              # MaxDirectMemorySize: 未設定だとデフォルトで Xmx と同額まで direct buffer が伸びられるため、
+              # コンテナの memory limit を超えうる。s5 での実測ピーク ~450MiB に対しマージンを取って 1g に制限する。
               value: >-
                 -XX:ErrorFile=/data/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError
                 -XX:HeapDumpPath=/data/ -XX:+CreateCoredumpOnCrash
@@ -107,6 +130,8 @@ spec:
                 -XX:+DebugNonSafepoints
                 -XX:ReservedCodeCacheSize=384m
                 -XX:MaxMetaspaceSize=384m
+                -XX:G1PeriodicGCInterval=60000
+                -XX:MaxDirectMemorySize=1g
 
             - name: ENABLE_JMX
               value: "true"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/stateful-set.yaml
@@ -83,14 +83,28 @@ spec:
             - name: EULA
               value: "TRUE"
 
+            # glibc の malloc arena の数を制限する。
+            # arena の上限はデフォルトで「CPU コア数 × 8」だが、glibc は cgroup を認識しないため
+            # ここでの CPU コア数は limits.cpu ではなくノードの物理コア数になり、arena が大量に作られうる。
+            # チャンク圧縮 (zlib) などの多スレッドからの細かい malloc/free で断片化した arena は
+            # free 済みでも OS にメモリを返さないため、RSS が戻らずに増え続ける一因になる。
+            - name: MALLOC_ARENA_MAX
+              value: "2"
+
             - name: JVM_OPTS
               # base image 側で JVM_OPTS に対して jmx exporter の設定を追加しているが、上書きが必要なためここで設定する
               # SeichiAssistによるワールドマイグレーションをするとメモリリークが発生するため、Papermc公式が推奨しているJVM Optionを追加する
               # ref: https://docs.papermc.io/paper/aikars-flags
+              #
+              # ただし Aikar's flags のうち DisableExplicitGC は ExplicitGCInvokesConcurrent に置き換えている。
+              # MaxDirectMemorySize の上限に達したとき、JVM は System.gc() を呼んで direct buffer の
+              # 回収を試みるが、DisableExplicitGC だとこの経路が塞がれて OutOfMemoryError になりうる。
+              # ExplicitGCInvokesConcurrent なら System.gc() が STW の Full GC ではなく concurrent cycle に
+              # 変換されるため、プラグインの System.gc() 呼び出しでラグらせないという元の目的も保たれる。
               value: >-
                 -javaagent:/jmx-exporter/jmx_prometheus_javaagent.jar=18321:/jmx-exporter/jmx-exporter-config.yaml
                 -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=200
-                -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:+AlwaysPreTouch
+                -XX:+UnlockExperimentalVMOptions -XX:+ExplicitGCInvokesConcurrent -XX:+AlwaysPreTouch
                 -XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M
                 -XX:G1ReservePercent=20 -XX:G1HeapWastePercent=5 -XX:G1MixedGCCountTarget=4
                 -XX:InitiatingHeapOccupancyPercent=15 -XX:G1MixedGCLiveThresholdPercent=90
@@ -99,6 +113,15 @@ spec:
                 -Daikars.new.flags=true
 
             - name: JVM_XX_OPTS
+              # G1PeriodicGCInterval: 無人時間帯は Old 世代の回収 (concurrent cycle) が一度も走らず、
+              # Cleaner 経由で解放されるネイティブメモリ (Deflater 等) が Old 世代へ昇格したまま蓄積して
+              # OOMKilled に至りうる (2026-07-18 の mcserver--s5 の障害調査より。詳細は #5486, #5488)。
+              # このフラグは「指定時間、どの GC も走らなかったとき」に concurrent cycle を強制する (JEP 346)。
+              # 無人時でも Young GC は数分に 1 回走ってタイマーをリセットするため、それより短い 1 分に設定する。
+              # 賑わっている時間帯は GC 間隔が数秒のためこのフラグは発動しない。
+              #
+              # MaxDirectMemorySize: 未設定だとデフォルトで Xmx と同額まで direct buffer が伸びられるため、
+              # コンテナの memory limit を超えうる。s5 での実測ピーク ~450MiB に対しマージンを取って 1g に制限する。
               value: >-
                 -XX:ErrorFile=/data/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError
                 -XX:HeapDumpPath=/data/ -XX:+CreateCoredumpOnCrash
@@ -107,6 +130,8 @@ spec:
                 -XX:+DebugNonSafepoints
                 -XX:ReservedCodeCacheSize=384m
                 -XX:MaxMetaspaceSize=384m
+                -XX:G1PeriodicGCInterval=60000
+                -XX:MaxDirectMemorySize=1g
 
             - name: ENABLE_JMX
               value: "true"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/stateful-set.yaml
@@ -83,14 +83,28 @@ spec:
             - name: EULA
               value: "TRUE"
 
+            # glibc の malloc arena の数を制限する。
+            # arena の上限はデフォルトで「CPU コア数 × 8」だが、glibc は cgroup を認識しないため
+            # ここでの CPU コア数は limits.cpu ではなくノードの物理コア数になり、arena が大量に作られうる。
+            # チャンク圧縮 (zlib) などの多スレッドからの細かい malloc/free で断片化した arena は
+            # free 済みでも OS にメモリを返さないため、RSS が戻らずに増え続ける一因になる。
+            - name: MALLOC_ARENA_MAX
+              value: "2"
+
             - name: JVM_OPTS
               # base image 側で JVM_OPTS に対して jmx exporter の設定を追加しているが、上書きが必要なためここで設定する
               # SeichiAssistによるワールドマイグレーションをするとメモリリークが発生するため、Papermc公式が推奨しているJVM Optionを追加する
               # ref: https://docs.papermc.io/paper/aikars-flags
+              #
+              # ただし Aikar's flags のうち DisableExplicitGC は ExplicitGCInvokesConcurrent に置き換えている。
+              # MaxDirectMemorySize の上限に達したとき、JVM は System.gc() を呼んで direct buffer の
+              # 回収を試みるが、DisableExplicitGC だとこの経路が塞がれて OutOfMemoryError になりうる。
+              # ExplicitGCInvokesConcurrent なら System.gc() が STW の Full GC ではなく concurrent cycle に
+              # 変換されるため、プラグインの System.gc() 呼び出しでラグらせないという元の目的も保たれる。
               value: >-
                 -javaagent:/jmx-exporter/jmx_prometheus_javaagent.jar=18321:/jmx-exporter/jmx-exporter-config.yaml
                 -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=200
-                -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:+AlwaysPreTouch
+                -XX:+UnlockExperimentalVMOptions -XX:+ExplicitGCInvokesConcurrent -XX:+AlwaysPreTouch
                 -XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M
                 -XX:G1ReservePercent=20 -XX:G1HeapWastePercent=5 -XX:G1MixedGCCountTarget=4
                 -XX:InitiatingHeapOccupancyPercent=15 -XX:G1MixedGCLiveThresholdPercent=90
@@ -99,6 +113,15 @@ spec:
                 -Daikars.new.flags=true
 
             - name: JVM_XX_OPTS
+              # G1PeriodicGCInterval: 無人時間帯は Old 世代の回収 (concurrent cycle) が一度も走らず、
+              # Cleaner 経由で解放されるネイティブメモリ (Deflater 等) が Old 世代へ昇格したまま蓄積して
+              # OOMKilled に至りうる (2026-07-18 の mcserver--s5 の障害調査より。詳細は #5486, #5488)。
+              # このフラグは「指定時間、どの GC も走らなかったとき」に concurrent cycle を強制する (JEP 346)。
+              # 無人時でも Young GC は数分に 1 回走ってタイマーをリセットするため、それより短い 1 分に設定する。
+              # 賑わっている時間帯は GC 間隔が数秒のためこのフラグは発動しない。
+              #
+              # MaxDirectMemorySize: 未設定だとデフォルトで Xmx と同額まで direct buffer が伸びられるため、
+              # コンテナの memory limit を超えうる。s5 での実測ピーク ~450MiB に対しマージンを取って 1g に制限する。
               value: >-
                 -XX:ErrorFile=/data/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError
                 -XX:HeapDumpPath=/data/ -XX:+CreateCoredumpOnCrash
@@ -107,6 +130,8 @@ spec:
                 -XX:+DebugNonSafepoints
                 -XX:ReservedCodeCacheSize=384m
                 -XX:MaxMetaspaceSize=384m
+                -XX:G1PeriodicGCInterval=60000
+                -XX:MaxDirectMemorySize=1g
 
             - name: ENABLE_JMX
               value: "true"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/stateful-set.yaml
@@ -83,14 +83,28 @@ spec:
             - name: EULA
               value: "TRUE"
 
+            # glibc の malloc arena の数を制限する。
+            # arena の上限はデフォルトで「CPU コア数 × 8」だが、glibc は cgroup を認識しないため
+            # ここでの CPU コア数は limits.cpu ではなくノードの物理コア数になり、arena が大量に作られうる。
+            # チャンク圧縮 (zlib) などの多スレッドからの細かい malloc/free で断片化した arena は
+            # free 済みでも OS にメモリを返さないため、RSS が戻らずに増え続ける一因になる。
+            - name: MALLOC_ARENA_MAX
+              value: "2"
+
             - name: JVM_OPTS
               # base image 側で JVM_OPTS に対して jmx exporter の設定を追加しているが、上書きが必要なためここで設定する
               # SeichiAssistによるワールドマイグレーションをするとメモリリークが発生するため、Papermc公式が推奨しているJVM Optionを追加する
               # ref: https://docs.papermc.io/paper/aikars-flags
+              #
+              # ただし Aikar's flags のうち DisableExplicitGC は ExplicitGCInvokesConcurrent に置き換えている。
+              # MaxDirectMemorySize の上限に達したとき、JVM は System.gc() を呼んで direct buffer の
+              # 回収を試みるが、DisableExplicitGC だとこの経路が塞がれて OutOfMemoryError になりうる。
+              # ExplicitGCInvokesConcurrent なら System.gc() が STW の Full GC ではなく concurrent cycle に
+              # 変換されるため、プラグインの System.gc() 呼び出しでラグらせないという元の目的も保たれる。
               value: >-
                 -javaagent:/jmx-exporter/jmx_prometheus_javaagent.jar=18321:/jmx-exporter/jmx-exporter-config.yaml
                 -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=200
-                -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:+AlwaysPreTouch
+                -XX:+UnlockExperimentalVMOptions -XX:+ExplicitGCInvokesConcurrent -XX:+AlwaysPreTouch
                 -XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M
                 -XX:G1ReservePercent=20 -XX:G1HeapWastePercent=5 -XX:G1MixedGCCountTarget=4
                 -XX:InitiatingHeapOccupancyPercent=15 -XX:G1MixedGCLiveThresholdPercent=90
@@ -99,6 +113,15 @@ spec:
                 -Daikars.new.flags=true
 
             - name: JVM_XX_OPTS
+              # G1PeriodicGCInterval: 無人時間帯は Old 世代の回収 (concurrent cycle) が一度も走らず、
+              # Cleaner 経由で解放されるネイティブメモリ (Deflater 等) が Old 世代へ昇格したまま蓄積して
+              # OOMKilled に至りうる (2026-07-18 の mcserver--s5 の障害調査より。詳細は #5486, #5488)。
+              # このフラグは「指定時間、どの GC も走らなかったとき」に concurrent cycle を強制する (JEP 346)。
+              # 無人時でも Young GC は数分に 1 回走ってタイマーをリセットするため、それより短い 1 分に設定する。
+              # 賑わっている時間帯は GC 間隔が数秒のためこのフラグは発動しない。
+              #
+              # MaxDirectMemorySize: 未設定だとデフォルトで Xmx と同額まで direct buffer が伸びられるため、
+              # コンテナの memory limit を超えうる。s5 での実測ピーク ~450MiB に対しマージンを取って 1g に制限する。
               value: >-
                 -XX:ErrorFile=/data/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError
                 -XX:HeapDumpPath=/data/ -XX:+CreateCoredumpOnCrash
@@ -107,6 +130,8 @@ spec:
                 -XX:+DebugNonSafepoints
                 -XX:ReservedCodeCacheSize=384m
                 -XX:MaxMetaspaceSize=384m
+                -XX:G1PeriodicGCInterval=60000
+                -XX:MaxDirectMemorySize=1g
 
             - name: ENABLE_JMX
               value: "true"


### PR DESCRIPTION
## 概要

mcserver--s5 の OOMKilled 調査(#5486, #5488, #5489)で確立したネイティブメモリ蓄積への対策一式を、同じ構成を持つ s1, s2, s3, s7 の StatefulSet に適用する。変更内容は 4 サーバーとも同一で、s5 の現行設定と揃える。

| 変更 | 目的 |
|---|---|
| `-XX:G1PeriodicGCInterval=60000` | アイドル時に Old 世代の回収を強制。GC 待ちで滞留するネイティブメモリ(Deflater 等が Cleaner 経由で握るもの)の蓄積を平衡させる |
| `-XX:MaxDirectMemorySize=1g` | direct buffer の上限(未設定だと Xmx と同額まで伸びうる) |
| `DisableExplicitGC` → `ExplicitGCInvokesConcurrent` | direct buffer 上限到達時の自己回収経路の確保。プラグインの `System.gc()` によるラグ防止という元の目的は維持される |
| `MALLOC_ARENA_MAX=2` | glibc arena の断片化による「解放済みメモリの抱え込み」の抑制 |

## 背景

- s5 は上記対策の適用前、約 3.5 時間ごとに OOMKilled されていた(7/18 だけで 3 回)。適用後は無人時間帯の増加が平衡し、賑わい時の増加も 1/3 以下になり、OOMKilled は発生していない
- s1 の 2 日分の計測で、s5 と同じ「増えたら戻らない蓄積(1 日 +3 GiB)」を確認済み。現在症状が出ていないのは余白(heap 16G に対し limit 26Gi)が大きいためで、構造的には同じ問題を抱えている
- 負荷増加時に余白の薄いサーバーから順に s5 と同じ突然死が起きうるため、全サーバーに予防適用する

## 確認事項

- 変更内容は s5 で 7/18〜7/19 に段階的に適用し、それぞれ Grafana の計測で効果を確認済み(詳細は各 PR を参照)
- 4 サーバーの該当箇所(env / JVM_OPTS / JVM_XX_OPTS)は s5 と同一構造であることを確認済み
- `MaxDirectMemorySize=1g` は s7(heap 4G)にも一律適用している。上限であって予約ではないため、heap が小さいサーバーでも実害はない(未設定時のデフォルト = Xmx より厳しくなるのみ)
- 適用には各 Pod の再起動が伴うため、Sync のタイミングは低負荷時間帯を推奨

## 補足

- draft として作成。s5 の週末フルサイクル(土曜ピーク越え)の最終確認後に ready にする想定
- 対象は s 系サーバーのみ。lobby / kagawa / one-day-to-reset / votelistener / debug 系は heap が小さく蓄積速度も遅いと見込まれるため、今回は対象外(必要になったら別 PR で追従)

🤖 Generated with Claude Code