### PR TITLE
fix(mcserver-debug): ネイティブメモリ蓄積対策を debug-s1, debug-s2 へ横展開

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
@@ -130,25 +130,50 @@ spec:
             - name: EULA
               value: "TRUE"
 
+            # glibc の malloc arena の数を制限する。
+            # arena の上限はデフォルトで「CPU コア数 × 8」だが、glibc は cgroup を認識しないため
+            # ここでの CPU コア数は limits.cpu ではなくノードの物理コア数になり、arena が大量に作られうる。
+            # チャンク圧縮 (zlib) などの多スレッドからの細かい malloc/free で断片化した arena は
+            # free 済みでも OS にメモリを返さないため、RSS が戻らずに増え続ける一因になる。
+            - name: MALLOC_ARENA_MAX
+              value: "2"
+
             - name: JVM_OPTS
               # base image 側で JVM_OPTS に対して jmx exporter の設定を追加しているが、上書きが必要なためここで設定する
               # SeichiAssistによるワールドマイグレーションをするとメモリリークが発生するため、Papermc公式が推奨しているJVM Optionを追加する
               # ref: https://docs.papermc.io/paper/aikars-flags
+              #
+              # ただし Aikar's flags のうち DisableExplicitGC は ExplicitGCInvokesConcurrent に置き換えている。
+              # MaxDirectMemorySize の上限に達したとき、JVM は System.gc() を呼んで direct buffer の
+              # 回収を試みるが、DisableExplicitGC だとこの経路が塞がれて OutOfMemoryError になりうる。
+              # ExplicitGCInvokesConcurrent なら System.gc() が STW の Full GC ではなく concurrent cycle に
+              # 変換されるため、プラグインの System.gc() 呼び出しでラグらせないという元の目的も保たれる。
               value: >-
                 -javaagent:/jmx-exporter/jmx_prometheus_javaagent.jar=18321:/jmx-exporter/jmx-exporter-config.yaml
-                -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=200 
-                -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:+AlwaysPreTouch 
-                -XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M 
-                -XX:G1ReservePercent=20 -XX:G1HeapWastePercent=5 -XX:G1MixedGCCountTarget=4 
-                -XX:InitiatingHeapOccupancyPercent=15 -XX:G1MixedGCLiveThresholdPercent=90 
-                -XX:G1RSetUpdatingPauseTimePercent=5 -XX:SurvivorRatio=32 -XX:+PerfDisableSharedMem 
+                -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=200
+                -XX:+UnlockExperimentalVMOptions -XX:+ExplicitGCInvokesConcurrent -XX:+AlwaysPreTouch
+                -XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M
+                -XX:G1ReservePercent=20 -XX:G1HeapWastePercent=5 -XX:G1MixedGCCountTarget=4
+                -XX:InitiatingHeapOccupancyPercent=15 -XX:G1MixedGCLiveThresholdPercent=90
+                -XX:G1RSetUpdatingPauseTimePercent=5 -XX:SurvivorRatio=32 -XX:+PerfDisableSharedMem
                 -XX:MaxTenuringThreshold=1 -Dusing.aikars.flags=https://mcflags.emc.gs
                 -Daikars.new.flags=true
 
             - name: JVM_XX_OPTS
+              # G1PeriodicGCInterval: 無人時間帯は Old 世代の回収 (concurrent cycle) が一度も走らず、
+              # Cleaner 経由で解放されるネイティブメモリ (Deflater 等) が Old 世代へ昇格したまま蓄積して
+              # OOMKilled に至りうる (2026-07-18 の mcserver--s5 の障害調査より。詳細は #5486, #5488)。
+              # このフラグは「指定時間、どの GC も走らなかったとき」に concurrent cycle を強制する (JEP 346)。
+              # 無人時でも Young GC は数分に 1 回走ってタイマーをリセットするため、それより短い 1 分に設定する。
+              # 賑わっている時間帯は GC 間隔が数秒のためこのフラグは発動しない。
+              #
+              # MaxDirectMemorySize: 未設定だとデフォルトで Xmx と同額まで direct buffer が伸びられるため、
+              # コンテナの memory limit を超えうる。s5 での実測ピーク ~450MiB に対しマージンを取って 1g に制限する。
               value: >-
                 -XX:+UnlockDiagnosticVMOptions
                 -XX:+DebugNonSafepoints
+                -XX:G1PeriodicGCInterval=60000
+                -XX:MaxDirectMemorySize=1g
 
             - name: ENABLE_JMX
               value: "true"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s2/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s2/stateful-set.yaml
@@ -130,14 +130,28 @@ spec:
             - name: EULA
               value: "TRUE"
 
+            # glibc の malloc arena の数を制限する。
+            # arena の上限はデフォルトで「CPU コア数 × 8」だが、glibc は cgroup を認識しないため
+            # ここでの CPU コア数は limits.cpu ではなくノードの物理コア数になり、arena が大量に作られうる。
+            # チャンク圧縮 (zlib) などの多スレッドからの細かい malloc/free で断片化した arena は
+            # free 済みでも OS にメモリを返さないため、RSS が戻らずに増え続ける一因になる。
+            - name: MALLOC_ARENA_MAX
+              value: "2"
+
             - name: JVM_OPTS
               # base image 側で JVM_OPTS に対して jmx exporter の設定を追加しているが、上書きが必要なためここで設定する
               # SeichiAssistによるワールドマイグレーションをするとメモリリークが発生するため、Papermc公式が推奨しているJVM Optionを追加する
               # ref: https://docs.papermc.io/paper/aikars-flags
