### PR TITLE
feat(alertmanager): Discord 通知経路を notify=discord の opt-in で追加する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
@@ -43,7 +43,13 @@ spec:
           # 偽発火で、drain が prometheus Pod を動かすたびに窓の最中に firing する (2026-07-20 の窓で
           # wk-2 の再起動を 3 周期 (約 40 分) ブロックした実績)。アラート式側に > 0 ガードを入れて
           # 根治したが、本物の停滞時も再起動の保留ではアップロードは復旧しないため除外は維持する
-          alertFilterRegexp: "^(Watchdog|InfoInhibitor|TargetDown|KubeJobFailed|CPUThrottlingHigh|PrometheusNotConnectedToAlertmanagers|KubePodCrashLooping|KubePodNotReady|KubeDeploymentReplicasMismatch|KubeStatefulSetReplicasMismatch|KubeletTooManyPods|ThanosSidecarUploadStale)$"
+          # PortalAlertRouteSmokeTest / InfraAlertRouteSmokeTest: #5601 の Discord 通知経路
+          # (2 系統) の疎通確認用の合成アラート (常時 firing のため、除外しないと
+          # 確認期間中の再起動窓を全てブロックする)
+          # SeichiPortalHighErrorRate / SeichiPortalBackendCrashLoop: seichi-portal の
+          # アプリケーションアラート (#5611, #5618)。アプリのエラーはノード再起動で
+          # 直らないため、ノード保守をブロックさせない
+          alertFilterRegexp: "^(Watchdog|InfoInhibitor|TargetDown|KubeJobFailed|CPUThrottlingHigh|PrometheusNotConnectedToAlertmanagers|KubePodCrashLooping|KubePodNotReady|KubeDeploymentReplicasMismatch|KubeStatefulSetReplicasMismatch|KubeletTooManyPods|ThanosSidecarUploadStale|PortalAlertRouteSmokeTest|InfraAlertRouteSmokeTest|SeichiPortalHighErrorRate|SeichiPortalBackendCrashLoop)$"
           # kubelet のパッチ更新も kured の drain + 再起動に相乗りさせる。
           # pkgs.k8s.io はマイナーごとの repo (core:/stable:/v1.3x) なので、apt で入るのは
           # 同一マイナー内のパッチのみ。マイナーアップグレードは従来どおり kubeadm で手動実施し、

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
@@ -279,10 +279,42 @@ spec:
                     expr: 1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes
                   - record: node:node_cpu_utilisation:avg5m
                     expr: 1 - avg by (node) (rate(node_cpu_seconds_total{mode="idle"}[5m]))
-        # どこにも通知しない状態(null receiver)で有効化し、Prometheus との接続のみ確立する。
-        # chart デフォルトの config は root receiver が "null" だが、通知が飛ばないことが
-        # 運用上の前提であるため、GitOps 定義として明示的に固定している。
-        # Discord 通知経路の追加は #5601 で行う。
+          # #5601 の受け入れ確認用の合成アラート (常時 firing)。2 系統の route
+          # (discord-portal / discord-infra) をそれぞれ疎通確認するため 2 本ある。
+          # マージ後に各チャンネルへ firing 通知 (ロールメンション付き) が 1 回ずつ
+          # 届くことを確認し、このブロックを削除する。削除のマージで resolved 通知も
+          # 確認できる。kured の alertFilterRegexp にも登録済み (常時 firing のため、
+          # 登録しないと再起動窓 05:00-07:00 をブロックする)
+          alert-route-smoke-test:
+            groups:
+              - name: alert-route-smoke-test
+                rules:
+                  - alert: PortalAlertRouteSmokeTest
+                    expr: vector(1)
+                    labels:
+                      # chart 既定の inhibit_rules が severity=info を InfoInhibitor で
+                      # 抑制するため、Watchdog と同じ none にして確実に配送させる
+                      severity: none
+                      notify: discord
+                      team: portal
+                    annotations:
+                      summary: Discord 通知経路 (portal 系統) の疎通確認用の合成アラート
+                      description: notify=discord + team=portal ルートの firing/resolved 確認用。確認が済んだらこのルールを削除する。
+                  - alert: InfraAlertRouteSmokeTest
+                    expr: vector(1)
+                    labels:
+                      severity: none
+                      notify: discord
+                    annotations:
+                      summary: Discord 通知経路 (インフラ系統) の疎通確認用の合成アラート
+                      description: team なしの notify=discord ルートの firing/resolved 確認用。確認が済んだらこのルールを削除する。
+        # 既定はどこにも通知しない (root receiver "null")。Discord への通知は
+        # notify=discord ラベルによる明示 opt-in のみ (#5601)。severity ベースの
+        # 一括通知は行わない (既存ルールのノイズをそのまま流さないため。
+        # どのルールに notify=discord を付けるかの監査は #5602)。
+        # 通知先は 2 系統: portal アプリ系 (team=portal) は discord-portal、
+        # それ以外 (インフラ系) は discord-infra。route は先勝ちのため
+        # team=portal の分岐を先に書く
         alertmanager:
           enabled: true
           config:
