### PR TITLE
fix: ThanosSidecarUploadStale の sidecar 再起動直後の偽発火を修正

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
@@ -39,10 +39,10 @@ spec:
           # wk-1 が 107/110 Pod になり全ノードの再起動が止まった実績)。Pod 数だけの偏りは
           # CPU/メモリ requests が高い本クラスタでは descheduler の LowNodeUtilization でも
           # 解消できない (全リソースが閾値未満のノードが存在しないため移動先候補が出ない)
-          # ThanosSidecarUploadStale: kured の drain で garage / Prometheus 周辺の Pod が退避される
-          # と sidecar のアップロードが滞って発火する自傷性のアラートで、放置で自己回復する。
-          # 再起動を保留してもアップロード停滞は解消しないうえ、2026-07-20 の窓で wk-2 の再起動を
-          # 3 周期 (約 40 分) ブロックし窓クローズ間際まで押し込んだ実績があるため除外する
+          # ThanosSidecarUploadStale: 実態は sidecar 再起動でメトリクスが 0 リセットされることによる
+          # 偽発火で、drain が prometheus Pod を動かすたびに窓の最中に firing する (2026-07-20 の窓で
+          # wk-2 の再起動を 3 周期 (約 40 分) ブロックした実績)。アラート式側に > 0 ガードを入れて
+          # 根治したが、本物の停滞時も再起動の保留ではアップロードは復旧しないため除外は維持する
           alertFilterRegexp: "^(Watchdog|InfoInhibitor|TargetDown|KubeJobFailed|CPUThrottlingHigh|PrometheusNotConnectedToAlertmanagers|KubePodCrashLooping|KubePodNotReady|KubeDeploymentReplicasMismatch|KubeStatefulSetReplicasMismatch|KubeletTooManyPods|ThanosSidecarUploadStale)$"
           # kubelet のパッチ更新も kured の drain + 再起動に相乗りさせる。
           # pkgs.k8s.io はマイナーごとの repo (core:/stable:/v1.3x) なので、apt で入るのは

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
@@ -237,7 +237,14 @@ spec:
               - name: thanos
                 rules:
                   - alert: ThanosSidecarUploadStale
-                    expr: time() - max by (namespace, pod) (thanos_objstore_bucket_last_successful_upload_time{job="prometheus-kube-prometheus-thanos-discovery"}) > 6 * 60 * 60
+                    # thanos_objstore_bucket_last_successful_upload_time は sidecar 再起動で 0 に
+                    # リセットされるため、> 0 で除外しないと Prometheus Pod が再作成されるたびに
+                    # 「6 時間以上未アップロード」扱いで 15 分後に偽発火する (2026-07-20 の kured 窓で
+                    # drain により Pod が移動し、次の 2h ブロックのアップロード (08:00 JST) まで
+                    # 約 2.5 時間誤 firing、wk-2 の再起動を約 40 分ブロックした実績)。
+                    # 「再起動後 1 度もアップロードが成功しない」ケースはこの式では拾えなくなるが、
+                    # 能動的な失敗は ThanosSidecarUploadFailures / ThanosObjectStorageOperationFailures が検知する
+                    expr: time() - max by (namespace, pod) (thanos_objstore_bucket_last_successful_upload_time{job="prometheus-kube-prometheus-thanos-discovery"} > 0) > 6 * 60 * 60
                     for: 15m
                     labels:
                       severity: error


### PR DESCRIPTION
thanos_objstore_bucket_last_successful_upload_time は sidecar 再起動で 0 にリセットされるため、Prometheus Pod が drain 等で再作成されるたびに
「6 時間以上未アップロード」判定となり 15 分後に偽発火していた。
2026-07-20 の kured 窓では drain で Pod が移動した 05:15 から次の 2h ブロックのアップロード (08:00) まで誤 firing し、wk-2 の再起動を
約 40 分ブロックした。式に > 0 ガードを入れて 0 リセット中の系列を
評価対象から外す。あわせて kured.yaml の除外理由コメントを
正確な機序 (メトリクスリセット起因) に修正する。