### PR TITLE
feat: seichi-portal-backend 用の Debezium を追加する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/debezium/configmap.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/debezium/configmap.yaml
@@ -16,15 +16,16 @@ data:
     debezium.source.connector.class=io.debezium.connector.mariadb.MariaDbConnector
     debezium.source.offset.storage=org.apache.kafka.connect.storage.FileOffsetBackingStore
     debezium.source.offset.storage.file.filename=data/offsets.dat
-    debezium.source.schema.internal.ignore=true
     debezium.source.schema.history.internal=io.debezium.storage.file.history.FileSchemaHistory
     debezium.source.schema.history.internal.file.filename=data/dbhistory.dat
+    debezium.source.include.schema.changes=false
     debezium.source.offset.flush.interval.ms=0
+    debezium.source.heartbeat.interval.ms=30000
     debezium.source.database.hostname=mariadb
     debezium.source.database.port=3306
     debezium.source.database.user=debezium
     debezium.source.database.server.id=1001
-    debezium.source.database.dbname=seichi_portal
+    debezium.source.database.include.list=seichi_portal
     debezium.source.topic.prefix=seichi_portal
     debezium.source.snapshot.mode=initial
 

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/debezium/configmap.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/debezium/configmap.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: seichi-portal-debezium-config
+  namespace: seichi-minecraft
+data:
+  application.properties: |
+    debezium.sink.type=rabbitmq
+    debezium.sink.rabbitmq.connection.host=seichi-portal-rabbitmq
+    debezium.sink.rabbitmq.connection.port=5672
+    debezium.sink.rabbitmq.connection.username=seichi-portal
+    debezium.sink.rabbitmq.ackTimeout=3000
+    debezium.sink.rabbitmq.exchange=seichi_portal
+    debezium.sink.rabbitmq.routingKey=seichi_portal
+
+    debezium.source.connector.class=io.debezium.connector.mariadb.MariaDbConnector
+    debezium.source.offset.storage=org.apache.kafka.connect.storage.FileOffsetBackingStore
+    debezium.source.offset.storage.file.filename=data/offsets.dat
+    debezium.source.schema.internal.ignore=true
+    debezium.source.schema.history.internal=io.debezium.storage.file.history.FileSchemaHistory
+    debezium.source.schema.history.internal.file.filename=data/dbhistory.dat
+    debezium.source.offset.flush.interval.ms=0
+    debezium.source.database.hostname=mariadb
+    debezium.source.database.port=3306
+    debezium.source.database.user=debezium
+    debezium.source.database.server.id=1001
+    debezium.source.database.dbname=seichi_portal
+    debezium.source.topic.prefix=seichi_portal
+    debezium.source.snapshot.mode=initial
+
+    debezium.format.key=json
+    debezium.format.value=json
+
+    quarkus.log.console.json=false

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/debezium/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/debezium/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: seichi-portal-debezium
+  namespace: seichi-minecraft
+  labels:
+    app: seichi-portal-debezium
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: seichi-portal-debezium
+  template:
+    metadata:
+      labels:
+        app: seichi-portal-debezium
+    spec:
+      securityContext:
+        fsGroup: 185
+      containers:
+        - name: debezium
+          image: quay.io/debezium/server:3.6
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: DEBEZIUM_SINK_RABBITMQ_CONNECTION_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: seichi-portal-rabbitmq-credentials
+                  key: password
+            - name: DEBEZIUM_SOURCE_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: debezium-db-credentials
+                  key: password
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 768Mi
+          livenessProbe:
+            httpGet:
+              path: /q/health/live
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /q/health/ready
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: config
+              mountPath: /debezium/config/application.properties
+              subPath: application.properties
+            - name: data
+              mountPath: /debezium/data
+      volumes:
+        - name: config
+          configMap:
+            name: seichi-portal-debezium-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: seichi-portal-debezium-data

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/debezium/pvc.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/debezium/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: seichi-portal-debezium-data
+  namespace: seichi-minecraft
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/default-deny-policy/allow--from-seichi-portal-debezium--to-datastores.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/default-deny-policy/allow--from-seichi-portal-debezium--to-datastores.yaml
@@ -1,0 +1,23 @@
+# Debezium が MariaDB の binlog を読み取り、RabbitMQ へ CDC イベントを送るための egress 許可。
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow--from-seichi-portal-debezium--to-datastores
+spec:
+  endpointSelector:
+    matchLabels:
+      app: seichi-portal-debezium
+  egress:
+    - toServices:
+        - k8sService:
+            serviceName: mariadb
+            namespace: seichi-minecraft
+        - k8sService:
+            serviceName: seichi-portal-rabbitmq
+            namespace: seichi-minecraft
+      toPorts:
+        - ports:
+            - port: "3306"
+              protocol: TCP
+            - port: "5672"
+              protocol: TCP

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/debezium-db-user.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/debezium-db-user.yaml
@@ -1,0 +1,47 @@
+apiVersion: "secretgenerator.mittwald.de/v1alpha1"
+kind: "StringSecret"
+metadata:
+  namespace: seichi-minecraft
+  name: debezium-db-credentials
+spec:
+  forceRegenerate: false
+  fields:
+    - fieldName: "password"
+      encoding: "hex"
+      length: "32"
+
+---
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: User
+metadata:
+  namespace: seichi-minecraft
+  name: debezium
+spec:
+  mariaDbRef:
+    name: mariadb
+    waitForIt: true
+  passwordSecretKeyRef:
+    name: debezium-db-credentials
+    key: password
+  maxUserConnections: 5
+
+---
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Grant
+metadata:
+  namespace: seichi-minecraft
+  name: debezium
+spec:
+  mariaDbRef:
+    name: mariadb
+    waitForIt: true
+  privileges:
+    - "SELECT"
+    - "RELOAD"
+    - "SHOW DATABASES"
+    - "REPLICATION SLAVE"
+    - "REPLICATION CLIENT"
+  database: "*"
+  table: "*"
+  username: "debezium"
+  grantOption: false

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
@@ -43,6 +43,7 @@ spec:
     binlog_row_image = FULL
     binlog_legacy_event_pos = 1
     log_bin_compress = 0
+    binlog_expire_logs_seconds = 604800
 
   resources:
     requests:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
@@ -38,6 +38,11 @@ spec:
     performance_schema_instrument='memory/%=ON'
     max-connections=400
     join_buffer_size=256K
+    log_bin = mariadb-bin
+    binlog_format = ROW
+    binlog_row_image = FULL
+    binlog_legacy_event_pos = 1
+    log_bin_compress = 0
 
   resources:
     requests:


### PR DESCRIPTION
## 概要
- seichi-portal-backend が必要とする MariaDB の binlog 設定と Debezium 専用ユーザーを追加
- MariaDB から RabbitMQ へ CDC イベントを送る Debezium Server を Kubernetes 上に追加
- offset／schema history の永続化、Secret 参照、MariaDB／RabbitMQ への egress 許可を設定

## 確認事項
- `git diff main...HEAD --check` を実行し、空白エラーがないことを確認
- Debezium の設定、Secret、PVC、Service 参照の静的整合性を確認
- MariaDB の権限と binlog 設定は Debezium 公式要件に照合
- ローカルに接続可能な Kubernetes クラスタがないため、`kubectl` による dry-run／実クラスタへの適用確認は未実施

## 補足
- MariaDB operator の HA 構成を考慮し、MariaDB の `server_id` は固定せず、Debezium connector 側の ID のみ `1001` としている

🤖 Generated with Codex