### PR TITLE
fix: MariaDB の binlog 由来の PVC 枯渇見込みと slow-log eviction を解消する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
@@ -17,7 +17,7 @@ spec:
   port: 3306
 
   storage:
-    size: 500Gi
+    size: 600Gi
     storageClassName: synology-iscsi-storage
     resizeInUseVolumes: true
     waitForVolumeResize: true

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
@@ -44,6 +44,19 @@ spec:
     binlog_legacy_event_pos = 1
     log_bin_compress = 0
     binlog_expire_logs_seconds = 604800
+    # CoreProtect (s1,s2,s3,s5,s7) は日次 04:00 JST の truncate で全量が入れ替わり、
+    # 書き込みも膨大 (s5 単体で日中 100GiB 超)。ROW + FULL row image の binlog に
+    # 乗せると 7 日保持では PVC (600Gi) を数日で使い切るため binlog から除外する。
+    # ROW 形式では「変更されたテーブルの属する DB」でフィルタされるので
+    # cross-database 更新の取りこぼしはなく、Debezium のキャプチャ対象も
+    # seichi_portal のみなので影響しない。coreprotect__mc_lobby は truncate
+    # 対象外かつ ~20MiB と小さいので binlog に残し PITR を維持する。
+    # カンマ区切り不可 (1 DB 1 行)・動的変更不可のため反映には Pod 再作成が必要。
+    binlog_ignore_db = coreprotect__mc_s1
+    binlog_ignore_db = coreprotect__mc_s2
+    binlog_ignore_db = coreprotect__mc_s3
+    binlog_ignore_db = coreprotect__mc_s5
+    binlog_ignore_db = coreprotect__mc_s7
 
   resources:
     requests:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
@@ -84,13 +84,16 @@ spec:
   # stdout に流すための emptyDir。mariadb-operator は spec.volumes / spec.volumeMounts を
   # primary container と sidecar container の両方に自動伝播するため、sidecar 側で
   # 同じ mountPath を書くと "must be unique" エラーになる。
-  # sizeLimit: MariaDB slow log は自動ローテーションされない。実測 ~230 KB/h なので
-  # 500Mi = ~3 ヶ月分。想定外の増加でノードの ephemeral storage を巻き込む前に
-  # Pod が eviction される上限として設定する。
+  # sizeLimit: MariaDB slow log は自動ローテーションされない。500Mi 設定当時は
+  # ~230KB/h 想定だったが、CoreProtect 系クエリで ~55MiB/h まで膨張し、
+  # 2026-07-31〜08-02 に sizeLimit 超過の eviction (= MariaDB の強制再作成) が
+  # 5 回発生した。発生量は long_query_time で抑え、slow-log-rotator sidecar で
+  # ローテーションした上で、rotator 停止時にもノードの ephemeral storage を
+  # 巻き込む前に落ちる最終上限として 4Gi を確保する。
   volumes:
     - name: slow-log
       emptyDir:
-        sizeLimit: 500Mi
+        sizeLimit: 4Gi
   volumeMounts:
     - name: slow-log
       mountPath: /var/log/mysql

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
@@ -131,6 +131,45 @@ spec:
           cpu: 100m
           memory: 64Mi
 
