### PR TITLE
feat(prometheus): Alertmanager を null receiver で有効化する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
@@ -19,7 +19,7 @@ spec:
           create: true
           rules:
             kubeProxy: false
-            alertmanager: false
+            alertmanager: true
             windows: false
         prometheus-windows-exporter:
           prometheus:
@@ -280,8 +280,21 @@ spec:
                     expr: 1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes
                   - record: node:node_cpu_utilisation:avg5m
                     expr: 1 - avg by (node) (rate(node_cpu_seconds_total{mode="idle"}[5m]))
+        # どこにも通知しない状態(null receiver)で有効化し、Prometheus との接続のみ確立する。
+        # chart デフォルトの config は root receiver が "null" だが、通知が飛ばないことが
+        # 運用上の前提であるため、GitOps 定義として明示的に固定している。
+        # Discord 通知経路の追加は #5601、HA 化は #5600 で行う。
         alertmanager:
-          enabled: false
+          enabled: true
+          config:
+            route:
+              receiver: "null"
+              routes:
+                - receiver: "null"
+                  matchers:
+                    - alertname = "Watchdog"
+            receivers:
+              - name: "null"
         kubeApiServer:
           serviceMonitor:
             metricRelabelings:


### PR DESCRIPTION
Closes #5599

**⚠️ スタック PR**: #5615 (#5598 のバージョン差解消) の上に積んでいます。#5615 が先にマージされると base は自動的に main へ切り替わります。

## 変更内容

- `alertmanager.enabled: false` → `true`(32d9c5ed3 / 2023-05-24 以来の無効化を解除)
- root receiver を `"null"` に明示し、どの通知先にも送信しない状態で起動する
  - chart デフォルト config も root receiver は `"null"` だが、「通知が飛ばない」ことが運用上の前提のため GitOps 定義として明示した
  - `Watchdog` の null ルーティング(chart デフォルトと同一)も明示
  - `global` / `inhibit_rules` / `route.group_by` 等は helm の deep merge により chart デフォルトが維持される
- `defaultRules.rules.alertmanager: true` で Alertmanager 自身の監視ルール(AlertmanagerConfigInconsistent 等)を有効化

## 受け入れ条件

- [ ] Prometheus の Alertmanager endpoint が healthy になる(`/api/v1/alertmanagers`)
- [ ] `PrometheusNotConnectedToAlertmanagers` が resolved になる
- [ ] どの receiver にも通知が飛んでいない(receiver は `"null"` のみ)

## 後続

- HA 化・PDB・PVC: #5600
- Discord 通知経路(`notify=discord` opt-in): #5601

🤖 Generated with [Claude Code](https://claude.com/claude-code)