### PR TITLE
chore(k8s-monitoring): chart を 4.3.2 へ更新する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-k8s-monitoring.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-k8s-monitoring.yaml
@@ -13,7 +13,7 @@ spec:
   source:
     chart: k8s-monitoring
     repoURL: https://grafana.github.io/helm-charts
-    targetRevision: 4.3.1
+    targetRevision: 4.3.2
     helm:
       values: |
         cluster:


### PR DESCRIPTION
Closes #5605

## 変更内容

- grafana-k8s-monitoring の chart バージョンを 4.3.1 → 4.3.2 へ更新(2026-08-01 時点の最新。4.x が現行メジャーで 5.x は存在しないことを helm repo index で確認済み)

seichi-portal の OTel 受け入れ設定(#5607, #5608)を積む前のパッチ適用。values の変更はなし。

## 受け入れ条件の確認方法

- ArgoCD で `k8s-monitoring` Application が Synced / Healthy
- Alloy 各コンポーネント(alloy-singleton / alloy-logs / alloy-receiver / alloy-profiles)が正常稼働

🤖 Generated with [Claude Code](https://claude.com/claude-code)