### PR TITLE
chore(alertmanager): 疎通確認済みの合成アラートを撤去する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
@@ -43,13 +43,10 @@ spec:
           # 偽発火で、drain が prometheus Pod を動かすたびに窓の最中に firing する (2026-07-20 の窓で
           # wk-2 の再起動を 3 周期 (約 40 分) ブロックした実績)。アラート式側に > 0 ガードを入れて
           # 根治したが、本物の停滞時も再起動の保留ではアップロードは復旧しないため除外は維持する
-          # PortalAlertRouteSmokeTest / InfraAlertRouteSmokeTest: #5601 の Discord 通知経路
-          # (2 系統) の疎通確認用の合成アラート (常時 firing のため、除外しないと
-          # 確認期間中の再起動窓を全てブロックする)
           # SeichiPortalHighErrorRate / SeichiPortalBackendCrashLoop: seichi-portal の
           # アプリケーションアラート (#5611, #5618)。アプリのエラーはノード再起動で
           # 直らないため、ノード保守をブロックさせない
-          alertFilterRegexp: "^(Watchdog|InfoInhibitor|TargetDown|KubeJobFailed|CPUThrottlingHigh|PrometheusNotConnectedToAlertmanagers|KubePodCrashLooping|KubePodNotReady|KubeDeploymentReplicasMismatch|KubeStatefulSetReplicasMismatch|KubeletTooManyPods|ThanosSidecarUploadStale|PortalAlertRouteSmokeTest|InfraAlertRouteSmokeTest|SeichiPortalHighErrorRate|SeichiPortalBackendCrashLoop)$"
+          alertFilterRegexp: "^(Watchdog|InfoInhibitor|TargetDown|KubeJobFailed|CPUThrottlingHigh|PrometheusNotConnectedToAlertmanagers|KubePodCrashLooping|KubePodNotReady|KubeDeploymentReplicasMismatch|KubeStatefulSetReplicasMismatch|KubeletTooManyPods|ThanosSidecarUploadStale|SeichiPortalHighErrorRate|SeichiPortalBackendCrashLoop)$"
           # kubelet のパッチ更新も kured の drain + 再起動に相乗りさせる。
           # pkgs.k8s.io はマイナーごとの repo (core:/stable:/v1.3x) なので、apt で入るのは
           # 同一マイナー内のパッチのみ。マイナーアップグレードは従来どおり kubeadm で手動実施し、

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
@@ -292,35 +292,6 @@ spec:
                     expr: 1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes
                   - record: node:node_cpu_utilisation:avg5m
                     expr: 1 - avg by (node) (rate(node_cpu_seconds_total{mode="idle"}[5m]))
-          # #5601 の受け入れ確認用の合成アラート (常時 firing)。2 系統の route
-          # (discord-portal / discord-infra) をそれぞれ疎通確認するため 2 本ある。
-          # マージ後に各チャンネルへ firing 通知 (ロールメンション付き) が 1 回ずつ
-          # 届くことを確認し、このブロックを削除する。削除のマージで resolved 通知も
-          # 確認できる。kured の alertFilterRegexp にも登録済み (常時 firing のため、
-          # 登録しないと再起動窓 05:00-07:00 をブロックする)
-          alert-route-smoke-test:
-            groups:
-              - name: alert-route-smoke-test
-                rules:
-                  - alert: PortalAlertRouteSmokeTest
-                    expr: vector(1)
-                    labels:
-                      # chart 既定の inhibit_rules が severity=info を InfoInhibitor で
-                      # 抑制するため、Watchdog と同じ none にして確実に配送させる
-                      severity: none
-                      notify: discord
-                      team: portal
-                    annotations:
-                      summary: Discord 通知経路 (portal 系統) の疎通確認用の合成アラート
-                      description: notify=discord + team=portal ルートの firing/resolved 確認用。確認が済んだらこのルールを削除する。
-                  - alert: InfraAlertRouteSmokeTest
-                    expr: vector(1)
-                    labels:
-                      severity: none
-                      notify: discord
-                    annotations:
-                      summary: Discord 通知経路 (インフラ系統) の疎通確認用の合成アラート
-                      description: team なしの notify=discord ルートの firing/resolved 確認用。確認が済んだらこのルールを削除する。
         # 既定はどこにも通知しない (root receiver "null")。Discord への通知は
         # notify=discord ラベルによる明示 opt-in のみ (#5601)。severity ベースの
         # 一括通知は行わない (既存ルールのノイズをそのまま流さないため。


### PR DESCRIPTION
## 概要 (#5601 の後片付け)

Discord 通知経路 (2 系統) の疎通確認が完了したため、受け入れ確認用の常時 firing 合成アラート 2 本 (`PortalAlertRouteSmokeTest` / `InfraAlertRouteSmokeTest`) と kured の除外リストの対応エントリを削除します。

確認済みの事実 (2026-08-02 03:15 JST 時点):
- Alertmanager の webhook 通知: **8 件送信・失敗 0** (両チャンネルへの firing 通知+4h ごとの再通知)
- Alertmanager Pod は #5651 マージ後に Secret マウント付きで rolling restart 済み
- Loki ruler の 3 ルールもロード済み (現在は全て inactive = 正常)

マージすると数分後 (resolve_timeout 5m) に両チャンネルへ ✅ resolved 通知が届き、send_resolved の動作確認も完了します。これが #5601 の受け入れ条件の最後の 1 つです。

refs #5601

🤖 Generated with [Claude Code](https://claude.com/claude-code)