### PR TITLE
feat(gachadata): OTel と Pyroscope の環境変数を供給する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/gachadata-server/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/gachadata-server/deployment.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         app: gachadata-server
+      annotations:
+        resource.opentelemetry.io/service.name: gachadata-server
     spec:
       containers:
         - name: gachadata-server
@@ -22,9 +24,12 @@ spec:
             requests:
               cpu: 15m
               memory: 32Mi
+            # OTel exporter / Pyroscope サンプリングのオーバーヘッド吸収のため増強
+            # (seichi-game-data-publisher / seichi-portal-backend が exporter 導入時に
+            # 300m へ増強した実績に倣う)
             limits:
-              cpu: 50m
-              memory: 64Mi
+              cpu: 300m
+              memory: 128Mi
           env:
             - name: MYSQL_USER
               value: mcserver
@@ -39,3 +44,21 @@ spec:
               value: "3306"
             - name: HTTP_PORT
               value: "80"
+            # ---- 観測 (gachadata-server#239 の OTel + Pyroscope 対応イメージで有効化) ----
+            # 旧イメージはこれらの env を読まないため、先にマージしても無害
+            - name: ENV_NAME
+              value: production
+            - name: OTEL_SERVICE_NAME
+              value: "gachadata-server"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://k8s-monitoring-alloy-receiver.monitoring.svc.cluster.local:4318"
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: "http/protobuf"
+            - name: OTEL_TRACES_SAMPLER
+              value: "parentbased_always_on"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "deployment.environment=production,deployment.environment.name=production"
+            - name: PYROSCOPE_SERVER_ADDRESS
+              value: "http://pyroscope.monitoring.svc.cluster.local:4040"
+            - name: PYROSCOPE_APPLICATION_NAME
+              value: "gachadata-server"


### PR DESCRIPTION
## 概要

GiganticMinecraft/gachadata-server#239 (Sentry 撤去 + OTel/Pyroscope 移行) の対応イメージ向けに、観測の環境変数を供給します。

- OTLP トレース: alloy-receiver :4318 (portal-backend と同じ設定一式)
- stdout JSON ログ: `ENV_NAME=production` で有効化 (panic=true 契約は #5618 の Loki ルール群と互換)
- 継続プロファイリング: Pyroscope への push (`PYROSCOPE_SERVER_ADDRESS` / `PYROSCOPE_APPLICATION_NAME`、game-data-publisher と同じ語彙)
- CPU limit 50m→300m / memory 64Mi→128Mi (exporter 導入時の game-data-publisher / portal-backend の増強実績に倣う)

## マージ順序

**制約なし**。旧イメージはこれらの env を読まないため、gachadata-server#239 のマージ・イメージ更新 (Renovate) と前後しても安全です。両方が揃った時点で有効化されます。

refs #5613

🤖 Generated with [Claude Code](https://claude.com/claude-code)