### PR TITLE
fix: イメージ署名検証の PolicyViolation を解消する (安定タグ + digest ピンで Renovate 追従に乗せる)

### DIFF
--- a/.github/workflows/build_mcserver_images.yaml
+++ b/.github/workflows/build_mcserver_images.yaml
@@ -59,10 +59,13 @@ jobs:
             image_ver: 1.0.0
           - image: ghcr.io/giganticminecraft/seichi_minecraft_server_debug_lobby
             build_context: ./docker-images/mcservers/debug/seichi-servers/individual-images/deb-lobby
+            image_ver: 1.0.0
           - image: ghcr.io/giganticminecraft/seichi_minecraft_server_debug_seichi_1
             build_context: ./docker-images/mcservers/debug/seichi-servers/individual-images/deb-s1
+            image_ver: 1.0.0
           - image: ghcr.io/giganticminecraft/seichi_minecraft_server_debug_seichi_2
             build_context: ./docker-images/mcservers/debug/seichi-servers/individual-images/deb-s2
+            image_ver: 1.0.0
 
     steps:
       - name: checkout

--- a/.github/workflows/mod_downloader.yaml
+++ b/.github/workflows/mod_downloader.yaml
@@ -61,9 +61,12 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.IMAGE }}
+          # 1.0.0 は再 push される安定タグ。マニフェスト側は 1.0.0@sha256:... で参照し、
+          # digest の更新は Renovate が追従する (mcserver 系イメージと同じ方式)
           tags: |
             type=sha,prefix=sha-,suffix=,format=short
             type=schedule,pattern={{date 'YYYYMMDD'}}
+            type=raw,value=1.0.0
 
       - name: Build (and push if on main)
         id: build

--- a/docker-images/mcservers/debug/seichi-servers/individual-images/deb-lobby/Dockerfile
+++ b/docker-images/mcservers/debug/seichi-servers/individual-images/deb-lobby/Dockerfile
@@ -1,5 +1,8 @@
 FROM ghcr.io/giganticminecraft/seichi_minecraft_server_debug_base_1_18_2:1.0.0@sha256:f05fc91cfdb7fa803d089d4039b85f070ebb5ca04887fab6cd7210d38ef1eddc
 
+# このイメージは sha-<git short SHA> タグに加えて、再 push される安定タグ 1.0.0 でも公開される。
+# マニフェスト側は 1.0.0@sha256:... で参照し、digest の更新は Renovate が追従する。
+
 COPY --link ./additional-plugin-configs /plugins
 COPY --link ./common-minecraft-server-configs /config
 

--- a/docker-images/mcservers/debug/seichi-servers/individual-images/deb-s1/Dockerfile
+++ b/docker-images/mcservers/debug/seichi-servers/individual-images/deb-s1/Dockerfile
@@ -1,5 +1,8 @@
 FROM ghcr.io/giganticminecraft/seichi_minecraft_server_debug_base_1_18_2:1.0.0@sha256:f05fc91cfdb7fa803d089d4039b85f070ebb5ca04887fab6cd7210d38ef1eddc
 
+# このイメージは sha-<git short SHA> タグに加えて、再 push される安定タグ 1.0.0 でも公開される。
+# マニフェスト側は 1.0.0@sha256:... で参照し、digest の更新は Renovate が追従する。
+
 # プラグインの設定ファイル
 COPY --link ./additional-plugin-configs /plugins
 

--- a/docker-images/mcservers/debug/seichi-servers/individual-images/deb-s2/Dockerfile
+++ b/docker-images/mcservers/debug/seichi-servers/individual-images/deb-s2/Dockerfile
@@ -1,5 +1,8 @@
 FROM ghcr.io/giganticminecraft/seichi_minecraft_server_debug_base_1_18_2:1.0.0@sha256:f05fc91cfdb7fa803d089d4039b85f070ebb5ca04887fab6cd7210d38ef1eddc
 
