### PR TITLE
feat(beyla): RED metrics の正を Tempo spanmetrics に一本化する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-k8s-monitoring.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/grafana-k8s-monitoring.yaml
@@ -82,6 +82,19 @@ spec:
                   exclude_instrument:
                     - exe_path: ".*alloy.*|.*otelcol.*|.*beyla.*"
                     - k8s_namespace: garage-admin
+                  # HTTP の RED metrics の正は Tempo metrics-generator (span-metrics
+                  # processor) に一本化する (#5604)。OTel SDK 計装済みサービス
+                  # (seichi-portal-frontend/backend 等) は Beyla が二重にトレースを
+                  # 生成しないよう除外する。exclude_otel_instrumented_services は
+                  # Beyla のデフォルト true だが、一本化の決定として明文化する
+                  exclude_otel_instrumented_services: true
+                  # Beyla は除外判定したサービスについても span metrics / service graph
+                  # metrics だけは生成し続けるのがデフォルト (SDK 側がサンプリングする
+                  # 環境向けの挙動)。本クラスタの SDK は parentbased_always_on で全量
+                  # トレースを送るため Tempo 側の spanmetrics が全量を反映しており、
+                  # Beyla 側の生成は将来 Beyla メトリクスのスクレイプを有効化した際に
+                  # 二重計上になるだけなので止める
+                  exclude_otel_instrumented_services_span_metrics: true
             resources:
               requests:
                 cpu: 20m


### PR DESCRIPTION
## 概要 (#5604)

RED metrics の生成元を **Tempo metrics-generator (span-metrics processor) に一本化**する決定を実装します。

## 判断根拠 (2026-08-01 実測)

- Prometheus に存在する RED metrics は `traces_spanmetrics_*` のみ。Beyla の prometheus_export (application / application_span 等を expose) は**どこからもスクレイプされていない** (clusterMetrics / annotationAutodiscovery / prometheusOperatorObjects 全て無効のため)
- SDK は `parentbased_always_on` で全量トレースを送るため、Tempo 側の spanmetrics が全量を反映している
- #5611 のエラーレートアラートも `traces_spanmetrics_calls_total` 前提

## 変更内容

- `exclude_otel_instrumented_services: true`: Beyla デフォルト値の明文化 (SDK 計装済みサービスへの二重トレース生成を防ぐ)
- `exclude_otel_instrumented_services_span_metrics: true` (デフォルト false): Beyla は除外判定したサービスでも span metrics / service graph metrics は生成し続けるのがデフォルトのため、将来 Beyla メトリクスのスクレイプを有効化した際の二重計上の芽を止める

オプション名・デフォルト値・意味は [Beyla service discovery ドキュメント](https://grafana.com/docs/beyla/latest/configure/service-discovery/)で確認済み。k8s-monitoring 4.3.2 の helm template でレンダー結果も確認済み。

refs #5604

🤖 Generated with [Claude Code](https://claude.com/claude-code)