### PR TITLE
fix(pyroscope): metastore に PVC を張り raft の無限選挙ループを止める

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-pyroscope.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-pyroscope.yaml
@@ -35,10 +35,46 @@ spec:
           enabled: false
 
         pyroscope:
-          # v2 アーキテクチャ: profile を Garage (S3 互換) に直接書き込むため
-          # ローカル PVC は不要。chart デフォルトでも false だが意図を明示する。
+          # v2 でも metastore だけは stateful で、ローカル PVC が必須。
+          # profile の block 本体は Garage (S3 互換) に直接書かれるが、
+          # metastore は raft の WAL / snapshot / block index を
+          # /data-metastore (data ボリュームの .metastore subPath) に置く。
+          # 上流も -metastore.raft.dir / -metastore.raft.snapshots-dir の
+          # help に "It must be a persistent directory, not a tmpfs or
+          # similar." と明記している。
+          #
+          # chart デフォルトの persistence.enabled=false では data ボリュームが
+          # emptyDir になり、
+          #   1. WAL がノードの root fs (他コンテナと共有・IOPS 分離なし) に載る
+          #   2. Pod 再作成のたびに block index が全消失し、Garage に書き済みの
+          #      block が全て参照不能になる (起動時の DLQ 復旧ストームと
+          #      "failed to find blocks ... Key not found" の原因)
+          # という二重の問題があったため PVC を張る。
+          #
+          # 容量: v2 はローカルに block 本体を置かないので、載るのは
+          # raft の WAL / snapshot と block index だけ。
+          # - WAL は snapshot-threshold(8192) + trailing-logs(18432) で
+          #   おおよそ 26k entry に上限が付く
+          # - snapshot は snapshots-retain=3 で index 3 世代分
+          # - index は追跡中の block 数に比例して伸びる (ここだけ非有界)
+          # Garage の pyroscope バケットは 3 ヶ月で 41.6 GiB / 313,969
+          # オブジェクト。block 1 つあたりの metadata が数 KB とすると
+          # index は GB 未満のオーダーに収まる見込みだが、これまで index が
+          # Pod 再作成のたびに消えていたため定常状態を観測できていない。
+          # chart デフォルトの 10Gi でも足りる公算が高いものの、WAL が
+          # ENOSPC を踏むと今回直している metastore 停止そのものが再発する
+          # ため、余裕を持たせて 32Gi にする。
+          # (synology-iscsi-storage は ALLOWVOLUMEEXPANSION=true なので
+          #  後からオンライン拡張も可能)
+          #
+          # storageClass: monitoring 名前空間の他の stateful ワークロード
+          # (prometheus / loki / tempo / thanos) と揃える。ノード障害時に
+          # index を失わないことを優先し、ノード局所の topolvm ではなく
+          # ネットワーク越しの iSCSI を選ぶ。
           persistence:
-            enabled: false
+            enabled: true
+            size: 32Gi
+            storageClassName: synology-iscsi-storage
 
           # Pyroscope 自身への自己 scrape を停止。
           # chart デフォルトは pyroscope Pod に
@@ -56,6 +92,29 @@ spec:
           extraArgs:
             # structuredConfig 内の ${VAR} を環境変数で展開させる
             config.expand-env: "true"
+
+            # chart デフォルトは debug。1 Pod で 1 日あたり 1200 万行超を
+            # Loki に流していたため info に落とす。
+            log.level: info
+
+            # raft のログストア書き込みに被せられる 10s のタイムアウトを外す。
+            # 上流の timeoutLogStore は、タイムアウト時に raft へ error を返す
+            # 一方で書き込み goroutine はそのまま走り続ける実装になっており、
+            # WAL には index N が書かれたのに raft のメモリ上の lastLog は
+            # N-1 のまま、という乖離が起きる。こうなると leader に昇格する
+            # たびに no-op entry の append が
+            #   "non-monotonic log entries: tried to append index N after N"
+            # で失敗して follower に降格し、選挙が無限ループする
+            # (実際に term が 111527 まで進み、compaction が数日間停止した)。
+            #
+            # この timeout は「leader のディスクが詰まったとき follower に
+            # 選挙を起こさせる」ためのもので、replicaCount=1 の単一ノード
+            # 構成では得るものが無い (降格しても同じノードが再選するだけ)。
+            # 0 を渡すと上流は wrapper 自体を無効化するため、乖離の余地を消す。
+            # 代わりにディスクが詰まった場合は metastore が停止するが、
+            # 状態が壊れて数日間気付けないよりは望ましい。
+            metastore.raft.log-store-timeout: "0"
+
             # architecture.storage=v2 では write-path=segment-writer も必須だが
             # chart 2.0.1 は v2 を立てても write-path を自動セットしない (確認済)。
             # 起動時に "write-path=segment-writer is required for v2 storage layer"


### PR DESCRIPTION
## 症状

Pyroscope の metastore が数日間 leader 選挙を無限ループし、compaction が完全に停止していました。エラーログは毎時 36,000 行、うち `failed to prepare compaction plan` が 31,775 行 (約 9 回/秒)。Alloy からの push も 500 で弾かれて profile が落ちています。

```
caller=compaction_service.go:96 level=error component=metastore
  msg="failed to prepare compaction plan"
  err="rpc error: code = Unavailable desc = node is not the leader"
```

Loki で見る限り 8 日前 (retention の限界) には既に同じレートで出ており、少なくとも 1 週間以上この状態でした。ArgoCD 上は Synced / Healthy、Grafana の Pyroscope datasource も health OK なので、何も検知できていませんでした。

## 原因

`replicaCount=1` の単一ノードなのに leader になれないのは raft の状態が壊れていたためです。以下を毎秒繰り返していました。