@@ -292,8 +324,38 @@ spec:
                 - receiver: "null"
                   matchers:
                     - alertname = "Watchdog"
+                - receiver: "discord-portal"
+                  matchers:
+                    - notify = "discord"
+                    - team = "portal"
+                  group_by: ["alertname", "namespace", "service"]
+                  group_wait: 30s
+                  group_interval: 5m
+                  repeat_interval: 4h
+                - receiver: "discord-infra"
+                  matchers:
+                    - notify = "discord"
+                  group_by: ["alertname", "namespace", "service"]
+                  group_wait: 30s
+                  group_interval: 5m
+                  repeat_interval: 4h
             receivers:
               - name: "null"
+              # webhook URL は公開リポジトリに書けないため、Terraform 管理の Secret
+              # (alertmanagerSpec.secrets でマウント) をファイル参照する。
+              # Alertmanager は allowed_mentions を設定しないため、content 内の
+              # ロールメンションがそのまま ping になる (embed 側の title/message に
+              # 書いても ping しない)。ロール ID はどちらも backup 失敗通知と同じ
+              # 運用ロールを暫定使用。チャンネルごとの専用ロールに変える場合は
+              # 各 content の ID を差し替える (#5601)
+              - name: "discord-portal"
+                discord_configs:
+                  - webhook_url_file: /etc/alertmanager/secrets/portal-alert-discord/webhook-url
+                    content: '<@&532704116799963168>'
+              - name: "discord-infra"
+                discord_configs:
+                  - webhook_url_file: /etc/alertmanager/secrets/infra-alert-discord/webhook-url
+                    content: '<@&532704116799963168>'
           # 通知・Silence の可用性を確保するための HA 構成。
           # Prometheus 自体は 1 レプリカのため、ルール評価までは HA にならない(受容済み)。
           podDisruptionBudget:
@@ -302,6 +364,11 @@ spec:
           alertmanagerSpec:
             replicas: 2
             podAntiAffinity: hard
+            # 各 receiver の webhook_url_file が参照する Secret を
+            # /etc/alertmanager/secrets/<name>/ にマウントする (#5601)
+            secrets:
+              - portal-alert-discord
+              - infra-alert-discord
             # Silence・通知状態 (nflog) の永続化。Alertmanager の状態は小さいので 1Gi で十分
             storage:
               volumeClaimTemplate:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -410,6 +410,18 @@ variable "backup_failure_notify_webhook_url" {
   sensitive   = true
 }
 
+variable "portal_alert_discord_webhook_url" {
+  description = "Discord webhook URL used by Alertmanager receiver discord-portal (notify=discord + team=portal alerts)"
+  type        = string
+  sensitive   = true
+}
+
+variable "infra_alert_discord_webhook_url" {
+  description = "Discord webhook URL used by Alertmanager receiver discord-infra (notify=discord alerts without team=portal)"
+  type        = string
+  sensitive   = true
+}
+
 #endregion
 
 #region on-premise minecraft config secrets

--- a/terraform/onp_cluster_secrets.tf
+++ b/terraform/onp_cluster_secrets.tf
@@ -345,6 +345,41 @@ resource "kubernetes_secret_v1" "truenas_exporter_api_key" {
   type = "Opaque"
 }
 
