### PR TITLE
feat(argo-workflows): failedPodRestart を有効化してノード退避からの自動復旧を追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/argo-workflows.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/argo-workflows.yaml
@@ -34,6 +34,9 @@ spec:
                 strategy: OnWorkflowSuccess
               ttlStrategy:
                 secondsAfterCompletion: 592200
+          failedPodRestart:
+            enabled: true
+            maxRestarts: 3
         executor:
           env:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT


### PR DESCRIPTION
## Summary
- Argo Workflows の `controller.failedPodRestart` を有効化 (`enabled: true`, `maxRestarts: 3`)
- ノード Evict / NodeShutdown / NodeAffinity 不一致 / UnexpectedAdmissionError 等でメインコンテナ起動前に Pod が失敗した際、`retryStrategy` なしでも自動的に Pod を再作成できるようになります(v4.0 で追加された機能)
- `mcserver-backup-workflow-template` の DAG (StatefulSet スケールダウン → バックアップ → 復旧) は各ステップに `retryStrategy` を持っていないため、バックアップ実行中のノード一時障害でワークフロー全体が失敗しやすい状態でした。本変更はテンプレート側の変更なしにこの種の一過性インフラ障害への耐性を上げます

## Test plan
- [x] `helm repo add argo https://argoproj.github.io/argo-helm` → `helm pull argo/argo-workflows --version 1.0.20` でチャートを取得し、変更前後の values で `helm template` をローカル実行、差分が `workflow-controller-configmap` の `failedPodRestart.enabled: false → true` (および付随する `checksum/cm` アノテーション更新)のみであることを確認
- [x] `helm lint` がエラーなしで通過することを確認
- [ ] ArgoCD の自動 sync 後、`workflow-controller-configmap` に `failedPodRestart` セクションが反映され、コントローラ Pod がロールアウトされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)