### PR TITLE
feat(cilium): seichi-portal → alloy-receiver の OTLP/Faro 通信を明示許可する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/monitoring-default-deny-policy/allow--from-seichi-portal--to-alloy-receiver.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/monitoring-default-deny-policy/allow--from-seichi-portal--to-alloy-receiver.yaml
@@ -1,0 +1,30 @@
+# seichi-minecraft namespace の seichi-portal (backend/frontend) から
+# Alloy receiver への OTLP HTTP (4318/TCP) / Faro (12347/TCP) の ingress 許可。
+# 対になる seichi-minecraft 側の egress 許可は
+# apps/seichi-minecraft/default-deny-policy/ にある。
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow--from-seichi-portal--to-alloy-receiver
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: alloy-receiver
+      app.kubernetes.io/instance: k8s-monitoring-alloy-receiver
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: seichi-minecraft
+          matchExpressions:
+            - key: app
+              operator: In
+              values:
+                - seichi-portal-backend
+                - seichi-portal-frontend
+      toPorts:
+        - ports:
+            - port: "4318"
+              protocol: TCP
+            - port: "12347"
+              protocol: TCP

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/default-deny-policy/allow--from-seichi-portal--to-alloy-receiver.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/default-deny-policy/allow--from-seichi-portal--to-alloy-receiver.yaml
@@ -1,0 +1,32 @@
+# seichi-portal (backend/frontend) が OTel テレメトリを monitoring namespace の
+# Alloy receiver (k8s-monitoring-alloy-receiver) へ送るための egress 許可。
+#   - 4318/TCP:  OTLP HTTP (traces/logs/metrics)
+#   - 12347/TCP: Faro receiver (frontend の Next.js が /collect を receiver へプロキシする)
+# 対になる monitoring 側の ingress 許可は
+# apps/cluster-wide-apps/monitoring-default-deny-policy/ にある。
+# seichi-portal-frontend の Deployment は未追加 (#5610) だが、
+# backend と同じ app ラベル体系を前提に先回りで対象へ含めている。
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow--from-seichi-portal--to-alloy-receiver
+spec:
+  endpointSelector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - seichi-portal-backend
+          - seichi-portal-frontend
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: monitoring
+            app.kubernetes.io/name: alloy-receiver
+            app.kubernetes.io/instance: k8s-monitoring-alloy-receiver
+      toPorts:
+        - ports:
+            - port: "4318"
+              protocol: TCP
+            - port: "12347"
+              protocol: TCP


### PR DESCRIPTION
Closes #5607

## 変更内容

policyAuditMode 解除に備え、seichi-portal から Alloy receiver への通信を両側の namespace で明示許可する CiliumNetworkPolicy を追加します。

1. **seichi-minecraft 側 egress** (`apps/seichi-minecraft/default-deny-policy/`)
   - `app in (seichi-portal-backend, seichi-portal-frontend)` の Pod → monitoring の alloy-receiver への 4318/TCP・12347/TCP
2. **monitoring 側 ingress** (`apps/cluster-wide-apps/monitoring-default-deny-policy/`)
   - alloy-receiver Pod への同ポートの ingress を seichi-minecraft の portal Pod からのみ許可

issue の作業内容は egress 側のみですが、monitoring namespace にも default-deny があるため、受け入れ条件(audit ログに違反が出ない)を満たすには ingress 側の対も必要と判断して両方入れています。

## 実装メモ

- alloy-receiver の Pod ラベルは実クラスタで確認済み: `app.kubernetes.io/name: alloy-receiver` + `app.kubernetes.io/instance: k8s-monitoring-alloy-receiver`(Service `k8s-monitoring-alloy-receiver` の selector と同一)
- `seichi-portal-frontend` はまだ Deployment が存在しない(#5610)ため先回りの指定です。#5610 実装時に `app: seichi-portal-frontend` ラベルへ揃えてください
- ポリシーは audit モード中の追加なので、既存トラフィックへの影響はありません

## ⚠️ レビュー時に判断してほしい点(audit 解除の前提に関わる)

既存の `default-deny-all` は `ingressDeny` / `egressDeny`(明示 Deny ルール)方式ですが、Cilium は **Deny ポリシーが Allow より常に優先**されます:

> "Deny policies take precedence over allow policies, regardless of whether they are a Cilium Network Policy, a Clusterwide Cilium Network Policy or even a Kubernetes Network Policy."
> — https://docs.cilium.io/en/stable/security/policy/deny/

このため、entities `all` に対する Deny が残ったまま policyAuditMode を解除すると、**本 PR を含むすべての allow rule は効かず全断**になります。また audit モード中も「drop されるはずの通信」として記録され続けるため、audit カウントもゼロにならない可能性が高いです。audit 解除の前に、default-deny を「明示 Deny」ではなく「ポリシー存在による default deny」(空の `ingress:` / `egress:` セクション等)へ変換する必要があると思われます。本 PR のスコープ外のため手は入れていませんが、別 issue 化を推奨します。

## 受け入れ条件の確認方法

- Hubble の NetworkPolicy Planning ダッシュボードで、portal → alloy-receiver:4318/12347 の通信がポリシー違反(audit)として計上されなくなること(backend の OTel 導入後に確認可能)

🤖 Generated with [Claude Code](https://claude.com/claude-code)