### PR TITLE
fix(alertmanager): discord_configs を webhook_configs + payload に置き換え operator の reconcile 失敗を解消する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
@@ -354,21 +354,54 @@ spec:
                   repeat_interval: 4h
             receivers:
               - name: "null"
+              # discord_configs ではなく webhook_configs で Discord ネイティブ JSON を
+              # 直接 POST する。理由: prometheus-operator は alertmanager 設定を自前の
+              # 内部モデルで parse しており、discord_configs の webhook_url_file を
+              # 認識できない (operator v0.92.1 時点、main も未対応)。discord_configs で
+              # これを使うと operator の reconcile が
+              #   field webhook_url_file not found in type alertmanager.discordConfig
+              # で失敗し続け、Secret マウントの STS 更新が永久に走らない (2026-08-01 実測)。
+              # webhook_configs の url_file / payload は operator も認識する。
+              #
+              # payload は文字列テンプレートではなく YAML 構造ごと JSON エンコードされる
+              # (各文字列だけがテンプレート評価される) ため、annotation の日本語や引用符も
+              # 安全に JSON 化される。
               # webhook URL は公開リポジトリに書けないため、Terraform 管理の Secret
               # (alertmanagerSpec.secrets でマウント) をファイル参照する。
-              # Alertmanager は allowed_mentions を設定しないため、content 内の
-              # ロールメンションがそのまま ping になる (embed 側の title/message に
-              # 書いても ping しない)。ロール ID はどちらも backup 失敗通知と同じ
-              # 運用ロールを暫定使用。チャンネルごとの専用ロールに変える場合は
-              # 各 content の ID を差し替える (#5601)
+              # content 内のロールメンションと allowed_mentions で ping する (backup
+              # 失敗通知と同じ運用ロールを暫定使用。チャンネル専用ロールに変える場合は
+              # content と allowed_mentions の両方の ID を差し替える #5601)
               - name: "discord-portal"
-                discord_configs:
-                  - webhook_url_file: /etc/alertmanager/secrets/portal-alert-discord/webhook-url
-                    content: '<@&532704116799963168>'
+                webhook_configs:
+                  - url_file: /etc/alertmanager/secrets/portal-alert-discord/webhook-url
+                    # payload に含めるアラート数の上限。embed description の 4096 字制限を
+                    # 超えて Discord に 400 で拒否されないための安全弁 (printf の
+                    # "%.Ns" による各フィールドの切り詰めと併用)
+                    max_alerts: 5
+                    payload:
+                      content: '<@&532704116799963168> {{ template "__subject" . }}'
+                      allowed_mentions:
+                        roles: ["532704116799963168"]
+                      embeds:
+                        - title: '{{ if eq .Status "firing" }}🔥 [FIRING:{{ .Alerts.Firing | len }}]{{ else }}✅ [RESOLVED]{{ end }} {{ printf "%.200s" (.GroupLabels.SortedPairs.Values | join " ") }}'
+                          description: |-
+                            {{ range .Alerts }}**{{ .Labels.alertname }}** ({{ .Status }}){{ with .Annotations.summary }} — {{ printf "%.200s" . }}{{ end }}
+                            {{ with .Annotations.description }}{{ printf "%.500s" . }}
+                            {{ end }}{{ end }}
               - name: "discord-infra"
-                discord_configs:
-                  - webhook_url_file: /etc/alertmanager/secrets/infra-alert-discord/webhook-url
-                    content: '<@&532704116799963168>'
+                webhook_configs:
+                  - url_file: /etc/alertmanager/secrets/infra-alert-discord/webhook-url
+                    max_alerts: 5
+                    payload:
+                      content: '<@&532704116799963168> {{ template "__subject" . }}'
+                      allowed_mentions:
+                        roles: ["532704116799963168"]
+                      embeds:
+                        - title: '{{ if eq .Status "firing" }}🔥 [FIRING:{{ .Alerts.Firing | len }}]{{ else }}✅ [RESOLVED]{{ end }} {{ printf "%.200s" (.GroupLabels.SortedPairs.Values | join " ") }}'
+                          description: |-
+                            {{ range .Alerts }}**{{ .Labels.alertname }}** ({{ .Status }}){{ with .Annotations.summary }} — {{ printf "%.200s" . }}{{ end }}
+                            {{ with .Annotations.description }}{{ printf "%.500s" . }}
+                            {{ end }}{{ end }}
           # 通知・Silence の可用性を確保するための HA 構成。
           # Prometheus 自体は 1 レプリカのため、ルール評価までは HA にならない(受容済み)。
           podDisruptionBudget:


### PR DESCRIPTION
## 問題 (#5640 マージ後に発覚)

prometheus-operator は alertmanager 設定を**自前の内部モデルで parse**しており、`discordConfig` に `webhook_url_file` フィールドが存在しない (v0.92.1 時点。**upstream main も未対応**なのでバージョン待ちでは解決しない)。

このため operator の alertmanager sync が以下で失敗し続け、**Secret マウントを含む StatefulSet 更新が永久に適用されない**状態だった (Pod は旧世代のまま 2.4h、generated config も旧 null 設定のまま):

```
provision alertmanager configuration: failed to initialize from secret: yaml: unmarshal errors:
  line 30: field webhook_url_file not found in type alertmanager.discordConfig
```

副作用として現在 firing 中の smoke アラート 2 本は旧設定の null receiver に落ちており、Discord への誤配・通知失敗は発生していない。

## 修正

`discord_configs` → `webhook_configs` に置き換え、Discord ネイティブ JSON を直接 POST する:

- `url_file` / `max_alerts` / `payload` はいずれも operator の webhookConfig モデルが認識する (v0.92.1 の types.go で確認)
- `payload` は YAML 構造ごと JSON エンコードされ、文字列 leaf のみテンプレート評価される実装 (v0.33.1 の renderPayload を確認) のため、annotation の日本語・引用符も安全
- 副産物として `allowed_mentions` を明示できるようになった (backup 失敗通知と同じ形式) ほか、embed に 🔥/✅ の firing/resolved 表示を追加
- `max_alerts: 5` + `printf "%.Ns"` の切り詰めで Discord の 4096 字制限による 400 を防止

## 検証済み

- **Alertmanager v0.33.1 の template パッケージ実物**で 3 テンプレート (content/title/description) を日本語+引用符+LogQL 波括弧入りのモックデータで描画し、組み立てた JSON を**実際の webhook に POST して HTTP 204 を確認** (#monitor-seichi-portal に ping なしのテストメッセージが 1 通あります)
- helm template 87.21.0 でレンダー結果の構造を確認 (tplConfig=false のため Helm 側のテンプレート干渉なし)

マージすると operator の reconcile が通り、STS が Secret マウント付きで rolling restart → firing 中の smoke アラート 2 本が両チャンネルに配送されるはずです。

refs #5601

🤖 Generated with [Claude Code](https://claude.com/claude-code)