### PR TITLE
fix(mcserver-debug): world 展開ボリュームを 60Gi に増やし展開中の rm でピークを抑える

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/app-templates/seichi-debug-minecraft-on-seichiassist-pr/templates/debug-s1/seichiassist.yaml
@@ -83,10 +83,12 @@ spec:
                 mkdir -p "/downloaded-worlds/${BASENAME}"
                 echo "Extracting: ${f} -> /downloaded-worlds/${BASENAME}"
                 unzstd -c "${f}" | tar -xf - -C "/downloaded-worlds/${BASENAME}"
+                # 展開の済んだ圧縮ファイルはループ内で即削除する。
+                # ループ末尾で一括削除すると (全圧縮ファイル + 全展開データ) が同居し、
+                # ピーク使用量が展開後サイズの倍近くに達してボリュームが枯渇するため。
+                rm -f "${f}"
               done
               chown -R 1000:1000 /downloaded-worlds/
-              echo "Cleaning up tar.zst files..."
-              rm -f /downloaded-worlds/*.tar.zst
               echo "World data extraction complete."
               ls -la /downloaded-worlds/
           volumeMounts:
@@ -343,7 +345,9 @@ spec:
                 storageClassName: topolvm-provisioner
                 resources:
                   requests:
-                    storage: 30Gi
+                    # 展開後のワールド合計が約 31 GiB (2026-07 実測) あり 30Gi では展開中に枯渇していた。
+                    # 実データ + 稼働中の world 増加分の余裕を見て 60Gi にする。
+                    storage: 60Gi
 
         # WorldEditがSchematicaを保存・読み取るするためのvolume
         - name: worldedit-schematica-volume

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s1/stateful-set.yaml
@@ -106,10 +106,12 @@ spec:
                 mkdir -p "/downloaded-worlds/${BASENAME}"
                 echo "Extracting: ${f} -> /downloaded-worlds/${BASENAME}"
                 unzstd -c "${f}" | tar -xf - -C "/downloaded-worlds/${BASENAME}"
+                # 展開の済んだ圧縮ファイルはループ内で即削除する。
+                # ループ末尾で一括削除すると (全圧縮ファイル + 全展開データ) が同居し、
+                # ピーク使用量が展開後サイズの倍近くに達してボリュームが枯渇するため。
+                rm -f "${f}"
               done
               chown -R 1000:1000 /downloaded-worlds/
-              echo "Cleaning up tar.zst files..."
-              rm -f /downloaded-worlds/*.tar.zst
               echo "World data extraction complete."
               ls -la /downloaded-worlds/
           volumeMounts:
@@ -413,7 +415,9 @@ spec:
                 storageClassName: topolvm-provisioner
                 resources:
                   requests:
-                    storage: 30Gi
+                    # 展開後のワールド合計が約 31 GiB (2026-07 実測) あり 30Gi では展開中に枯渇していた。
+                    # 実データ + 稼働中の world 増加分の余裕を見て 60Gi にする。
+                    storage: 60Gi
 
         # WorldEditがSchematicaを保存・読み取るするためのvolume
         - name: worldedit-schematica-volume

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s2/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/mcserver--debug-s2/stateful-set.yaml
@@ -106,10 +106,12 @@ spec:
                 mkdir -p "/downloaded-worlds/${BASENAME}"
                 echo "Extracting: ${f} -> /downloaded-worlds/${BASENAME}"
                 unzstd -c "${f}" | tar -xf - -C "/downloaded-worlds/${BASENAME}"
+                # 展開の済んだ圧縮ファイルはループ内で即削除する。
+                # ループ末尾で一括削除すると (全圧縮ファイル + 全展開データ) が同居し、
+                # ピーク使用量が展開後サイズの倍近くに達してボリュームが枯渇するため。
+                rm -f "${f}"
               done
               chown -R 1000:1000 /downloaded-worlds/
-              echo "Cleaning up tar.zst files..."
-              rm -f /downloaded-worlds/*.tar.zst
               echo "World data extraction complete."
               ls -la /downloaded-worlds/
           volumeMounts:
@@ -406,7 +408,9 @@ spec:
                 storageClassName: topolvm-provisioner
                 resources:
                   requests:
-                    storage: 30Gi
+                    # 展開後のワールド合計が約 31 GiB (2026-07 実測) あり 30Gi では展開中に枯渇していた。
+                    # 実データ + 稼働中の world 増加分の余裕を見て 60Gi にする。
+                    storage: 60Gi
 
         # WorldEditがSchematicaを保存・読み取るするためのvolume
         - name: worldedit-schematica-volume


### PR DESCRIPTION
## 概要

デバッグ環境 `mcserver--debug-s1` / `mcserver--debug-s2` の `world-extractor` init コンテナが `No space left on device` で落ち、`Init:CrashLoopBackOff` から復帰できなくなっていた問題を修正する。

## 原因(実測ベース)

ワールド展開先の `world-download-volume`(TopoLVM generic ephemeral, **30Gi**)が容量不足だった。稼働中 Pod に read-only で ephemeral container を差し込んで実測した結果:

| 項目 | 実測値 |
|---|---|
| 展開後のワールド合計 | **31.13 GiB** (33,425,274,880 bytes) |
| 圧縮 tar.zst 合計 | ~21.7 GiB |
| 展開中のピーク使用量(現行スクリプト) | **~52.8 GiB** |

- 展開後データ(31.13 GiB)だけで 30Gi を超過している。
- さらに現行の extractor は圧縮 tar.zst をループ末尾まで削除しないため、`(全圧縮 + 全展開)` が同居してピークが ~52.8 GiB に達し、`world_SW_2` の展開途中で枯渇していた。
- `c72f7a4fd`(emptyDir → 30Gi TopoLVM 移行)のコミットメッセージにある「world データ 約 6GB」は圧縮量の過小見積もりで、実データ(特に `world_SW_2/3/4` が各 ~8 GiB)と乖離していた。

内訳(展開後):

| world | 圧縮 | 展開後 |
|---|---|---|
| world_2 | 1.0G | 4.04 GiB |
| world_SW_2 | 6.2G | 8.09 GiB |
| world_SW_3 | 6.8G | 8.61 GiB |
| world_SW_4 | 6.3G | 8.18 GiB |
| world_SW_nether | 1.0G | 1.13 GiB |
| world_2/SW_the_end, world_SW | | ~1.1 GiB |
| **合計** | ~21.7G | **31.13 GiB** |

## 変更内容(s1 / s2 / PR 環境テンプレート `debug-s1`)

1. **`storage: 30Gi` → `60Gi`**
   展開後 31 GiB + 稼働中の world 増加分の余裕を確保。両ノードの TopoLVM 空きは 560 GiB (wk-1) / 960 GiB (wk-3) で余力十分。
2. **展開ループ内で `rm -f "${f}"`**
   圧縮ファイルを展開直後に削除し、`(全圧縮 + 全展開)` の同居を解消。ピークを ~37 GiB に抑え、リトライ時の再展開も不要になる(末尾の一括 `rm` は削除)。

## デプロイ手順(マージ後・手動)

`seichi-debug-minecraft-mcserver--debug-s1` / `-s2` は auto-sync **オフ** のため手動同期が必要:

\`\`\`
argocd sync seichi-debug-minecraft-mcserver--debug-s1
argocd sync seichi-debug-minecraft-mcserver--debug-s2
kubectl delete pod mcserver--debug-s1-0 mcserver--debug-s2-0 -n seichi-debug-minecraft
\`\`\`

ephemeral PVC は Pod 削除で GC され、再作成時にテンプレートの 60Gi + 新 extractor で作り直される(ワールドは Garage から再取得)。

> 即時復旧が必要な場合は、マージを待たず既存 PVC を `kubectl patch ... storage=60Gi`(`allowVolumeExpansion=true`)でオンライン拡張すれば、現行 extractor が次のリトライで完走する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)