### PR TITLE
fix(seichi-portal): DISCORD_BOT_TOKEN を Secret 経由で供給し CrashLoopBackOff を解消する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
@@ -67,3 +67,8 @@ spec:
               value: "5672"
             - name: RABBITMQ_ROUTING_KEY
               value: seichi_portal
+            - name: DISCORD_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: seichi-portal-discord-bot-token
+                  key: DISCORD_BOT_TOKEN

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -598,6 +598,16 @@ variable "meilisearch__master_key" {
 
 #endregion
 
+#region seichi-portal secrets
+
+variable "seichi_portal__discord_bot_token" {
+  description = "Discord bot token for seichi-portal-backend"
+  type        = string
+  sensitive   = true
+}
+
+#endregion
+
 #region tailscale-approval-bot secrets
 
 variable "tailscale_approval_bot__tailnet" {

--- a/terraform/onp_cluster_minecraft_secrets.tf
+++ b/terraform/onp_cluster_minecraft_secrets.tf
@@ -280,6 +280,21 @@ resource "kubernetes_secret_v1" "seichi_portal_meilisearch_master_key" {
   type = "Opaque"
 }
 
+resource "kubernetes_secret_v1" "seichi_portal_discord_bot_token" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
+
+  metadata {
+    name      = "seichi-portal-discord-bot-token"
+    namespace = "seichi-minecraft"
+  }
+
+  data = {
+    DISCORD_BOT_TOKEN = var.seichi_portal__discord_bot_token
+  }
+
+  type = "Opaque"
+}
+
 resource "kubernetes_secret_v1" "tailscale_approval_bot_secrets" {
   depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 


### PR DESCRIPTION
Closes #5606

## 変更内容

seichi-portal-backend は起動時に `DISCORD_` prefix の envy デシリアライズで `bot_token` を要求しており([config.rs](https://github.com/GiganticMinecraft/seichi-portal-backend/blob/main/server/infra/resource/src/outgoing/config.rs))、`DISCORD_BOT_TOKEN` が未供給のため panic → CrashLoopBackOff していました。既存の Discord bot token 群と同じパターンで配線します。

- **Terraform** (`main.tf`): sensitive variable `seichi_portal__discord_bot_token` を追加
- **Terraform** (`onp_cluster_minecraft_secrets.tf`): Secret `seichi-portal-discord-bot-token`(namespace: seichi-minecraft、key: `DISCORD_BOT_TOKEN`)を作成
- **k8s** (`seichi-portal-backend/deployment.yaml`): `DISCORD_BOT_TOKEN` を secretKeyRef で注入

## ⚠️ マージ前に必要な人間の作業

このリポジトリの GitHub Actions Secret に **`TF_VAR_SEICHI_PORTAL__DISCORD_BOT_TOKEN`** を実トークン値で登録してください(`expose-all-tf-vars-to-github-env.sh` が小文字化して `TF_VAR_seichi_portal__discord_bot_token` として渡します)。

**未登録のままマージすると main の terraform apply が変数未定義で失敗します。**

## マージ後の流れ

1. terraform apply が Secret `seichi-portal-discord-bot-token` を作成
2. ArgoCD が Deployment を sync(Secret 作成前に sync された場合は一時的に `CreateContainerConfigError` になりますが、Secret 作成後の kubelet リトライで自然回復します)
3. Pod が Ready になり `GET /health` が 200 を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)