### PR TITLE
fix: PR デバッグ環境の lobby が Paper をダウンロードできず起動しない問題を修正

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-lobby/lobby-server.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-lobby/lobby-server.yaml
@@ -117,6 +117,11 @@ spec:
               value: PAPER
             - name: VERSION
               value: "1.18.2"
+            # api.papermc.io の v2 API が廃止され (410 Gone)、mc-image-helper 1.40.7 による
+            # ビルド解決が失敗するため、後継の fill API が返す直リンクを指定して回避する
+            # https://fill.papermc.io/v3/projects/paper/versions/1.18.2/builds/388 の server:default
+            - name: PAPER_DOWNLOAD_URL
+              value: https://fill-data.papermc.io/v1/objects/0578f18f4d632b494b468ec56b3b414b5b56fea087ee7d39cf6dcdf4c9d01f05/paper-1.18.2-388.jar
             - name: EULA
               value: "TRUE"
 


### PR DESCRIPTION
## 問題

SeichiAssist PR #2936 に `ready-for-review` ラベルを付けて PR デバッグ環境を起動したところ、`mcserver--debug-lobby-0` が CrashLoopBackOff になり環境が Healthy にならなかった。

ログを確認すると、起動時の Paper ダウンロードが失敗している:

```
me.itzg.helpers.http.FailedRequestException: HTTP request of
https://api.papermc.io/v2/projects/paper/versions/1.18.2/builds
failed with 410 Gone
```

PaperMC が旧 v2 API (api.papermc.io) を廃止したためで、手元から curl しても同じく 410 (`"error":"sunset"`) が返る。lobby のベースイメージに入っている mc-image-helper 1.40.7 は旧 API しか知らないため、リトライしても回復しない。新規に起動する PR デバッグ環境の lobby はすべて同じ理由で失敗する。

## 修正

itzg のベースイメージ更新は Java 17 系タグの更新が止まっているため難しい。代わりに、mc-image-helper が対応している `PAPER_DOWNLOAD_URL` を指定して API でのビルド解決を回避する。

URL は後継の [fill API](https://fill.papermc.io/v3/projects/paper/versions/1.18.2/builds/388) が返す `server:default` の直リンク (Paper 1.18.2 build 388、debug-s1 が現在動作しているものと同じビルド)。HTTP 200 で取得できることは確認済み。

`TYPE=PAPER` を使っているのはリポジトリ内でこの lobby のみのため、影響範囲はこの 1 箇所。

## 確認方法

マージ後、`ready-for-review` ラベルの付いた SeichiAssist PR の Application が selfHeal で再 sync され、`mcserver--debug-lobby-0` が Running になること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)