### PR TITLE
fix: PR デバッグ環境の namespace を Application の管理下に入れて閉鎖時に削除されるようにする

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/namespace.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/namespace.yaml
@@ -1,0 +1,9 @@
+# PR 環境の namespace を Application の管理リソースとして作成する。
+# ApplicationSet の CreateNamespace=true で作られた namespace は Application の
+# 管理外のため、PR クローズで Application が削除されても namespace だけが
+# 残り続けていた。管理下に入れることで、Application 削除のカスケードで
+# namespace ごと (中の PVC なども含めて) 削除されるようになる。
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: seichi-debug-minecraft-on-seichiassist-pr-{{ .Values.SeichiAssistPullRequestNumber }}


### PR DESCRIPTION
## 問題

SeichiAssist の PR がクローズされると ApplicationSet が Application を削除し、管理リソースはカスケードで消えるが、**`CreateNamespace=true` で作られた namespace は Application の管理外のため残り続ける**。現在 9 個の残骸 namespace が存在する (pr-2115 は 2 年前のもの。ほぼ空だが pr-2115 には prune 漏れの Service も残っている)。

## 対応

Namespace を chart のリソースとして明示的に作成し、Application の管理下に入れる。これにより PR クローズ → Application 削除のカスケードで namespace ごと (今後は TopoLVM の PVC なども含めて) 削除される。

- AppProject `seichi-debug-minecrafts-on-seichiassist-prs` の `clusterResourceWhitelist` は `*/*` のため権限追加は不要 (確認済み)
- ApplicationSet 側の `CreateNamespace=true` は初回 sync の順序保険として残す (ArgoCD は Namespace kind を先に適用するため実質不要だが害もない)

## 既存の残骸 namespace について

本 PR の対象は今後の分のみ。既存の 9 個は一度だけ手動削除が必要:

```sh
kubectl delete ns \
  seichi-debug-minecraft-on-seichiassist-pr-2115 \
  seichi-debug-minecraft-on-seichiassist-pr-2610 \
  seichi-debug-minecraft-on-seichiassist-pr-2617 \
  seichi-debug-minecraft-on-seichiassist-pr-2667 \
  seichi-debug-minecraft-on-seichiassist-pr-2693 \
  seichi-debug-minecraft-on-seichiassist-pr-2782 \
  seichi-debug-minecraft-on-seichiassist-pr-2861 \
  seichi-debug-minecraft-on-seichiassist-pr-2865 \
  seichi-debug-minecraft-on-seichiassist-pr-2936
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
