### PR TITLE
fix: mod-downloader とデバッグ用 mcserver の参照を署名済みイメージ (1.0.0@digest) に切り替える

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-lobby/lobby-server.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-lobby/lobby-server.yaml
@@ -34,7 +34,7 @@ spec:
             - "-c"
             - 'wget -O /root/jmx-exporter-download/jmx-exporter-javaagent.jar "${JMX_EXPORTER_URL}"'
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -58,7 +58,7 @@ spec:
             - name: mod-downloader-volume
               mountPath: /plugins
         - name: world-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -192,7 +192,7 @@ spec:
                 lp group default permission set worldguard.region.flag.regions.own.* true
                 lp group default permission set joinleave.silentleave true
 
-          image: ghcr.io/giganticminecraft/seichi_minecraft_server_debug_base_1_18_2:sha-b6ee419@sha256:880ce91ee28e65b1178779aeb61a974e2e85406607138cf7694f2d8fe7d19cd3
+          image: ghcr.io/giganticminecraft/seichi_minecraft_server_debug_base_1_18_2:1.0.0@sha256:f05fc91cfdb7fa803d089d4039b85f070ebb5ca04887fab6cd7210d38ef1eddc
           name: minecraft
           ports:
             - containerPort: 25565

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       initContainers:
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -46,7 +46,7 @@ spec:
             - name: mod-downloader-volume
               mountPath: /downloaded-plugins
         - name: world-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -283,7 +283,7 @@ spec:
                 rg flag -w world_SW_the_end __global__ deny-spawn ENDER_DRAGON
                 mv reload
 
-          image: ghcr.io/giganticminecraft/seichi_minecraft_server_debug_seichi_1:sha-b62e356@sha256:f155c86e06658f57a1eb80d9fdb783a87e6906f51b95e2bdc671520acc719998
+          image: ghcr.io/giganticminecraft/seichi_minecraft_server_debug_seichi_1:1.0.0@sha256:f599e1647aa73cdd2bf16198a31bf54991619845540c5fd835a88fc8eb8bc288
           name: minecraft
           ports:
             - containerPort: 25565

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-lobby/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-lobby/stateful-set.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       initContainers:
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -145,7 +145,7 @@ spec:
                 /downloaded-plugins
                 /plugins
 
-          image: ghcr.io/giganticminecraft/seichi_minecraft_server_debug_lobby:sha-1b1f435@sha256:e8e9d01740a037642e611e576dc48cf69ea975bb2b4c8eeab514d35f7f5d0f7a
+          image: ghcr.io/giganticminecraft/seichi_minecraft_server_debug_lobby:1.0.0@sha256:e36f76fb96a4ae20e7bdf8e79c1780dcb473a00099fbfb29cec22bddfa95a21a
           name: minecraft
           ports:
             - containerPort: 25565

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       initContainers:
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -45,7 +45,7 @@ spec:
             - name: mod-downloader-volume
               mountPath: /downloaded-plugins
         - name: seichiassist-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -69,7 +69,7 @@ spec:
             - name: mod-downloader-volume
               mountPath: /downloaded-plugins
         - name: world-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -323,7 +323,7 @@ spec:
                 /downloaded-plugins
                 /plugins
 
-          image: ghcr.io/giganticminecraft/seichi_minecraft_server_debug_seichi_1:sha-b62e356@sha256:f155c86e06658f57a1eb80d9fdb783a87e6906f51b95e2bdc671520acc719998
+          image: ghcr.io/giganticminecraft/seichi_minecraft_server_debug_seichi_1:1.0.0@sha256:f599e1647aa73cdd2bf16198a31bf54991619845540c5fd835a88fc8eb8bc288
           name: minecraft
           ports:
             - containerPort: 25565

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s2/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s2/stateful-set.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       initContainers:
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -45,7 +45,7 @@ spec:
             - name: mod-downloader-volume
               mountPath: /downloaded-plugins
         - name: seichiassist-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -69,7 +69,7 @@ spec:
             - name: mod-downloader-volume
               mountPath: /downloaded-plugins
         - name: world-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -316,7 +316,7 @@ spec:
                 /downloaded-plugins
                 /plugins
 
