### PR TITLE
fix: デバッグ環境の大容量 emptyDir を TopoLVM の generic ephemeral volume に置き換える

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-lobby/lobby-server.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-lobby/lobby-server.yaml
@@ -442,8 +442,19 @@ spec:
           emptyDir: {}
 
         # S1から取ってきたワールドデータをぶちこむボリューム
+        # emptyDir だとノードの ephemeral-storage (kubelet の eviction 対象) を
+        # 消費して Evict の引き金になるため、Pod と生死を共にする
+        # TopoLVM のローカルボリューム (generic ephemeral volume) を使う
         - name: world-download-volume
-          emptyDir: {}
+          ephemeral:
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                storageClassName: topolvm-provisioner
+                resources:
+                  requests:
+                    storage: 10Gi
 
         # WorldEditがSchematicaを保存・読み取るするためのvolume
         - name: worldedit-schematica-volume

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
@@ -331,8 +331,19 @@ spec:
           emptyDir: {}
 
         # S1から取ってきたワールドデータをぶちこむボリューム
+        # emptyDir だとノードの ephemeral-storage (kubelet の eviction 対象) を
+        # 数 GB 消費して Evict の引き金になるため、Pod と生死を共にする
+        # TopoLVM のローカルボリューム (generic ephemeral volume) を使う
         - name: world-download-volume
-          emptyDir: {}
+          ephemeral:
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                storageClassName: topolvm-provisioner
+                resources:
+                  requests:
+                    storage: 30Gi
 
         # WorldEditがSchematicaを保存・読み取るするためのvolume
         - name: worldedit-schematica-volume

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/mariadb/mariadb.yaml
@@ -169,8 +169,30 @@ spec:
               name: sqldump-volume
       restartPolicy: Always
       volumes:
+        # storage (MariaDB datadir) と sqldump-volume (本番バックアップの SQL) は
+        # 合わせて数 GB 消費する。emptyDir だとノードの ephemeral-storage
+        # (kubelet の eviction 対象) を圧迫して Evict の引き金になるため、
+        # Pod と生死を共にする TopoLVM のローカルボリュームを使う
         - name: storage
+          ephemeral:
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                storageClassName: topolvm-provisioner
+                resources:
+                  requests:
+                    storage: 20Gi
         - name: sqldump-volume
+          ephemeral:
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                storageClassName: topolvm-provisioner
+                resources:
+                  requests:
+                    storage: 10Gi
         - name: mariadb-config
           configMap:
             name: mariadb-config

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
@@ -401,8 +401,19 @@ spec:
           emptyDir: {}
 
         # Garageからダウンロードしたワールドデータを展開してMinecraftに受け渡すためのvolume
+        # emptyDir だとノードの ephemeral-storage (kubelet の eviction 対象) を
+        # 数 GB 消費して Evict の引き金になるため、Pod と生死を共にする
+        # TopoLVM のローカルボリューム (generic ephemeral volume) を使う
         - name: world-download-volume
-          emptyDir: {}
+          ephemeral:
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                storageClassName: topolvm-provisioner
+                resources:
+                  requests:
+                    storage: 30Gi
 
         # WorldEditがSchematicaを保存・読み取るするためのvolume
         - name: worldedit-schematica-volume

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s2/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s2/stateful-set.yaml
@@ -394,8 +394,19 @@ spec:
           emptyDir: {}
 
         # Garageからダウンロードしたワールドデータを展開してMinecraftに受け渡すためのvolume
+        # emptyDir だとノードの ephemeral-storage (kubelet の eviction 対象) を
+        # 数 GB 消費して Evict の引き金になるため、Pod と生死を共にする
+        # TopoLVM のローカルボリューム (generic ephemeral volume) を使う
         - name: world-download-volume
-          emptyDir: {}
+          ephemeral:
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                storageClassName: topolvm-provisioner
+                resources:
+                  requests:
+                    storage: 30Gi
 
         # WorldEditがSchematicaを保存・読み取るするためのvolume
         - name: worldedit-schematica-volume


### PR DESCRIPTION
## 問題

PR デバッグ環境の s1 が短時間に何度も再起動していた件の根本対応。原因はクラッシュではなく **kubelet による Evict の連鎖** だった (PR-2936 環境で 11:15〜12:11 UTC に 6 回):

```
The node was low on resource: ephemeral-storage.
Container world-extractor was using ..., request is 0
```

world データ (約 6GB) や debug MariaDB のデータ (6〜7GB) が emptyDir にあり、ephemeral-storage を **request 0 のまま**大量消費するため、ノードのディスクが逼迫すると真っ先に Evict される。Evict → StatefulSet が再作成 → world を再ダウンロード (それ自体がディスクを消費) → また Evict、という悪循環になっていた。当日はイメージのリビルドを複数回行ったため image 層でノードディスクが埋まり、発火しやすくなっていた。

## 対応

大容量の emptyDir を **TopoLVM の generic ephemeral volume** に置き換える:

- Pod と同時に作成・削除されるノード局所のローカル LVM ボリューム (揮発的なローカルディスク)
- kubelet の ephemeral-storage 会計から外れるため、ノードのディスク逼迫時の Evict 対象にならない
- `WaitForFirstConsumer` + 容量アノテーションでスケジューラが空き容量を考慮する (現在 wk-1: 590Gi, wk-2/3: 990Gi 空き)

| 対象 | volume | サイズ |
|---|---|---|
| PR 環境 debug-s1 | world-download-volume (/data) | 30Gi |
| PR 環境 debug-lobby | world-download-volume (/data) | 10Gi |
| PR 環境 mariadb | storage (datadir) / sqldump-volume | 20Gi / 10Gi |
| 常設 debug-s1 / debug-s2 | world-download-volume (/data) | 各 30Gi |

Pod template のみの変更なので通常のローリング更新で適用される (StatefulSet の再作成は不要)。Pod 再作成時に旧 PVC の削除を少し待つことがあるが、TopoLVM の削除は速いため実害はない想定。

## 対象外 (今後の課題)

- 常設 lobby の /data は既に volumeClaimTemplates で PVC 化されているため変更なし
- 常設 MariaDB は mariadb-operator CR の `storage.ephemeral: true` (emptyDir)。operator 側が generic ephemeral volume をサポートするか未確認のため今回は見送り
- 常設 debug-s1 / debug-s2 に**どこからもマウントされていない** 30Gi の `volumeClaimTemplates` (`mcserver--debug-s1-data` / `s2-data`、デフォルト SC = Synology iSCSI に確保) が残っている。旧設計の残骸と思われるが、volumeClaimTemplates は immutable で STS の作り直しが必要なため別途対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)