### PR TITLE
chore(seichi-portal): backend と frontend のイメージを更新

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: seichi-portal-backend
-          image: ghcr.io/giganticminecraft/seichi-portal-backend:0.2.1@sha256:f1b683a251027504e8f7f413fa0270a4675c26fc713479d467d5fe23a74a1226
+          image: ghcr.io/giganticminecraft/seichi-portal-backend:0.2.2@sha256:5bb41e8d31f4f94e84eb0da10d0b313b91fab7645c9a8093642cdfe606095f77
           resources:
             # OTel exporter のオーバーヘッド吸収のため limit を 100m から 300m へ増強
             # (seichi-game-data-publisher が exporter 導入時に 50m→300m へ増強した実績に倣う)

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-frontend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-frontend/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: seichi-portal-frontend
-          image: ghcr.io/giganticminecraft/seichi-portal-frontend:0.3.1@sha256:eab8bb9ce00d291e554b5726de51bb18b1c3e277aa922515ea1806f7dac49443
+          image: ghcr.io/giganticminecraft/seichi-portal-frontend:0.3.2@sha256:9d65f9089513367d260b7c3671d101947ad16a95cc115ddbb73748839f7feb5f
           ports:
             - name: http
               containerPort: 3000


### PR DESCRIPTION
## 概要
- seichi-portal-backend を 0.2.2 に更新
- seichi-portal-frontend を 0.3.2 に更新
- それぞれ GHCR の multi-arch index digest を固定

## 確認事項
- GitHub のリリース情報と frontend の package.json で更新バージョンを確認
- GHCR のイメージマニフェストを確認し、指定した digest と一致することを確認
- `git diff --check` は成功
- Kubernetes API サーバーが利用できないため、`kubectl` によるリソース認識までの dry-run は未完了

🤖 Generated with Codex