+# このイメージは sha-<git short SHA> タグに加えて、再 push される安定タグ 1.0.0 でも公開される。
+# マニフェスト側は 1.0.0@sha256:... で参照し、digest の更新は Renovate が追従する。
+
 # プラグインの設定ファイル
 COPY --link ./additional-plugin-configs /plugins
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -95,6 +95,19 @@
       ],
     },
     {
+      // ghcr.io/giganticminecraft/* は Kyverno の verify-ghcr-image-signatures
+      // (verifyDigest: true) の検証対象であり、tag のみの参照は
+      // "missing digest" の PolicyViolation になる。Audit モードでは
+      // mutateDigest: true を設定できないため、Git 側で digest をピン留めする
+      matchDatasources: [
+        'docker',
+      ],
+      matchPackageNames: [
+        'ghcr.io/giganticminecraft/**',
+      ],
+      pinDigests: true,
+    },
+    {
       // ノードの containerd / runc のパッチ更新はノールックで automerge する
       // (kubelet のパッチ追従は Renovate を経由せず kured の rebootCommand で完結している)。
       // マージしてもバイナリ差し替えと sentinel 作成までで、実際の再起動は


### PR DESCRIPTION
## 問題

`verify-ghcr-image-signatures` ポリシーで 2 種類の PolicyViolation が出ている (Audit モードのため Pod の起動自体はブロックされていない):

1. **`missing digest`** — ポリシーが `verifyDigest: true` のため、tag のみ (digest なし) のイメージ参照はすべて違反になる。Audit モードでは Kyverno の `mutateDigest: true` を設定できない (dbe2ffe07 参照) ため、ポリシー側での自動付与はできない。
2. **`no signatures found`** — Cosign 署名はワークフローに導入済み (469146e22, 2026-03-13) で、**最近のビルドはすべて署名されている**。違反しているのは、マニフェストが署名導入前のイメージを参照し続けている以下のみ:
   - `mod-downloader:sha-6f4c728` (2026-03-01 ビルド、26 箇所)
   - デバッグ用 mcserver イメージ (`debug_seichi_1:sha-b62e356` など、2026-02 ビルド)

## 根本原因

production 系 mcserver は「再 push される安定タグ + digest ピン (`1.0.0@sha256:...`)」で参照されており、リビルドのたびに Renovate が digest 更新 PR を出すため署名導入後も自動追従できていた (例: #5505)。一方、デバッグ用 mcserver と mod-downloader は**凍結された `sha-<commit>` タグで参照されており Renovate が追従できず**、署名導入前のイメージ参照のまま取り残されていた。

## 修正

すべて「Renovate に追従させる」方針に統一する:

- **Renovate に `pinDigests: true` を追加** (`ghcr.io/giganticminecraft/**`): digest なし参照への digest 付与を Renovate が行い、1. が解消される。GitHub Actions の digest ピン留めと同じ方針。
- **デバッグ用 mcserver 3 イメージ (`debug_lobby` / `debug_seichi_1` / `debug_seichi_2`) の matrix に `image_ver: 1.0.0` を追加**: production 系と同じく安定タグを公開する。
- **mod-downloader にも安定タグ `1.0.0` を追加**。
- Dockerfile へのコメント追記は、`dorny/paths-filter` のビルド条件 (build_context 配下の変更) を通すため。**この PR のマージで 3 つのデバッグイメージと mod-downloader が再ビルドされ、署名付きの `1.0.0` タグが公開される。**

なお `debug_base_1_18_2` は既に `image_ver: 1.0.0` があり本日リビルド済み (#5501)、truenas-exporter の最新ビルド (7a584ea22) も署名済みのため、変更は不要 (digest ピンのみで解消)。

## マージ後のフォローアップ

1. ビルド完了後、マニフェストの参照を `1.0.0@sha256:<digest>` 形式へ切り替える PR を作成する (mod-downloader 26 箇所 + デバッグ用 mcserver 5 箇所)。以後は Renovate が digest を自動追従するため、今回のような「署名導入前のまま放置」は構造的に再発しない。
2. 他リポジトリでビルドされているイメージ (seichi-portal-backend, gachadata-server, idea-reaction など) が未署名の場合は、それぞれのリポジトリで Cosign 署名の追加が別途必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)