### PR TITLE
fix: RabbitMQ 起動待ちを再試行する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/rabbitmq/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/rabbitmq/deployment.yaml
@@ -37,7 +37,9 @@ spec:
                   - /bin/sh
                   - -ec
                   - |
-                    rabbitmqctl await_startup --timeout 300
+                    until rabbitmqctl await_startup --timeout 5 >/dev/null 2>&1; do
+                      sleep 1
+                    done
                     if rabbitmqctl list_users --silent | awk -v user="$SEICHI_PORTAL_RABBITMQ_USER" '$1 == user { found=1 } END { exit(found ? 0 : 1) }'; then
                       rabbitmqctl change_password "$SEICHI_PORTAL_RABBITMQ_USER" "$SEICHI_PORTAL_RABBITMQ_PASSWORD"
                     else


### PR DESCRIPTION
postStart フックは RabbitMQ 本体より先に実行される場合があるため、ノードが起動するまで rabbitmqctl を再試行する。