+# Alertmanager の Discord 通知経路 (#5601)。
+# kube-prometheus-stack の alertmanagerSpec.secrets でマウントされ、
+# 各 receiver の webhook_url_file が
+# /etc/alertmanager/secrets/<name>/webhook-url を参照する。
+# portal アプリ用 (team=portal) とインフラ用で通知先チャンネルを分けている
+resource "kubernetes_secret_v1" "portal_alert_discord" {
+  depends_on = [kubernetes_namespace_v1.onp_monitoring]
+
+  metadata {
+    name      = "portal-alert-discord"
+    namespace = "monitoring"
+  }
+
+  data = {
+    "webhook-url" = var.portal_alert_discord_webhook_url
+  }
+
+  type = "Opaque"
+}
+
+resource "kubernetes_secret_v1" "infra_alert_discord" {
+  depends_on = [kubernetes_namespace_v1.onp_monitoring]
+
+  metadata {
+    name      = "infra-alert-discord"
+    namespace = "monitoring"
+  }
+
+  data = {
+    "webhook-url" = var.infra_alert_discord_webhook_url
+  }
+
+  type = "Opaque"
+}
+
 resource "kubernetes_secret_v1" "onp_kubechecks_github_app_secret" {
   depends_on = [kubernetes_namespace_v1.kubechecks]
 


### PR DESCRIPTION
## 概要 (#5601)

Discord 通知経路を **2 系統** (portal アプリ系 / インフラ系) で追加する。

- Terraform: monitoring ns に Secret `portal-alert-discord` / `infra-alert-discord` を作成 (webhook URL は GitHub Secrets から供給)
- receiver `discord-portal` (`notify=discord` **かつ** `team=portal`) と `discord-infra` (team なしの `notify=discord`) を `webhook_url_file` で定義。既定 receiver は `null` のまま (opt-in 方式)。route は先勝ちのため team=portal の分岐を先に配置
- 各 route とも group_by [alertname, namespace, service] / group_wait 30s / group_interval 5m / repeat_interval 4h
- ロールメンションは content 内 `<@&532704116799963168>` (両系統とも backup 失敗通知と同じ運用ロールを暫定使用。チャンネル専用ロールにする場合は各 content の 1 行を差し替え)
- 受け入れ確認用の常時 firing 合成アラートを 2 本追加 (`PortalAlertRouteSmokeTest` = portal 系統 / `InfraAlertRouteSmokeTest` = インフラ系統。chart 既定の inhibit_rules が severity=info を抑制するため severity=none)
- kured の alertFilterRegexp に smoke test 2 本と #5611/#5618 のアラート名を登録

## この webhook に届くもの

- **discord-portal**: #5641 の portal アプリアラート 5 本 (team=portal) + PortalAlertRouteSmokeTest
- **discord-infra**: #5643 の第 1 弾インフラ critical 12 本 + InfraAlertRouteSmokeTest
- それ以外の全ルール (約 170 本) は root receiver `null` に落ち、どこにも通知されない

## ⚠️ マージ前の前提

**GitHub repo secrets の設定が必要です (2 つ):**

- `TF_VAR_PORTAL_ALERT_DISCORD_WEBHOOK_URL` (portal 通知チャンネルの webhook)
- `TF_VAR_INFRA_ALERT_DISCORD_WEBHOOK_URL` (インフラ通知チャンネルの webhook)

未設定のまま merge すると tf plan が変数不足で失敗します (現在の CI fail はこれ)。設定後に re-run → green を確認して draft を外してください。

## マージ後の確認手順

1. 両チャンネルに firing 通知 (ロールメンション付き) が 1 回ずつ届くこと
2. `notify=discord` のないアラートが Discord へ流れないこと
3. 確認後、合成アラートのブロック (additionalPrometheusRulesMap の `alert-route-smoke-test`) を削除する PR で resolved 通知を確認

## 検証済み

- kube-prometheus-stack 87.21.0 で helm template し、alertmanager.yaml (route 2 系統 / receivers) と Alertmanager CR (secrets 2 件) のレンダー結果を確認
- discord_configs のフィールド (webhook_url_file / content) は Alertmanager v0.33 のドキュメントで確認
- secrets のマウントパス /etc/alertmanager/secrets/<name> は prometheus-operator API リファレンスで確認
- feat/portal-alert-rules (#5641) との kured.yaml 同一行は両ブランチで同内容にしてあり、merge-tree でどちらの順でも conflict しないことを確認

refs #5601

🤖 Generated with [Claude Code](https://claude.com/claude-code)