### PR TITLE
fix: Meilisearch の OOMKilled を防ぐ

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/meilisearch/meilisearch.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/meilisearch/meilisearch.yaml
@@ -26,10 +26,10 @@ spec:
         resources:
           requests:
             cpu: "15m"
-            memory: "64Mi"
+            memory: "512Mi"
           limits:
             cpu: "50m"
-            memory: "128Mi"
+            memory: "1Gi"
   destination:
     server: https://kubernetes.default.svc
     namespace: seichi-minecraft


### PR DESCRIPTION
## 概要
- Meilisearch が 128Mi のメモリ上限で OOMKilled になり、`seichi-portal-backend` の検索リクエストが失敗していたため、メモリ設定を以前の安全側の値へ戻す
- メモリ request を `64Mi` から `512Mi`、limit を `128Mi` から `1Gi` へ変更

## 確認事項
- Grafana Loki／Prometheus で、Meilisearch の `OOMKilled` とバックエンドの同時刻の接続エラーを確認
- `git diff --check` を実行し、空白エラーがないことを確認
- 変更対象は `seichi-portal-meilisearch` のリソース設定 1 ファイルのみ
- YAML 専用検証ツール（`yq`、`yamllint`）は環境にないため未実行

## 補足
- 再デプロイ後は Meilisearch のメモリ使用量と OOM 再発の有無を確認する

🤖 Generated with Codex