+    # slow log をサイズベースでローテーションする。MariaDB はログを自動で
+    # ローテーションしないため、公式の案内どおり mv → FLUSH SLOW LOGS で
+    # 新ファイルへ切り替える (mv 中も mysqld は旧 inode へ書き続けるので
+    # ログの破損はない)。tailer の tail -F は名前で追跡するため新ファイルへ
+    # 自動で追従する (切り替わりの数行は失われ得るが、tailer 再起動時と同じ
+    # トレードオフとして許容する)。しきい値 1GiB は emptyDir の sizeLimit (4Gi)
+    # に対し、ローテーション中に旧ファイルが一時的に共存しても余裕がある値。
+    # 接続は同一 Pod 内 TCP (127.0.0.1)。mariadb-operator は root@'%' を管理
+    # しており operator 自身も TCP で接続しているため、この経路で FLUSH できる。
+    - name: slow-log-rotator
+      image: docker-registry1.mariadb.com/library/mariadb:11.8
+      env:
+        - name: MARIADB_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mariadb
+              key: root-password
+      command: ["/bin/sh", "-c"]
+      args:
+        - |
+          LOG=/var/log/mysql/mysql-slow.log
+          LIMIT=$((1024 * 1024 * 1024))
+          while true; do
+            sleep 300
+            SIZE=$(stat -c %s "$LOG" 2>/dev/null || echo 0)
+            if [ "$SIZE" -gt "$LIMIT" ]; then
+              mv "$LOG" "$LOG.1"
+              mariadb -h 127.0.0.1 -u root -p"$MARIADB_ROOT_PASSWORD" -e "FLUSH SLOW LOGS;"
+              rm -f "$LOG.1"
+            fi
+          done
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          cpu: 100m
+          memory: 128Mi
+
   podSecurityContext:
     runAsUser: 0
 

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
@@ -140,6 +140,14 @@ spec:
     # に対し、ローテーション中に旧ファイルが一時的に共存しても余裕がある値。
     # 接続は同一 Pod 内 TCP (127.0.0.1)。mariadb-operator は root@'%' を管理
     # しており operator 自身も TCP で接続しているため、この経路で FLUSH できる。
+    #
+    # .1 の削除は FLUSH の成功が確認できた後に限る。mysqld は rename 後も
+    # 旧 inode (.1) へ書き続けるため、FLUSH 前に消すと open-but-unlinked の
+    # ファイルが emptyDir を消費し続け、$LOG 不在でサイズ検知も効かなくなり
+    # 回復不能になる。FLUSH 失敗時や rename と FLUSH の間で rotator が
+    # 再起動した場合は .1 が残るので、ループ先頭で FLUSH を再試行して回復する。
+    # .1 が未解決の間は次の rotate を行わない (mv で .1 を上書きすると
+    # 旧 inode がリークするため)。その間の増加は sizeLimit (4Gi) が抑える。
     - name: slow-log-rotator
       image: docker-registry1.mariadb.com/library/mariadb:11.8
       env:
@@ -153,14 +161,26 @@ spec:
         - |
           LOG=/var/log/mysql/mysql-slow.log
           LIMIT=$((1024 * 1024 * 1024))
+          flush_slow_logs() {
+            mariadb -h 127.0.0.1 -u root -p"$MARIADB_ROOT_PASSWORD" \
+              --connect-timeout=10 -e "FLUSH SLOW LOGS;"
+          }
           while true; do
-            sleep 300
-            SIZE=$(stat -c %s "$LOG" 2>/dev/null || echo 0)
-            if [ "$SIZE" -gt "$LIMIT" ]; then
+            if [ -f "$LOG.1" ]; then
+              if flush_slow_logs; then
+                rm -f "$LOG.1"
+              else
+                echo "slow-log-rotator: FLUSH SLOW LOGS failed; keeping $LOG.1 and retrying" >&2
+              fi
+            elif [ "$(stat -c %s "$LOG" 2>/dev/null || echo 0)" -gt "$LIMIT" ]; then
               mv "$LOG" "$LOG.1"
-              mariadb -h 127.0.0.1 -u root -p"$MARIADB_ROOT_PASSWORD" -e "FLUSH SLOW LOGS;"
-              rm -f "$LOG.1"
+              if flush_slow_logs; then
+                rm -f "$LOG.1"
+              else
+                echo "slow-log-rotator: FLUSH SLOW LOGS failed after rename; will recover on next cycle" >&2
+              fi
             fi
+            sleep 300
           done
       resources:
         requests:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml
@@ -26,7 +26,11 @@ spec:
     [mariadb]
     slow_query_log=true
     slow_query_log-file=/var/log/mysql/mysql-slow.log
