### PR TITLE
feat(seichi-portal-frontend): OTel 環境変数と reloader annotation を追加する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-frontend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-frontend/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: seichi-minecraft
   labels:
     app: seichi-portal-frontend
+  annotations:
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   selector:
@@ -53,3 +55,14 @@ spec:
               value: https://portal.seichi.click/api/discord
             - name: NEXT_PUBLIC_DEBUG_MODE
               value: "false"
+            # OTel SDK (@vercel/otel) 導入 (seichi-portal-frontend#932) 前は参照されない
+            - name: OTEL_SERVICE_NAME
+              value: "seichi-portal-frontend"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://k8s-monitoring-alloy-receiver.monitoring.svc.cluster.local:4318"
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: "http/protobuf"
+            - name: OTEL_TRACES_SAMPLER
+              value: "parentbased_always_on"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "service.namespace=seichi-portal,deployment.environment=production,deployment.environment.name=production"


### PR DESCRIPTION
Closes #5610

#5595 でデプロイ定義本体は導入済みのため、issue のチェックリストで残っていた OTel env を追加します。

- OTel env 一式(`OTEL_SERVICE_NAME: seichi-portal-frontend`、Alloy receiver への endpoint 等、seichi-game-data-publisher と同セット)。@vercel/otel 導入(seichi-portal-frontend#932)前は参照されない no-op
- `reloader.stakater.com/auto` annotation(backend が #5623 で付けたものと同様、`seichi-portal-frontend-secrets` ローテーション時に Pod を自動再起動させる)

🤖 Generated with [Claude Code](https://claude.com/claude-code)