### PR TITLE
fix: Cosign 署名をレガシー形式に変更し Kyverno が検証できるようにする

### DIFF
--- a/.github/workflows/build_mcserver_base_images.yaml
+++ b/.github/workflows/build_mcserver_base_images.yaml
@@ -97,7 +97,9 @@ jobs:
       - name: Sign container image with Cosign
         if: github.ref == 'refs/heads/main'
         run: |
-          cosign sign --yes --registry-referrers-mode=oci-1-1 \
+          # ghcr.io は OCI 1.1 referrers API 非対応で、cosign v3 デフォルトの bundle 形式の
+          # 署名は Kyverno が発見できないため、レガシー形式 (.sig タグ) で署名する
+          cosign sign --yes --new-bundle-format=false --use-signing-config=false \
             ${{ env.DOCKER_OUTPUT_IMAGE_NAME }}@${{ steps.build.outputs.digest }}
         env:
           COSIGN_EXPERIMENTAL: 1
@@ -111,6 +113,10 @@ jobs:
             --certificate-identity-regexp 'https://github\.com/GiganticMinecraft/.+' \
             --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
             ${{ env.DOCKER_OUTPUT_IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+
+          # 素の cosign verify は bundle 形式も透過的に読めてしまい形式のズレを
+          # 検出できないため、レガシー形式 (.sig タグ) の存在も別途確認する
+          docker buildx imagetools inspect "$(cosign triangulate ${{ env.DOCKER_OUTPUT_IMAGE_NAME }}@${{ steps.build.outputs.digest }})"
 
       - name: Run Trivy vulnerability scanner
         if: steps.build.outputs.digest != ''

--- a/.github/workflows/build_mcserver_images.yaml
+++ b/.github/workflows/build_mcserver_images.yaml
@@ -130,7 +130,9 @@ jobs:
       - if: steps.should_build.outputs.should_build == 'true' && github.ref == 'refs/heads/main'
         name: Sign container image with Cosign
         run: |
-          cosign sign --yes --registry-referrers-mode=oci-1-1 \
+          # ghcr.io は OCI 1.1 referrers API 非対応で、cosign v3 デフォルトの bundle 形式の
+          # 署名は Kyverno が発見できないため、レガシー形式 (.sig タグ) で署名する
+          cosign sign --yes --new-bundle-format=false --use-signing-config=false \
             ${{ matrix.image }}@${{ steps.build.outputs.digest }}
         env:
           COSIGN_EXPERIMENTAL: 1
@@ -144,6 +146,10 @@ jobs:
             --certificate-identity-regexp 'https://github\.com/GiganticMinecraft/.+' \
             --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
             ${{ matrix.image }}@${{ steps.build.outputs.digest }}
+
+          # 素の cosign verify は bundle 形式も透過的に読めてしまい形式のズレを
+          # 検出できないため、レガシー形式 (.sig タグ) の存在も別途確認する
+          docker buildx imagetools inspect "$(cosign triangulate ${{ matrix.image }}@${{ steps.build.outputs.digest }})"
 
       - if: steps.should_build.outputs.should_build == 'true' && steps.build.outputs.digest != ''
         name: Run Trivy vulnerability scanner

--- a/.github/workflows/mod_downloader.yaml
+++ b/.github/workflows/mod_downloader.yaml
@@ -86,7 +86,9 @@ jobs:
       - name: Sign container image with Cosign
         if: github.ref == 'refs/heads/main'
         run: |
-          cosign sign --yes --registry-referrers-mode=oci-1-1 \
+          # ghcr.io は OCI 1.1 referrers API 非対応で、cosign v3 デフォルトの bundle 形式の
+          # 署名は Kyverno が発見できないため、レガシー形式 (.sig タグ) で署名する
+          cosign sign --yes --new-bundle-format=false --use-signing-config=false \
             ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
         env:
           COSIGN_EXPERIMENTAL: 1
@@ -100,6 +102,10 @@ jobs:
             --certificate-identity-regexp 'https://github\.com/GiganticMinecraft/.+' \
             --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
             ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
+
+          # 素の cosign verify は bundle 形式も透過的に読めてしまい形式のズレを
+          # 検出できないため、レガシー形式 (.sig タグ) の存在も別途確認する
+          docker buildx imagetools inspect "$(cosign triangulate ${{ env.IMAGE }}@${{ steps.build.outputs.digest }})"
 
       - name: Run Trivy vulnerability scanner
         if: steps.build.outputs.digest != ''

--- a/.github/workflows/truenas_exporter.yaml
+++ b/.github/workflows/truenas_exporter.yaml
@@ -85,7 +85,9 @@ jobs:
       - name: Sign container image with Cosign
         if: github.ref == 'refs/heads/main'
         run: |
-          cosign sign --yes --registry-referrers-mode=oci-1-1 \
+          # ghcr.io は OCI 1.1 referrers API 非対応で、cosign v3 デフォルトの bundle 形式の
+          # 署名は Kyverno が発見できないため、レガシー形式 (.sig タグ) で署名する
+          cosign sign --yes --new-bundle-format=false --use-signing-config=false \
             ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
         env:
           COSIGN_EXPERIMENTAL: 1
@@ -99,6 +101,10 @@ jobs:
             --certificate-identity-regexp 'https://github\.com/GiganticMinecraft/.+' \
             --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
             ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
+
+          # 素の cosign verify は bundle 形式も透過的に読めてしまい形式のズレを
+          # 検出できないため、レガシー形式 (.sig タグ) の存在も別途確認する
+          docker buildx imagetools inspect "$(cosign triangulate ${{ env.IMAGE }}@${{ steps.build.outputs.digest }})"
 
       - name: Run Trivy vulnerability scanner
         if: steps.build.outputs.digest != ''

--- a/docker-images/mcservers/debug/seichi-servers/base-images/1_18_2/Dockerfile
+++ b/docker-images/mcservers/debug/seichi-servers/base-images/1_18_2/Dockerfile
@@ -3,6 +3,10 @@ FROM ghcr.io/giganticminecraft/seichi_minecraft_server_base:1.0.0-java17-jdk@sha
 
 ENV VERSION="1.18.2"
 
+# このイメージは安定タグ 1.0.0 でも公開され、マニフェスト側は 1.0.0@sha256:... で
+# 参照し、digest の更新は Renovate が追従する。
+# 署名は Kyverno が検証できるレガシー Cosign 形式 (.sig タグ) で行われる。
+
 # プラグインの設定ファイル
 COPY --link ./additional-plugin-configs /plugins
 COPY --link ./common-minecraft-server-configs /config

--- a/docker-images/mcservers/debug/seichi-servers/individual-images/deb-lobby/Dockerfile
+++ b/docker-images/mcservers/debug/seichi-servers/individual-images/deb-lobby/Dockerfile
@@ -2,6 +2,7 @@ FROM ghcr.io/giganticminecraft/seichi_minecraft_server_debug_base_1_18_2:1.0.0@s
 
 # このイメージは sha-<git short SHA> タグに加えて、再 push される安定タグ 1.0.0 でも公開される。
 # マニフェスト側は 1.0.0@sha256:... で参照し、digest の更新は Renovate が追従する。
+# 署名は Kyverno が検証できるレガシー Cosign 形式 (.sig タグ) で行われる。
 
 COPY --link ./additional-plugin-configs /plugins
 COPY --link ./common-minecraft-server-configs /config

--- a/docker-images/mcservers/debug/seichi-servers/individual-images/deb-s1/Dockerfile
+++ b/docker-images/mcservers/debug/seichi-servers/individual-images/deb-s1/Dockerfile
@@ -2,6 +2,7 @@ FROM ghcr.io/giganticminecraft/seichi_minecraft_server_debug_base_1_18_2:1.0.0@s
 
 # このイメージは sha-<git short SHA> タグに加えて、再 push される安定タグ 1.0.0 でも公開される。
 # マニフェスト側は 1.0.0@sha256:... で参照し、digest の更新は Renovate が追従する。
+# 署名は Kyverno が検証できるレガシー Cosign 形式 (.sig タグ) で行われる。
 
 # プラグインの設定ファイル
 COPY --link ./additional-plugin-configs /plugins

--- a/docker-images/mcservers/debug/seichi-servers/individual-images/deb-s2/Dockerfile
+++ b/docker-images/mcservers/debug/seichi-servers/individual-images/deb-s2/Dockerfile
@@ -2,6 +2,7 @@ FROM ghcr.io/giganticminecraft/seichi_minecraft_server_debug_base_1_18_2:1.0.0@s
 
 # このイメージは sha-<git short SHA> タグに加えて、再 push される安定タグ 1.0.0 でも公開される。
 # マニフェスト側は 1.0.0@sha256:... で参照し、digest の更新は Renovate が追従する。
+# 署名は Kyverno が検証できるレガシー Cosign 形式 (.sig タグ) で行われる。
 
 # プラグインの設定ファイル
 COPY --link ./additional-plugin-configs /plugins

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/kyverno-policies/verify-image-signatures.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/kyverno-policies/verify-image-signatures.yaml
@@ -24,12 +24,12 @@ spec:
           verifyDigest: true
           required: true
           useCache: true
-          # ビルド側は cosign sign --registry-referrers-mode=oci-1-1 で署名しており、
-          # 署名は OCI 1.1 形式 (fallback タグ sha256-<digest>) で保存される。
-          # Kyverno はデフォルトではレガシー形式 (sha256-<digest>.sig タグ) しか
-          # 探さないため、これを有効にしないと署名済みイメージでも
-          # "no signatures found" になる
-          cosignOCI11: true
+          # 署名はレガシー Cosign 形式 (sha256-<digest>.sig タグ) を前提とする。
+          # cosign v3 デフォルトの sigstore bundle 形式は、ghcr.io が OCI 1.1
+          # referrers API 非対応のため fallback タグに保存されるが、その index の
+          # descriptor に正しい artifactType が乗らず Kyverno が bundle を発見
+          # できない (type: SigstoreBundle でも検証不可)。このためビルド側は
+          # --new-bundle-format=false でレガシー形式に署名している
           imageReferences:
             - "ghcr.io/giganticminecraft/*"
           attestors:


### PR DESCRIPTION
#5512 (cosignOCI11) では解消しなかった `no signatures found` の根本対応。

## 調査で確定した事実

1. **署名自体は有効**: Kyverno v1.18.2 と同一の sigstore-go v1.1.4・同一の検証オプション (`WithTransparencyLog(1)` + `WithObserverTimestamps(1)`)・同一のポリシー (issuer + subjectRegExp + artifact digest) でローカル検証したところ**成功**した。
2. **Kyverno がバンドルを発見できない**: cosign v3 は ghcr.io が OCI 1.1 referrers API 非対応 (404) のため署名を fallback タグ `sha256-<digest>` に保存するが、その index の descriptor の artifactType が `application/vnd.oci.empty.v1+json` になっている。Kyverno は referrers を `application/vnd.dev.sigstore.bundle` プレフィックスでフィルタするため 1 件もマッチせず、`no matching signatures found` になる。Kyverno と同一の go-containerregistry v0.21.5 で再現確認済み:

   ```
   referrers entries: 1
     digest=sha256:d02ebe5360a8 artifactType="application/vnd.oci.empty.v1+json"
   kyverno-filter matched bundles: 0
   ```

3. `type: SigstoreBundle` + ignoreTlog/ignoreSCT の全組み合わせをクラスタ上のテストポリシーで試したが、フィルタ段階で落ちるためすべて fail (Kyverno main でも同ロジックのため、アップグレードでは解決しない)。

## 対応

**署名をレガシー Cosign 形式 (`sha256-<digest>.sig` タグ) に変更する** (`--new-bundle-format=false --use-signing-config=false`)。これは Kyverno のデフォルト (`type: Cosign`) が検証できる形式で、ghcr.io で完全に動作する。

- ビルドワークフロー 4 本の署名フラグを変更
- CI の検証ステップに **`.sig` タグの存在確認** (`cosign triangulate` + `imagetools inspect`) を追加 — 素の `cosign verify` は両形式を透過的に読めてしまい、今回のような形式のズレを検出できなかったため
- Kyverno ポリシーの `cosignOCI11` を撤回し、レガシー形式前提であることをコメントで明記
- デバッグ用イメージ 4 つの Dockerfile 更新は、マージ時に再ビルド (レガシー形式での再署名) を発火させるトリガー

## マージ後の流れ

1. mod-downloader / truenas-exporter / mcserver base / デバッグ用 4 イメージが再ビルドされ、レガシー形式で署名される
2. 新 digest への参照更新は Renovate (pinDigests) が自動追従
3. production 系イメージは次回の自然な再ビルド (Renovate の FROM digest 更新等) からレガシー署名になり、それまでは既存の violation が残る

🤖 Generated with [Claude Code](https://claude.com/claude-code)