+              #
+              # ただし Aikar's flags のうち DisableExplicitGC は ExplicitGCInvokesConcurrent に置き換えている。
+              # MaxDirectMemorySize の上限に達したとき、JVM は System.gc() を呼んで direct buffer の
+              # 回収を試みるが、DisableExplicitGC だとこの経路が塞がれて OutOfMemoryError になりうる。
+              # ExplicitGCInvokesConcurrent なら System.gc() が STW の Full GC ではなく concurrent cycle に
+              # 変換されるため、プラグインの System.gc() 呼び出しでラグらせないという元の目的も保たれる。
               value: >-
                 -javaagent:/jmx-exporter/jmx_prometheus_javaagent.jar=18321:/jmx-exporter/jmx-exporter-config.yaml
                 -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:MaxGCPauseMillis=200
-                -XX:+UnlockExperimentalVMOptions -XX:+DisableExplicitGC -XX:+AlwaysPreTouch
+                -XX:+UnlockExperimentalVMOptions -XX:+ExplicitGCInvokesConcurrent -XX:+AlwaysPreTouch
                 -XX:G1NewSizePercent=30 -XX:G1MaxNewSizePercent=40 -XX:G1HeapRegionSize=8M
                 -XX:G1ReservePercent=20 -XX:G1HeapWastePercent=5 -XX:G1MixedGCCountTarget=4
                 -XX:InitiatingHeapOccupancyPercent=15 -XX:G1MixedGCLiveThresholdPercent=90
@@ -146,9 +160,20 @@ spec:
                 -Daikars.new.flags=true
 
             - name: JVM_XX_OPTS
+              # G1PeriodicGCInterval: 無人時間帯は Old 世代の回収 (concurrent cycle) が一度も走らず、
+              # Cleaner 経由で解放されるネイティブメモリ (Deflater 等) が Old 世代へ昇格したまま蓄積して
+              # OOMKilled に至りうる (2026-07-18 の mcserver--s5 の障害調査より。詳細は #5486, #5488)。
+              # このフラグは「指定時間、どの GC も走らなかったとき」に concurrent cycle を強制する (JEP 346)。
+              # 無人時でも Young GC は数分に 1 回走ってタイマーをリセットするため、それより短い 1 分に設定する。
+              # 賑わっている時間帯は GC 間隔が数秒のためこのフラグは発動しない。
+              #
+              # MaxDirectMemorySize: 未設定だとデフォルトで Xmx と同額まで direct buffer が伸びられるため、
+              # コンテナの memory limit を超えうる。s5 での実測ピーク ~450MiB に対しマージンを取って 1g に制限する。
               value: >-
                 -XX:+UnlockDiagnosticVMOptions
                 -XX:+DebugNonSafepoints
+                -XX:G1PeriodicGCInterval=60000
+                -XX:MaxDirectMemorySize=1g
 
             - name: ENABLE_JMX
               value: "true"


### PR DESCRIPTION
## 概要

mcserver--s5 の OOMKilled 調査 (#5486, #5488, #5489) で確立し、本番の s1, s2, s3, s7 へ適用済み (#5493) のネイティブメモリ蓄積対策一式を、同じ base image・JVM フラグ構成を持つデバッグ環境の `mcserver--debug-s1`, `mcserver--debug-s2` にも適用する。

適用する変更 (すべて s5 で効果測定済み):
- `-XX:G1PeriodicGCInterval=60000`: アイドル時に Old 世代の回収を強制し、GC 待ちで滞留するネイティブメモリ (Deflater 等) の蓄積を平衡させる
- `-XX:MaxDirectMemorySize=1g`: direct buffer の上限を設ける (未設定だと Xmx と同額まで伸びうる)
- `DisableExplicitGC` → `ExplicitGCInvokesConcurrent`: direct buffer 上限到達時の自己回収経路を確保する
- `MALLOC_ARENA_MAX=2`: glibc arena の断片化による「解放済みメモリの抱え込み」を抑える

## 確認事項

- debug-s1, debug-s2 の該当箇所 (env / JVM_OPTS / JVM_XX_OPTS) は本番の s1〜s7 系と同一構造であることを確認済み
- 両サーバーとも heap 4G で、既に同じ変更を適用済みの本番 s7 (heap 4G) と同等サイズ。`MaxDirectMemorySize` は上限であって予約ではないため実害はないことは #5493 で確認済みの判断を踏襲
- デバッグ環境のため、本番同様の長時間計測での効果検証は行っていない。適用後の OOMKilled 有無・メモリ推移の観察はレビュー後の運用で確認する想定

## 補足

- PR #5493 の本文では debug 系サーバーは「heap が小さく蓄積速度も遅いと見込まれるため対象外」としていたが、今回ユーザーの依頼により debug-s1, debug-s2 の2台に横展開した

🤖 Generated with Claude Code