### PR TITLE
feat(prometheus): Alertmanager を HA 構成にする

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
@@ -283,7 +283,7 @@ spec:
         # どこにも通知しない状態(null receiver)で有効化し、Prometheus との接続のみ確立する。
         # chart デフォルトの config は root receiver が "null" だが、通知が飛ばないことが
         # 運用上の前提であるため、GitOps 定義として明示的に固定している。
-        # Discord 通知経路の追加は #5601、HA 化は #5600 で行う。
+        # Discord 通知経路の追加は #5601 で行う。
         alertmanager:
           enabled: true
           config:
@@ -295,6 +295,28 @@ spec:
                     - alertname = "Watchdog"
             receivers:
               - name: "null"
+          # 通知・Silence の可用性を確保するための HA 構成。
+          # Prometheus 自体は 1 レプリカのため、ルール評価までは HA にならない(受容済み)。
+          podDisruptionBudget:
+            enabled: true
+            minAvailable: 1
+          alertmanagerSpec:
+            replicas: 2
+            podAntiAffinity: hard
+            # Silence・通知状態 (nflog) の永続化。Alertmanager の状態は小さいので 1Gi で十分
+            storage:
+              volumeClaimTemplate:
+                spec:
+                  resources:
+                    requests:
+                      storage: 1Gi
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                cpu: 100m
+                memory: 128Mi
         kubeApiServer:
           serviceMonitor:
             metricRelabelings:


### PR DESCRIPTION
Closes #5600

#5616 で null receiver 有効化済みの Alertmanager に運用要件を足します。

## 変更内容

- `alertmanagerSpec.replicas: 2` + `podAntiAffinity: hard`(別ノードに強制分散。operator が gossip クラスタリングを自動構成し、Prometheus は両レプリカへ fan-out 送信する)
- PDB `minAvailable: 1`(kured のノード drain で 2 台同時に落ちない)
- PVC 1Gi(Silence・通知状態 nflog の永続化。storageClass はデフォルト = Prometheus 本体と同じ)
- resources: requests 10m/64Mi, limits 100m/128Mi

Prometheus 自体は 1 レプリカのままなので、ルール評価までは HA になりません(issue 記載どおり受容)。

## 確認方法

- `alertmanager-prometheus-kube-prometheus-alertmanager-{0,1}` が別ノードで Running
- 片系 Pod を削除しても Prometheus の Alertmanager endpoint が 1 系で healthy を維持
- Pod 再作成後に Silence が保持されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)