### PR TITLE
chore(prometheus): kube-prometheus-stack を 87.21.0 へ更新し Git と実機のバージョン差を解消する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     chart: kube-prometheus-stack
     repoURL: https://prometheus-community.github.io/helm-charts
-    targetRevision: 87.19.1
+    targetRevision: 87.21.0
     helm:
       releaseName: prometheus
       skipCrds: false


### PR DESCRIPTION
Closes #5598

## 背景

リポジトリの kube-prometheus-stack は 87.19.1 のままだが、実クラスタでは 87.21.0 が稼働しており GitOps 上の差分がある。

## 差分が生じた経緯(調査結果)

ArgoCD の `prometheus` Application の deploy history を確認したところ:

| revision | deployedAt (UTC) |
|---|---|
| 87.19.0 | 2026-07-22 11:56 |
| 87.19.1 | 2026-07-24 22:17 |
| **87.21.0** | **2026-08-01 00:50** |

2026-08-01 00:50 UTC に Application spec の `targetRevision` が直接 87.21.0 へ変更されて sync されている(Git を経由しない手動変更)。現在の live Application spec も `targetRevision: 87.21.0` で Synced / Healthy。

## 変更内容

- `targetRevision: 87.19.1` → `87.21.0`

実機と同一バージョンに合わせるため、この PR の sync でクラスタ側の実体は変化しない(Git 定義が実態に追いつくだけ)。なお upstream には 88.x が出ているが、メジャーアップデートは本 PR のスコープ外とした。

## 受け入れ条件の確認方法

- ArgoCD 上で `prometheus` Application が Synced / Healthy のままであること
- app-of-other-apps 側の差分が解消されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)