### PR TITLE
fix(argocd): repoServer/applicationSet の replicaCount を replicas に修正

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/argocd-helm-chart-values.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/argocd-helm-chart-values.yaml
@@ -150,7 +150,7 @@ redis:
         release: prometheus
 
 repoServer:
-  replicaCount: 1
+  replicas: 1
   resources:
     requests:
       cpu: 200m
@@ -163,7 +163,7 @@ repoServer:
         release: prometheus
 
 applicationSet:
-  replicaCount: 1
+  replicas: 1
   resources:
     requests:
       cpu: 15m


### PR DESCRIPTION
## Summary
- argo-helm chart `argo-cd`(現行 v10.1.4)の `repoServer`/`applicationSet` Deployment テンプレートは `.Values.<component>.replicas` を参照するが、`argocd-helm-chart-values.yaml` では chart に存在しない `replicaCount` キーが使われていた
- Helm は未知のキーを黙って無視するため、この値は何年もの間ずっと無視されており、実質的に chart デフォルト(1)がそのまま使われていた
- キー名を正しい `replicas` に修正。値(1)自体は変えていない

## Verification
- `helm pull argo-helm/argo-cd --version 10.1.4` で現行 pin バージョンの chart を取得し、修正前後の values で `helm template` を実行して出力を diff → **完全に差分なし**(修正前後で `replicas: 1` が同じ値で描画されることを確認、つまり今回の変更は現状の挙動に影響しない安全な変更)

## Test plan
- [x] `helm template` で修正前後の描画結果が一致することを確認済み(ローカルで実施)
- [ ] ArgoCD が Terraform 経由でこの values を pick up して正常に sync されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)