### PR TITLE
feat: faro.receiver に rate limit 引き上げと seichi-portal の source map location を設定する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-k8s-monitoring.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-k8s-monitoring.yaml
@@ -303,12 +303,13 @@ spec:
                   // seichi-portal-sourcemaps バケットへ
                   //   {release}/_next/static/**/*.map
                   // のキーでアップロードする (seichi-portal-frontend#934)。
-                  // {{ .Release }} は Faro SDK の app.release (payload の
-                  // Meta.App.Release) で置換されるため、frontend 側は app.release に
-                  // リリースバージョンを設定する必要がある。
+                  // path 中の .Release テンプレートは Faro SDK の app.release
+                  // (payload の Meta.App.Release) で置換されるため、frontend 側は
+                  // app.release にリリースバージョンを設定する必要がある。
+                  // (Helm の tpl に食われないよう二重括弧をエスケープしている)
                   location {
                     minified_path_prefix = "https://portal.seichi.click/_next/static/"
-                    path                 = "http://seichi-portal-sourcemaps.garage.svc.cluster.local/{{ .Release }}/_next/static/"
+                    path                 = "http://seichi-portal-sourcemaps.garage.svc.cluster.local/{{ "{{" }} .Release {{ "}}" }}/_next/static/"
                   }
                 }
 

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-portal-sourcemaps/service.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-portal-sourcemaps/service.yaml
@@ -1,0 +1,24 @@
+# seichi-portal-frontend の source map を Alloy faro.receiver が取得するための
+# クラスタ内エンドポイント。Garage の s3-web (3902/TCP) を指す。
+#
+# Garage の web エンドポイントは Host ヘッダでバケットを解決する。この Service の
+# FQDN (seichi-portal-sourcemaps.garage.svc.cluster.local) は web の rootDomain
+# (.web.garage.svc.cluster.local) に一致しないため、Garage はホスト名全体を
+# バケットエイリアスとして解決する。そのためバケット側に
+#   global alias: seichi-portal-sourcemaps.garage.svc.cluster.local
+# を付与し、website access を許可しておく必要がある (#5608 の運用手順参照)。
+apiVersion: v1
+kind: Service
+metadata:
+  name: seichi-portal-sourcemaps
+  namespace: garage
+spec:
+  type: ClusterIP
+  ports:
+    - name: s3-web
+      port: 80
+      targetPort: 3902
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: garage
+    app.kubernetes.io/instance: garage

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/monitoring-default-deny-policy/allow--from-alloy-receiver--to-garage-web.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/monitoring-default-deny-policy/allow--from-alloy-receiver--to-garage-web.yaml
@@ -1,0 +1,25 @@
+# alloy-receiver の faro.receiver (sourcemaps location) が seichi-portal の
+# source map を Garage の web エンドポイント (3902/TCP) から取得するための
+# egress 許可。到達先の Service 定義は
+# apps/cluster-wide-apps/garage-portal-sourcemaps/ にある。
+# garage namespace 側に default-deny はないため ingress 側の対は不要。
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow--from-alloy-receiver--to-garage-web
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: alloy-receiver
+      app.kubernetes.io/instance: k8s-monitoring-alloy-receiver
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: garage
+            app.kubernetes.io/name: garage
+            app.kubernetes.io/instance: garage
+      toPorts:
+        - ports:
+            - port: "3902"
+              protocol: TCP


### PR DESCRIPTION
## 概要

seichi-portal-frontend のブラウザ計装（Faro）受け入れ準備の仕上げです（#5608）。

> [!NOTE]
> faro.receiver の rate limit 引き上げ・sourcemaps 設定の**本体は #5629 に巻き込まれる形で main に入っています**（共有作業環境でのコミット混線のため）。本 PR はその際に欠けた 3 点を補完する差分に組み直しました。

## 変更内容

### 1. `.Release` テンプレートの tpl 保護（バグ修正）

main の現状では location の path に書かれた `{{ .Release }}` が Helm の `tpl` に展開され、レンダリング結果が

```
path = "http://seichi-portal-sourcemaps.garage.svc.cluster.local/map[IsInstall:true IsUpgrade:false ...]/_next/static/"
```

というゴミパスになっています（ArgoCD が sync 済み。バケット未作成のため実害はまだ無し）。二重括弧エスケープで Alloy にリテラルの `{{ .Release }}` が渡るよう修正しました。**chart 4.3.2 の `helm template` でリテラル生存を検証済み**です。

### 2. source map 取得経路の Service 追加

Garage の web エンドポイントは Host ヘッダでバケットを解決するため、専用 Service `seichi-portal-sourcemaps`（ns: garage、:80 → garage pods :3902）を追加。この FQDN をバケットの global alias にする方式です（下記運用手順）。

### 3. NetworkPolicy

alloy-receiver → garage s3-web (3902/TCP) の egress 許可を `monitoring-default-deny-policy/` に追加（garage ns に default-deny は無いため ingress 側の対は不要）。

## マージ後に必要な運用手順（Garage 側、要 admin）

```sh
garage bucket create seichi-portal-sourcemaps
garage bucket alias --global seichi-portal-sourcemaps seichi-portal-sourcemaps.garage.svc.cluster.local
garage bucket website --allow seichi-portal-sourcemaps
garage key create seichi-portal-sourcemaps-ci
garage bucket allow --write seichi-portal-sourcemaps --key seichi-portal-sourcemaps-ci
```

作成した key は seichi-portal-frontend の source map アップロード CI（seichi-portal-frontend#934）用に repo secrets へ登録します。

## 関連 / 後続

- frontend 側: seichi-portal-frontend#934（アップロードキー規約 `{release}/_next/static/**/*.map`、Faro の **`app.release`** 設定 — Alloy の `.Release` は `Meta.App.Release` を参照するため `app.version` では不十分）
- CI（GitHub ホストランナー）→ クラスタ内 Garage の到達経路は別途要決定（cloudflared + CF Access サービストークン案を提案中）

Closes #5608

🤖 Generated with [Claude Code](https://claude.com/claude-code)
