### PR TITLE
fix: Kyverno が OCI 1.1 形式の Cosign 署名を検証できるようにする (cosignOCI11)

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/kyverno-policies/verify-image-signatures.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/kyverno-policies/verify-image-signatures.yaml
@@ -24,6 +24,12 @@ spec:
           verifyDigest: true
           required: true
           useCache: true
+          # ビルド側は cosign sign --registry-referrers-mode=oci-1-1 で署名しており、
+          # 署名は OCI 1.1 形式 (fallback タグ sha256-<digest>) で保存される。
+          # Kyverno はデフォルトではレガシー形式 (sha256-<digest>.sig タグ) しか
+          # 探さないため、これを有効にしないと署名済みイメージでも
+          # "no signatures found" になる
+          cosignOCI11: true
           imageReferences:
             - "ghcr.io/giganticminecraft/*"
           attestors:


### PR DESCRIPTION
## 問題

#5511 で署名済みイメージ (digest ピン付き) への参照に切り替えたにもかかわらず、新しいイメージにも `no signatures found` の PolicyViolation が出続けていた。

切り分けの結果:

- CI が署名した digest とマニフェストの参照 digest は一致している (`mod-downloader@sha256:0daa980e...`)
- CI 内の素の `cosign verify` は同じ digest で **検証成功** している
- ghcr 上の署名は `sha256-<digest>` タグ (OCI 1.1 の fallback 形式) に存在し、レガシー形式の `sha256-<digest>.sig` タグは 404
- Kyverno だけが `no signatures found` になる

原因は、ビルド側が `cosign sign --registry-referrers-mode=oci-1-1` で署名している一方、**Kyverno はデフォルトでレガシー形式の署名タグしか探さない**こと。つまり署名導入 (2026-03-13) 以降、**production を含む全イメージで一度も検証が成功していなかった** (PolicyReport で production の StatefulSet 群にも fail が付いていることを確認)。

CI の "Verify signature like Kyverno does" ステップは、素の `cosign verify` が両形式を透過的に読めるため、このモード不一致を検出できていなかった。

## 修正

verifyImages ルールに `cosignOCI11: true` を追加する (experimental だが、デプロイ済み Kyverno v1.18.2 の CRD に存在することを `kubectl explain` で確認済み)。

Audit モードのため、万一動作しない場合も Pod 起動への影響はない。マージ後、バックグラウンドスキャンで #5511 適用済みの参照 (デバッグ環境など) が pass に変わることを確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)