### PR TITLE
fix: ThanosSidecarUploadStale を kured のアラート除外リストに追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
@@ -39,7 +39,11 @@ spec:
           # wk-1 が 107/110 Pod になり全ノードの再起動が止まった実績)。Pod 数だけの偏りは
           # CPU/メモリ requests が高い本クラスタでは descheduler の LowNodeUtilization でも
           # 解消できない (全リソースが閾値未満のノードが存在しないため移動先候補が出ない)
-          alertFilterRegexp: "^(Watchdog|InfoInhibitor|TargetDown|KubeJobFailed|CPUThrottlingHigh|PrometheusNotConnectedToAlertmanagers|KubePodCrashLooping|KubePodNotReady|KubeDeploymentReplicasMismatch|KubeStatefulSetReplicasMismatch|KubeletTooManyPods)$"
+          # ThanosSidecarUploadStale: kured の drain で garage / Prometheus 周辺の Pod が退避される
+          # と sidecar のアップロードが滞って発火する自傷性のアラートで、放置で自己回復する。
+          # 再起動を保留してもアップロード停滞は解消しないうえ、2026-07-20 の窓で wk-2 の再起動を
+          # 3 周期 (約 40 分) ブロックし窓クローズ間際まで押し込んだ実績があるため除外する
+          alertFilterRegexp: "^(Watchdog|InfoInhibitor|TargetDown|KubeJobFailed|CPUThrottlingHigh|PrometheusNotConnectedToAlertmanagers|KubePodCrashLooping|KubePodNotReady|KubeDeploymentReplicasMismatch|KubeStatefulSetReplicasMismatch|KubeletTooManyPods|ThanosSidecarUploadStale)$"
           # kubelet のパッチ更新も kured の drain + 再起動に相乗りさせる。
           # pkgs.k8s.io はマイナーごとの repo (core:/stable:/v1.3x) なので、apt で入るのは
           # 同一マイナー内のパッチのみ。マイナーアップグレードは従来どおり kubeadm で手動実施し、


### PR DESCRIPTION
kured の drain で garage / Prometheus 周辺の Pod が退避されると sidecar のアップロード停滞で発火する自傷性のアラートで、放置で自己回復する。
2026-07-20 の再起動窓で wk-2 の再起動を 3 周期 (約 40 分) ブロックし、
窓クローズ (07:00) 間際まで押し込んだため除外する。