```
raft: election won: term=111527 tally=1
raft: entering leader state: leader="Node at 10.96.132.147:9099 [Leader]"
raft: failed to commit logs: error="unable to store logs within log store,
  err: \"non-monotonic log entries: tried to append index 123305 after 123305\""
raft: entering follower state
```

機序は上流の [`pkg/metastore/raftnode/logstore.go`](https://github.com/grafana/pyroscope/blob/v2.2.0/pkg/metastore/raftnode/logstore.go) の `timeoutLogStore` にあります。`StoreLogs` を goroutine で回して 10s (`metastore.raft.log-store-timeout` のデフォルト) で見切りますが、タイムアウト時に raft へ error を返す一方で**書き込み goroutine 自体は止まりません**。

```go
case <-time.After(s.timeout):
    ...
    return fmt.Errorf("log store write timed out after %s", s.timeout)
```

結果 WAL には index N が書かれたのに raft のメモリ上の `lastLog` は N-1 のまま乖離し、以降 leader に昇格するたび no-op entry の append が non-monotonic で落ちて降格する、を無限に繰り返します。**乖離はメモリ上の状態なので、プロセスを再起動するまで自然回復しません** (term が 111527 まで進んでいました)。

引き金は WAL の書き込みが 10s を超えたこと。metastore の `/data-metastore` (raft の WAL / snapshot / block index) が `persistence.enabled=false` により emptyDir、つまりノードの root fs 上にあり、他コンテナの書き込み層と共有で IOPS 分離がありませんでした。上流も `-metastore.raft.dir` / `-metastore.raft.snapshots-dir` の help に **"It must be a persistent directory, not a tmpfs or similar."** と明記しています。

emptyDir はもう一つ、**復旧手段そのものを壊していました**。この状態から抜けるには Pod 再作成しかありませんが、それをやると block index が丸ごと消え、Garage に書き済みの block が全て参照不能になります。起動時の DLQ 復旧ストームと `failed to find blocks ... Key not found` はその後遺症です。

なお values の元コメント「v2 は S3 に直接書くのでローカル PVC は不要」は、block 本体については正しいものの metastore については誤りでした。metastore は v2 で唯一の stateful コンポーネントです ([upstream docs](https://grafana.com/docs/pyroscope/latest/reference-pyroscope-v2-architecture/components/))。

## 対処

- **`persistence.enabled=true`** で `/data-metastore` を PVC に載せる
  - storageClass は monitoring の他の stateful ワークロード (prometheus / loki / tempo / thanos) と揃えて `synology-iscsi-storage`。ノード障害で index を失わないことを優先し、ノード局所の topolvm は選んでいません
  - 容量 32Gi。内訳は WAL (snapshot-threshold 8192 + trailing-logs 18432 で約 26k entry に上限)、snapshot 3 世代、block index (block 数に比例、ここだけ非有界)。Garage の pyroscope バケットが 3 ヶ月で 41.6 GiB / 313,969 オブジェクトなので index は GB 未満のオーダーの見込みですが、**index が毎回消えていたため定常状態を観測できていません**。chart デフォルトの 10Gi でも足りる公算が高いものの、WAL が ENOSPC を踏むと今回直している停止そのものが再発するため余裕を持たせました (`ALLOWVOLUMEEXPANSION=true` なので後からオンライン拡張も可能)
- **`metastore.raft.log-store-timeout=0`** で `timeoutLogStore` を無効化し、乖離が起きる余地自体を消す
  - この timeout は「leader のディスクが詰まったとき follower に選挙を起こさせる」ためのもので、単一ノード構成では降格しても同じノードが再選するだけで得るものがありません。上流実装も `timeout <= 0` なら wrapper ごとバイパスします
  - 代わりにディスクが詰まった場合は metastore が停止しますが、状態が壊れて 1 週間気付けないよりは望ましいと判断しました
- **`log.level` を chart デフォルトの debug から info へ** — 1 Pod で 1 日 1200 万行超を Loki に流していました

## 検証

chart 2.2.0 を実 values で `helm template` して確認済み。

```
- "-log.level=info"
- "-metastore.raft.log-store-timeout=0"
volumeClaimTemplates: data / 32Gi / synology-iscsi-storage
```

`emptyDir` は消え、`/data-metastore` (subPath `.metastore`) が PVC に載ります。Garage の secret 参照など既存の設定はそのまま維持されています。

## ⚠️ マージ後に一度だけ手作業が必要

StatefulSet の `volumeClaimTemplates` は immutable なので、この変更は既存 StatefulSet への apply が失敗します (server-side dry-run で確認済)。

```
The StatefulSet "pyroscope" is invalid: spec: Forbidden: updates to statefulset spec
for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy',
'revisionHistoryLimit', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds'
are forbidden
```

マージ後に一度だけ手で消して ArgoCD に作り直させてください。

```console
kubectl delete statefulset pyroscope -n monitoring --cascade=orphan
kubectl delete pod pyroscope-0 -n monitoring
```

現状 metastore の状態は emptyDir 上にあり Pod 再作成のたびに失われているので、この操作で新たに失うものはありません。

## フォローアップ (このPRの範囲外)

- Garage の pyroscope バケットに 41.6 GiB / 313,969 オブジェクト + 56,437 件の unfinished upload が溜まっています。大半は index から孤立した block なので、別途クリーンアップを検討したほうがよさそうです
- 今回 `/ready` は緑のまま、ArgoCD も Healthy のまま 1 週間以上壊れていました。raft の leader 不在や compaction 停止を検知する PrometheusRule があると良さそうです (現状 pyroscope は Prometheus に scrape されていません)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
