### PR TITLE
chore: seichi-portal-backendを0.2.0へ更新

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: seichi-minecraft
   labels:
     app: seichi-portal-backend
+  annotations:
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   selector:
@@ -17,7 +19,7 @@ spec:
     spec:
       containers:
         - name: seichi-portal-backend
-          image: ghcr.io/giganticminecraft/seichi-portal-backend:main-649c758@sha256:41644723938d101c004b817e0534f10a36479a8b7b38539df7031aed0e5ac36e
+          image: ghcr.io/giganticminecraft/seichi-portal-backend:0.2.0@sha256:c1681fc6d7c3e32c24b77bc28dee2d0d0d3725767785eeaf10a4bf06bea86da6
           resources:
             requests:
               cpu: 50m
@@ -43,6 +45,8 @@ spec:
               value: "9000"
             - name: ENV_NAME
               value: production
+            - name: FRONTEND_URL
+              value: https://portal.seichi.click
             - name: REDIS_HOST
               value: seichi-portal-valkey
             - name: REDIS_PORT
@@ -54,6 +58,16 @@ spec:
                 secretKeyRef:
                   name: seichi-portal-meilisearch-master-key
                   key: MEILI_MASTER_KEY
+            - name: MINECRAFT_BANS_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: seichi-portal-backend-secrets
+                  key: MINECRAFT_BANS_DATABASE_URL
+            - name: DISCORD_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: seichi-portal-backend-secrets
+                  key: DISCORD_BOT_TOKEN
             - name: RABBITMQ_USER
               value: seichi-portal
             - name: RABBITMQ_PASSWORD

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -598,6 +598,16 @@ variable "meilisearch__master_key" {
 
 #endregion
 
+#region seichi-portal-backend secrets
+
+variable "seichi_portal_backend__discord_bot_token" {
+  description = "Discord bot token for seichi-portal-backend"
+  type        = string
+  sensitive   = true
+}
+
+#endregion
+
 #region seichi-portal-frontend secrets
 
 variable "seichi_portal_frontend__ms_app_client_id" {

--- a/terraform/onp_cluster_minecraft_secrets.tf
+++ b/terraform/onp_cluster_minecraft_secrets.tf
@@ -280,6 +280,25 @@ resource "kubernetes_secret_v1" "seichi_portal_meilisearch_master_key" {
   type = "Opaque"
 }
 
+resource "kubernetes_secret_v1" "seichi_portal_backend_secrets" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
+
+  metadata {
+    name      = "seichi-portal-backend-secrets"
+    namespace = "seichi-minecraft"
+  }
+
+  data = {
+    DISCORD_BOT_TOKEN = var.seichi_portal_backend__discord_bot_token
+    MINECRAFT_BANS_DATABASE_URL = format(
+      "mysql://litebans:%s@mariadb:3306/litebans_gigantic_prod",
+      urlencode(random_password.minecraft__prod_mariadb_litebans_password.result),
+    )
+  }
+
+  type = "Opaque"
+}
+
 resource "kubernetes_secret_v1" "seichi_portal_frontend_secrets" {
   depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 


### PR DESCRIPTION
## 概要
- seichi-portal-backend を `0.2.0` の linux/amd64 digest 固定へ更新
- v0.2.0 で必要になる `FRONTEND_URL`、LiteBans 接続 URL、Discord Bot Token を設定
- Terraform Secret と既存の Reloader 設定で、秘密値の管理と Secret 更新時の再起動を構成

## 確認事項
- `terraform init -backend=false -input=false` を実行して provider を初期化
- `terraform validate -no-color` が成功
- `terraform fmt -check` が成功
- `git diff --check` が成功
- v0.2.0 の公式ソースと既存の LiteBans DB 定義を照合し、`mariadb` / `litebans` / `litebans_gigantic_prod` を確認
- 独立レビューで MUST FIX / SHOULD FIX なしを確認

## 補足
- GitHub Actions Secret `TF_VAR_SEICHI_PORTAL_BACKEND__DISCORD_BOT_TOKEN` の登録が必要です。未登録のままでは Terraform apply が失敗します。
- 使用している image digest は linux/amd64 用です。ARM ノードでの利用時は別 digest の確認が必要です。
- Kubernetes API server が利用できない環境のため、live apply と kubectl の OpenAPI dry-run は未実施です。

🤖 Generated with Codex