### PR TITLE
feat(grafana): Minecraft ダッシュボードに RSS / ページキャッシュの内訳パネルを追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/jvm-metrics/grafana-dashboard.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/jvm-metrics/grafana-dashboard.yaml
@@ -1039,6 +1039,36 @@ data:
           ],
           "title": "Last Terminated Reason",
           "type": "timeseries"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "description": "Breakdown of container memory into process RSS (actual allocation; sustained growth here leads to OOM kill) and page cache (reclaimable by the kernel; growth here is harmless). If the working set grows but RSS stays flat, the growth is just cache.",
+          "fieldConfig": {
+            "defaults": {
+              "color": { "mode": "palette-classic" },
+              "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 50, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false, "stacking": { "group": "A", "mode": "normal" }, "thresholdsStyle": { "mode": "off" } },
+              "mappings": [],
+              "min": 0,
+              "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+              "unit": "bytes"
+            },
+            "overrides": [
+              { "matcher": { "id": "byRegexp", "options": ".*rss" }, "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }] },
+              { "matcher": { "id": "byRegexp", "options": ".*cache" }, "properties": [{ "id": "color", "value": { "fixedColor": "blue", "mode": "fixed" } }] }
+            ]
+          },
+          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 99 },
+          "id": 407,
+          "options": {
+            "legend": { "calcs": ["lastNotNull", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+            "tooltip": { "mode": "multi", "sort": "desc" }
+          },
+          "targets": [
+            { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "max by (pod) (container_memory_rss{namespace=\"seichi-minecraft\", pod=~\"mcserver--$server-0\", container=\"minecraft\"})", "legendFormat": "{{pod}} rss", "refId": "A" },
+            { "datasource": { "type": "prometheus", "uid": "${datasource}" }, "expr": "max by (pod) (container_memory_working_set_bytes{namespace=\"seichi-minecraft\", pod=~\"mcserver--$server-0\", container=\"minecraft\"}) - max by (pod) (container_memory_rss{namespace=\"seichi-minecraft\", pod=~\"mcserver--$server-0\", container=\"minecraft\"})", "legendFormat": "{{pod}} cache", "refId": "B" }
+          ],
+          "title": "Memory Breakdown (RSS vs Page Cache)",
+          "type": "timeseries"
         }
       ],
       "refresh": "30s",


### PR DESCRIPTION
## 概要

Minecraft Servers ダッシュボードの「Container Resources & OOM Protection」行に、コンテナメモリを **RSS(プロセスの実確保)** と **ページキャッシュ(カーネルが回収可能)** に分解した積み上げ面グラフ「Memory Breakdown (RSS vs Page Cache)」を追加する。

- 既存の Container Memory パネルが表示する working set はページキャッシュを含むため、キャッシュが増えただけでも「メモリ消費が増加している」ように見える。実際に 7/19 の s5 の監視で、ワールドファイル I/O によるキャッシュ増加(+0.7 GiB)を実メモリの増加と誤認しかけた(実際は RSS 完全平坦)
- 積み上げ面の上端は working set とほぼ一致するので、既存パネルと同じ形のグラフが成分別に色分けされて見える。「上端が増えても下段(RSS)が平坦ならキャッシュの増加であり無害」という判読ができる
- 既存パネルには手を入れていない(「limit までの距離の監視」という役割には working set 単体が適切なため)

## 確認事項

- 埋め込み JSON の構文を jq でパース確認済み(panel id 407 として追加、既存 id と重複なし)
- クエリは Grafana MCP 経由で Prometheus に対して実行し、s5 の実データで「18:49 以降の増加が cache 成分のみ」と判別できることを確認済み
- `max by (pod)` で包んでいるのは、コンテナ再起動時の cAdvisor 系列分断を吸収し、引き算のラベルマッチングを成立させるため

🤖 Generated with Claude Code