-    long_query_time=0.1
+    # 0.1s では CoreProtect のバッチ INSERT が大量に載り、slow log が ~55MiB/h
+    # (当初想定 ~230KB/h の約 240 倍) まで膨張して emptyDir の sizeLimit 超過による
+    # Pod eviction を繰り返した。実測では 0.5s で該当 INSERT の約 96% を落としつつ、
+    # より重いクエリは引き続き捕捉できる。
+    long_query_time=0.5
     innodb_buffer_pool_size = 8G
     innodb_log_file_size = 512M
     innodb_flush_log_at_trx_commit = 2


### PR DESCRIPTION
## 背景

### 🔴 binlog による PVC 枯渇(8/5〜8/6 見込み)

8/1 の Debezium 導入 (aa57984c4, ab8f86e6d) で binlog が初めて有効化されたが、日次 04:00 JST に truncate される CoreProtect DB の膨大な書き込みがそのまま binlog に乗る状態だった。

実測 (2026-08-02 13:30 JST 時点):
- binlog 93 ファイル / 90.34GiB(有効化から約 20 時間、~4.6GiB/h)
- 7 日保持 (`binlog_expire_logs_seconds=604800`) での外挿: **約 780GiB**
- PVC 600Gi、使用 204GiB → **8/5〜8/6 頃に枯渇**(CoreProtect の日中ピークで前倒しの可能性あり)

### 🔴 slow-log emptyDir あふれによる Pod eviction

`long_query_time=0.1` + CoreProtect のバッチ INSERT により slow log が ~55MiB/h(当初想定 ~230KB/h の約 240 倍)で増加し、sizeLimit 500Mi 超過の eviction が **直近 48 時間で 5 回**発生(7/31 15:06、8/1 13:21、8/1 16:45、8/2 08:02、8/2 12:45 JST)。いずれも graceful shutdown で InnoDB クラッシュリカバリは発生していないが、DB の強制再作成が半日ごとに起きる状態。

## 変更内容(コミット単位)

1. **binlog_ignore_db で CoreProtect 5 DB (s1,s2,s3,s5,s7) を除外** — ROW 形式では変更対象テーブルの DB でフィルタされるため cross-database 更新の問題なし。Debezium のキャプチャ対象は `seichi_portal` のみ (`database.include.list` 確認済み) で影響なし
2. **long_query_time 0.1 → 0.5s** — 実測で CoreProtect の巨大 INSERT (888 件中 0.5s 以上は 37 件) の約 96% を除外
3. **slow-log sizeLimit 500Mi → 4Gi** — rotator 停止時の最終安全弁
4. **slow-log-rotator sidecar 追加** — 1GiB 超過で mv → FLUSH SLOW LOGS → 削除([公式の案内する手順](https://mariadb.com/docs/server/server-management/server-monitoring-logs/rotating-logs-on-unix-and-linux)に準拠)
5. **storage.size 500Gi → 600Gi** — 実 PVC との整合化(容量が増える変更ではない)

## トレードオフ

- 除外した CoreProtect 5 DB は binlog ベースの PITR / レプリケーション不可(日次ダンプのみ)。5 DB とも毎日 truncate される運用のため実害は限定的
- `coreprotect__mc_lobby` は truncate 対象外かつ ~20MiB のため**除外していない**(PITR 維持)

## 反映手順(要・計画停止)

`binlog_ignore_db` は動的変更不可、かつ mariadb-operator は `autoUpdateDataPlane: false` で StatefulSet が **OnDelete** のため、マージ後に Pod の明示削除が必要:

```sh
kubectl -n seichi-minecraft delete pod mariadb-0   # graceful shutdown (実測 30s 以内)
```

反映が翌日以降になる場合の止血: `SET GLOBAL binlog_expire_logs_seconds=86400`(動的・揮発性。1 日保持で定常 ~111GiB)

## 反映後の確認

- `SHOW VARIABLES LIKE 'binlog_ignore_db'` ではなく `SHOW MASTER STATUS` / binlog 増加速度の鈍化を確認
- PVC 使用量の日次ピークが低下すること(Grafana の MariaDB ダッシュボード)
- eviction イベントが再発しないこと
- Debezium の seichi_portal キャプチャが継続していること

🤖 Generated with [Claude Code](https://claude.com/claude-code)