-          image: ghcr.io/giganticminecraft/seichi_minecraft_server_debug_seichi_2:sha-944bf2c@sha256:3113c857345dbb949296972d3de224580a4fc371138d993a43d3fcf9c63c8dad
+          image: ghcr.io/giganticminecraft/seichi_minecraft_server_debug_seichi_2:1.0.0@sha256:dc27c95ddd8b4a209f4f39892e362a49394c4d7efbfabc20bd29c5037ab79cfe
           name: minecraft
           ports:
             - containerPort: 25565

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--kagawa/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--kagawa/stateful-set.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       initContainers:
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/stateful-set.yaml
@@ -25,7 +25,7 @@ spec:
         runAsUser: 1000
       initContainers:
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--one-day-to-reset/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--one-day-to-reset/stateful-set.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       initContainers:
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       initContainers:
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -45,7 +45,7 @@ spec:
             - name: mod-downloader-volume
               mountPath: /downloaded-plugins
         - name: seichiassist-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/stateful-set.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       initContainers:
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -45,7 +45,7 @@ spec:
             - name: mod-downloader-volume
               mountPath: /downloaded-plugins
         - name: seichiassist-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/stateful-set.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       initContainers:
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -45,7 +45,7 @@ spec:
             - name: mod-downloader-volume
               mountPath: /downloaded-plugins
         - name: seichiassist-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       initContainers:
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -45,7 +45,7 @@ spec:
             - name: mod-downloader-volume
               mountPath: /downloaded-plugins
         - name: seichiassist-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/stateful-set.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       initContainers:
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -45,7 +45,7 @@ spec:
             - name: mod-downloader-volume
               mountPath: /downloaded-plugins
         - name: seichiassist-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--votelistener/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--votelistener/stateful-set.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       initContainers:
         - name: mod-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900
@@ -45,7 +45,7 @@ spec:
             - name: mod-downloader-volume
               mountPath: /downloaded-plugins
         - name: seichiassist-downloader
-          image: ghcr.io/giganticminecraft/mod-downloader:sha-6f4c728
+          image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:0daa980e49144a0d6bd05e9255f1a26def14d8d303706243af34f8f9fd853738
           env:
             - name: S3_ENDPOINT
               value: garage.garage.svc.cluster.local:3900


### PR DESCRIPTION
#5508 のフォローアップ。ビルド済み・署名済み (CI 内で Kyverno と同条件の `cosign verify` を通過) の安定タグ `1.0.0` へ、digest ピン付きで参照を切り替える。

- `mod-downloader:sha-6f4c728` (2026-03-01, 未署名) → `1.0.0@sha256:0daa980e...` — 26 箇所
- `seichi_minecraft_server_debug_base_1_18_2:sha-b6ee419` → `1.0.0@sha256:f05fc91c...` (deb-* Dockerfile の FROM ピンと同一 digest)
- `seichi_minecraft_server_debug_seichi_1:sha-b62e356` → `1.0.0@sha256:f599e164...` — 2 箇所
- `seichi_minecraft_server_debug_seichi_2:sha-944bf2c` → `1.0.0@sha256:dc27c95d...`
- `seichi_minecraft_server_debug_lobby:sha-1b1f435` → `1.0.0@sha256:e36f76fb...`

これで対象イメージの `no signatures found` / `missing digest` 違反が解消され、以後の digest 更新は Renovate が追従する。

## 補足

- Renovate の #5509 (pin dependencies) は本 PR と同じ行に旧 sha- タグのまま digest を付けるため、**本 PR を先にマージ推奨**。マージ後に Renovate が #5509 を自動リベースし、残りのイメージ (gachadata-server, seichi-portal-backend など他リポジトリビルド分) のピン留めだけが残る。
- 本番 mcserver StatefulSet の initContainer (mod-downloader) も対象のため、次回 sync ウィンドウ (07:00-08:00 JST) で本番サーバーの Pod がローリング再起動される。
- 他リポジトリでビルドされているイメージが未署名の場合の署名対応は別途。

🤖 Generated with [Claude Code](https://claude.com/claude-code)