### PR TITLE
feat: seichi-portal-frontend を本番環境へ追加する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cloudflared-tunnel-exits/http-exits.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cloudflared-tunnel-exits/http-exits.yaml
@@ -76,6 +76,11 @@ spec:
             external-hostname: portal.public-gigantic-api.seichi.click
             internal-authority: "seichi-portal-backend.seichi-minecraft:80"
 
+          # 整地サーバーのフォームを置き換えるポータルサイト。
+          - name: seichi-portal-frontend
+            external-hostname: portal.seichi.click
+            internal-authority: "seichi-portal-frontend.seichi-minecraft:80"
+
           # gachadata.sqlを公開するためのエンドポイント。
           - name: gachadata-server
             external-hostname: gachadata.public-gigantic-api.seichi.click

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-frontend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-frontend/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: seichi-portal-frontend
+  namespace: seichi-minecraft
+  labels:
+    app: seichi-portal-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: seichi-portal-frontend
+  template:
+    metadata:
+      labels:
+        app: seichi-portal-frontend
+    spec:
+      containers:
+        - name: seichi-portal-frontend
+          image: ghcr.io/giganticminecraft/seichi-portal-frontend:0.2.0@sha256:d913390091df9bae0f8163cb59e4bcf6f94de970b3cf09afc8b9ad7d03d060b4
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 100m
+              memory: 256Mi
+          env:
+            - name: MS_APP_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: seichi-portal-frontend-secrets
+                  key: MS_APP_CLIENT_ID
+            - name: MS_APP_REDIRECT_URL
+              value: https://portal.seichi.click
+            - name: BACKEND_SERVER_URL
+              value: http://seichi-portal-backend:80
+            - name: DISCORD_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: seichi-portal-frontend-secrets
+                  key: DISCORD_CLIENT_ID
+            - name: DISCORD_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: seichi-portal-frontend-secrets
+                  key: DISCORD_CLIENT_SECRET
+            - name: DISCORD_REDIRECT_URI
+              value: https://portal.seichi.click/api/discord
+            - name: NEXT_PUBLIC_DEBUG_MODE
+              value: "false"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-frontend/service.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-frontend/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: seichi-minecraft
+  name: seichi-portal-frontend
+spec:
+  type: ClusterIP
+  ports:
+    - name: seichi-portal-frontend-web
+      port: 80
+      protocol: TCP
+      targetPort: 3000
+  selector:
+    app: seichi-portal-frontend

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -598,6 +598,28 @@ variable "meilisearch__master_key" {
 
 #endregion
 
+#region seichi-portal-frontend secrets
+
+variable "seichi_portal_frontend__ms_app_client_id" {
+  description = "Microsoft Entra ID application client ID for seichi-portal-frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "seichi_portal_frontend__discord_client_id" {
+  description = "Discord application client ID for seichi-portal-frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "seichi_portal_frontend__discord_client_secret" {
+  description = "Discord application client secret for seichi-portal-frontend"
+  type        = string
+  sensitive   = true
+}
+
+#endregion
+
 #region tailscale-approval-bot secrets
 
 variable "tailscale_approval_bot__tailnet" {

--- a/terraform/onp_cluster_minecraft_secrets.tf
+++ b/terraform/onp_cluster_minecraft_secrets.tf
@@ -280,6 +280,23 @@ resource "kubernetes_secret_v1" "seichi_portal_meilisearch_master_key" {
   type = "Opaque"
 }
 
+resource "kubernetes_secret_v1" "seichi_portal_frontend_secrets" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
+
+  metadata {
+    name      = "seichi-portal-frontend-secrets"
+    namespace = "seichi-minecraft"
+  }
+
+  data = {
+    MS_APP_CLIENT_ID      = var.seichi_portal_frontend__ms_app_client_id
+    DISCORD_CLIENT_ID     = var.seichi_portal_frontend__discord_client_id
+    DISCORD_CLIENT_SECRET = var.seichi_portal_frontend__discord_client_secret
+  }
+
+  type = "Opaque"
+}
+
 resource "kubernetes_secret_v1" "tailscale_approval_bot_secrets" {
   depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 


### PR DESCRIPTION
## 概要
- seichi-portal-frontend の Deployment と Service を seichi-minecraft namespace に追加します。
- コンテナは 3000 番で待ち受け、Service は 80 番から 3000 番へ転送します。
- portal.seichi.click の Cloudflare Tunnel、Terraform 管理の OAuth Secret を追加します。

## 確認事項
- `terraform fmt -check -diff` を実行し、成功しました。
- `git diff --check` を実行し、成功しました。
- イメージは `0.2.0@sha256:...` 形式で digest 固定しています。
- `terraform validate` はローカルに provider plugin がないため未実行です。
- Kubernetes dry-run はローカルにクラスタ API がないため未実行です。
- Terraform の PR workflow で、登録済みの OAuth Secret を使った plan 確認が必要です。

## 補足
- フロントエンド側の image release workflow が Cosign 署名を行っていないため、現行の Kyverno Audit ポリシーでは PolicyViolation が記録される可能性があります。

🤖 Generated with Codex