### PR TITLE
feat(seichi-portal-backend): OTel 環境変数とリソース増強を追加する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
@@ -94,5 +94,8 @@ spec:
               value: "http/protobuf"
             - name: OTEL_TRACES_SAMPLER
               value: "parentbased_always_on"
+            # service.version はここに書くと Renovate のイメージ更新(image: 行のみ書き換え)に
+            # 追従できず乖離するため含めない。アプリ側で CARGO_PKG_VERSION から
+            # OTel resource に埋め込むのが正
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "service.namespace=seichi-portal,deployment.environment=production,deployment.environment.name=production,service.version=0.2.0"
+              value: "service.namespace=seichi-portal,deployment.environment=production,deployment.environment.name=production"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
@@ -16,16 +16,21 @@ spec:
     metadata:
       labels:
         app: seichi-portal-backend
+      annotations:
+        resource.opentelemetry.io/service.name: seichi-portal-backend
+        resource.opentelemetry.io/service.namespace: seichi-portal
     spec:
       containers:
         - name: seichi-portal-backend
           image: ghcr.io/giganticminecraft/seichi-portal-backend:0.2.0@sha256:c1681fc6d7c3e32c24b77bc28dee2d0d0d3725767785eeaf10a4bf06bea86da6
           resources:
+            # OTel exporter のオーバーヘッド吸収のため limit を 100m から 300m へ増強
+            # (seichi-game-data-publisher が exporter 導入時に 50m→300m へ増強した実績に倣う)
             requests:
               cpu: 50m
               memory: 128Mi
             limits:
-              cpu: 100m
+              cpu: 300m
               memory: 256Mi
           env:
             - name: MYSQL_DATABASE
@@ -81,3 +86,13 @@ spec:
               value: "5672"
             - name: RABBITMQ_ROUTING_KEY
               value: seichi_portal
+            - name: OTEL_SERVICE_NAME
+              value: "seichi-portal-backend"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://k8s-monitoring-alloy-receiver.monitoring.svc.cluster.local:4318"
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: "http/protobuf"
+            - name: OTEL_TRACES_SAMPLER
+              value: "parentbased_always_on"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "service.namespace=seichi-portal,deployment.environment=production,deployment.environment.name=production,service.version=0.2.0"


### PR DESCRIPTION
Closes #5609

依存はいずれも解消済み:
- backend の OTel 計装リリース → 0.2.0 に `tracing_opentelemetry` 導入済み(#5623 でデプロイ済み)
- #5607(Cilium allow rule)→ #5619 でマージ済み

## 変更内容

- OTel env 一式を追加(export 先は Alloy receiver :4318、seichi-game-data-publisher と同セット)。`OTEL_RESOURCE_ATTRIBUTES` に `service.version=0.2.0` を含めたが、この値はイメージタグ更新時に追従しないため、リリース手順で更新するか外すかはレビューで判断してほしい
- CPU limit を 100m → 300m へ増強(game-data-publisher が exporter 導入時に CFS throttling を起こした実績への予防)
- pod annotation `resource.opentelemetry.io/service.name` / `service.namespace` を付与

## 注意

backend Pod は現在 ca-certificates 欠落による sentry 初期化 panic で CrashLoopBackOff 中です(#5606 のコメント参照)。そちらが解消されるまで、この PR の受け入れ条件(Tempo で `service.name=seichi-portal-backend` のトレースが検索できる)は確認できません。マージ自体は独立して可能です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)