### PR TITLE
fix: mcserver-backup WorkflowTemplate の gauge メトリクスに realtime を追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/workflow-template.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/workflow-template.yaml
@@ -146,6 +146,7 @@ spec:
               - key: server
                 value: "{{inputs.parameters.statefulset-name}}"
             gauge:
+              realtime: true
               value: "{{duration}}"
       volumes:
         - name: backup-target-volume
@@ -234,6 +235,7 @@ spec:
               - key: server
                 value: "{{inputs.parameters.coreprotect-db-name}}"
             gauge:
+              realtime: true
               value: "{{duration}}"
       script:
         image: mirror.gcr.io/mariadb:11.8


### PR DESCRIPTION
## Summary
- ArgoCD で `mcserver-backup-workflow-template` の適用が invalid になっていた不具合を修正
  - `spec.templates[5].metrics.prometheus[0].gauge.realtime: Required value`
  - `spec.templates[6].metrics.prometheus[0].gauge.realtime: Required value`
- Argo Workflows CRD (`argoproj.io_workflowtemplates`) では `metrics.prometheus[].gauge.realtime` が required フィールドであり、`run-backup` / `delete-coreprotect-db` テンプレートの duration gauge (`{{duration}}`) がこれを省略していたため validation エラーになっていた
- クラスタで使用中の chart (`argo-workflows` 1.0.22 / appVersion v4.0.8) の CRD、および upstream の公式ドキュメント・example (`docs/metrics.md`, `docs/variables.md`, `examples/custom-metrics.yaml`) を確認し、テンプレートレベルの `{{duration}}` はリアルタイム変数としてサポートされているため `realtime: true` を設定
- なお、直近の Renovate による chart バージョンアップ（1.0.20→1.0.22, #5544）が原因ではなく、メトリクス追加時（4月, f952eb2e5）から一貫して invalid だったことも確認済み（当時の chart 1.0.7 / appVersion v4.0.4 でも `realtime` は既に required だった）

## Test plan
- [ ] マージ後、ArgoCD で `mcserver-minecraft-workflows` (WorkflowTemplate) の sync/validation エラーが解消されることを確認
- [ ] 実際にバックアップ Workflow を1回実行し、`backup_step_duration_seconds` メトリクスが Prometheus に出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)