### PR TITLE
chore: seichi-portal-frontend を 0.3.1 に更新

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-frontend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-frontend/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: seichi-portal-frontend
-          image: ghcr.io/giganticminecraft/seichi-portal-frontend:0.2.0@sha256:d913390091df9bae0f8163cb59e4bcf6f94de970b3cf09afc8b9ad7d03d060b4
+          image: ghcr.io/giganticminecraft/seichi-portal-frontend:0.3.1@sha256:eab8bb9ce00d291e554b5726de51bb18b1c3e277aa922515ea1806f7dac49443
           ports:
             - name: http
               containerPort: 3000


### PR DESCRIPTION
## 概要
- upstream の最新公開イメージ `0.3.1` を本番 Deployment に反映する
- マルチアーキテクチャのイメージ index digest を `sha256:eab8bb9ce00d291e554b5726de51bb18b1c3e277aa922515ea1806f7dac49443` に更新する

## 確認事項
- upstream の `release v0.3.1` 準備済みコミットと、GHCR の `0.3.1` イメージマニフェストを確認した
- `git diff --check` が成功した
- `kubectl` によるマニフェスト検証は、ローカルに Kubernetes API サーバーがないため実施できなかった

## 補足
- 変更対象は `seichi-portal-frontend` Deployment のイメージ参照 1 行のみ

🤖 Generated with Codex