### PR TITLE
fix(observability): Sentry 撤去後の通知カバレッジと CNP allow を整備する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
@@ -43,10 +43,11 @@ spec:
           # 偽発火で、drain が prometheus Pod を動かすたびに窓の最中に firing する (2026-07-20 の窓で
           # wk-2 の再起動を 3 周期 (約 40 分) ブロックした実績)。アラート式側に > 0 ガードを入れて
           # 根治したが、本物の停滞時も再起動の保留ではアップロードは復旧しないため除外は維持する
-          # SeichiPortalHighErrorRate / SeichiPortalBackendCrashLoop: seichi-portal の
-          # アプリケーションアラート (#5611, #5618)。アプリのエラーはノード再起動で
-          # 直らないため、ノード保守をブロックさせない
-          alertFilterRegexp: "^(Watchdog|InfoInhibitor|TargetDown|KubeJobFailed|CPUThrottlingHigh|PrometheusNotConnectedToAlertmanagers|KubePodCrashLooping|KubePodNotReady|KubeDeploymentReplicasMismatch|KubeStatefulSetReplicasMismatch|KubeletTooManyPods|ThanosSidecarUploadStale|SeichiPortalHighErrorRate|SeichiPortalBackendCrashLoop)$"
+          # SeichiPortalHighErrorRate / SeichiPortalBackendCrashLoop /
+          # GachadataServerCrashLoop / ConifersIngestorJobFailed:
+          # アプリケーションアラート (#5611, #5618, Sentry 撤去後の通知カバレッジ)。
+          # アプリのエラーはノード再起動で直らないため、ノード保守をブロックさせない
+          alertFilterRegexp: "^(Watchdog|InfoInhibitor|TargetDown|KubeJobFailed|CPUThrottlingHigh|PrometheusNotConnectedToAlertmanagers|KubePodCrashLooping|KubePodNotReady|KubeDeploymentReplicasMismatch|KubeStatefulSetReplicasMismatch|KubeletTooManyPods|ThanosSidecarUploadStale|SeichiPortalHighErrorRate|SeichiPortalBackendCrashLoop|GachadataServerCrashLoop|ConifersIngestorJobFailed)$"
           # kubelet のパッチ更新も kured の drain + 再起動に相乗りさせる。
           # pkgs.k8s.io はマイナーごとの repo (core:/stable:/v1.3x) なので、apt で入るのは
           # 同一マイナー内のパッチのみ。マイナーアップグレードは従来どおり kubeadm で手動実施し、

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/loki-alert-rules/gachadata-server.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/loki-alert-rules/gachadata-server.yaml
@@ -1,0 +1,47 @@
+# gachadata-server のログベース通知。Sentry 撤去 (gachadata-server#239) 後の
+# 通知カバレッジ確保 (Codex レビュー指摘)。
+# 前提: gachadata-server#239 以降のイメージは stdout に 1 行 JSON を出力し、
+# panic hook が panic=true / level=ERROR を付ける (seichi-portal-backend と同じ契約)。
+# 旧イメージのログは JSON ではないため、この設定を先にマージしても
+# ルールは単にマッチしない (無害)。
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-alert-rules-gachadata-server
+  namespace: monitoring
+  labels:
+    loki_rule: "1"
+data:
+  gachadata-server.yaml: |
+    groups:
+      - name: gachadata-server-logs
+        interval: 1m
+        rules:
+          # 単発 panic から通知する (Sentry の panic 通知の代替)。
+          # 5xx はハンドラ内で tracing::error を出すため ERROR ルール側でも拾える
+          - alert: GachadataServerPanic
+            expr: |
+              sum by (service_name) (
+                count_over_time({job="seichi-minecraft/gachadata-server"} | json | panic="true" [5m])
+              ) > 0
+            labels:
+              severity: critical
+              notify: discord
+              service: gachadata-server
+            annotations:
+              summary: gachadata-server で panic が発生しました
+              description: 直近 5 分間に panic ログが記録されました。詳細は Loki で {job="seichi-minecraft/gachadata-server"} | json | panic="true" を実行して確認する。
+          # level=ERROR の頻発を通知する。低トラフィックサービスのため閾値は低め。
+          # dump 失敗・DB 接続失敗は error_handler が ERROR ログを出すためここで拾える
+          - alert: GachadataServerErrorLogs
+            expr: |
+              sum by (service_name) (
+                count_over_time({job="seichi-minecraft/gachadata-server"} | json | level="ERROR" | panic!="true" [10m])
+              ) > 3
+            labels:
+              severity: warning
+              notify: discord
+              service: gachadata-server
+            annotations:
+              summary: gachadata-server で ERROR ログが発生しています
+              description: 直近 10 分間の level=ERROR ログが閾値 (3 件) を超えています。

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/monitoring-default-deny-policy/allow--from-observed-apps--to-alloy-and-pyroscope.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/monitoring-default-deny-policy/allow--from-observed-apps--to-alloy-and-pyroscope.yaml
@@ -1,0 +1,52 @@
+# seichi-minecraft namespace の観測対象アプリからの ingress 許可。
+#   - alloy-receiver 4318/TCP: OTLP HTTP (gachadata-server。portal は既存の
+#     allow--from-seichi-portal--to-alloy-receiver.yaml が担う)
+#   - pyroscope 4040/TCP: 継続プロファイリングの push
+# 対になる seichi-minecraft 側の egress 許可は
+# apps/seichi-minecraft/default-deny-policy/ にある。
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow--from-gachadata--to-alloy-receiver
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: alloy-receiver
+      app.kubernetes.io/instance: k8s-monitoring-alloy-receiver
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: seichi-minecraft
+            app: gachadata-server
+      toPorts:
+        - ports:
+            - port: "4318"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow--from-observed-apps--to-pyroscope
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: pyroscope
+      app.kubernetes.io/instance: pyroscope
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: seichi-minecraft
+          matchExpressions:
+            - key: app
+              operator: In
+              values:
+                - seichi-portal-backend
+                - seichi-portal-frontend
+                - gachadata-server
+                - seichi-timed-stats-conifers-ingestor
+      toPorts:
+        - ports:
+            - port: "4040"
+              protocol: TCP

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/default-deny-policy/allow--from-observed-apps--to-alloy-and-pyroscope.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/default-deny-policy/allow--from-observed-apps--to-alloy-and-pyroscope.yaml
@@ -1,0 +1,53 @@
+# 観測対象アプリが monitoring namespace の受け口へテレメトリを送るための egress 許可。
+#   - alloy-receiver 4318/TCP: OTLP HTTP (gachadata-server。portal は既存の
+#     allow--from-seichi-portal--to-alloy-receiver.yaml が担う)
+#   - pyroscope 4040/TCP: 継続プロファイリングの push
+#     (portal backend/frontend, gachadata-server, conifers ingestor)
+# 対になる monitoring 側の ingress 許可は
+# apps/cluster-wide-apps/monitoring-default-deny-policy/ にある。
+# 注意: 現状の default-deny は明示 Deny (ingressDeny/egressDeny) 方式のため、
+# policyAuditMode を解除するとこの allow ごと無効化される。解除前に
+# deny 方式の変換が必要 (#5672)
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow--from-gachadata--to-alloy-receiver
+spec:
+  endpointSelector:
+    matchLabels:
+      app: gachadata-server
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: monitoring
+            app.kubernetes.io/name: alloy-receiver
+            app.kubernetes.io/instance: k8s-monitoring-alloy-receiver
+      toPorts:
+        - ports:
+            - port: "4318"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow--from-observed-apps--to-pyroscope
+spec:
+  endpointSelector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - seichi-portal-backend
+          - seichi-portal-frontend
+          - gachadata-server
+          - seichi-timed-stats-conifers-ingestor
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: monitoring
+            app.kubernetes.io/name: pyroscope
+            app.kubernetes.io/instance: pyroscope
+      toPorts:
+        - ports:
+            - port: "4040"
+              protocol: TCP

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/gachadata-server/prometheusrule.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/gachadata-server/prometheusrule.yaml
@@ -1,0 +1,29 @@
+# gachadata-server のアラート。Sentry 撤去 (gachadata-server#239) 後の
+# 通知カバレッジ確保 (Codex レビュー指摘)。
+# 起動時 panic のログは file tailer が拾う前にコンテナが死んで Loki に
+# 届かないため、CrashLoop は PrometheusRule 側で通知する
+# (seichi-portal-alerts の SeichiPortalBackendCrashLoop と同じ理由)。
+# アラート名は kured の alertFilterRegexp にも登録している。
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: gachadata-server-alerts
+  namespace: seichi-minecraft
+  labels:
+    release: prometheus
+spec:
+  groups:
+    - name: gachadata-server-alerts
+      rules:
+        - alert: GachadataServerCrashLoop
+          expr: |
+            max by (namespace, pod, container) (
+              max_over_time(kube_pod_container_status_waiting_reason{namespace="seichi-minecraft", container="gachadata-server", reason="CrashLoopBackOff", job="kube-state-metrics"}[5m])
+            ) >= 1
+          for: 5m
+          labels:
+            severity: critical
+            notify: discord
+          annotations:
+            summary: "gachadata-server が CrashLoopBackOff です"
+            description: "Pod {{ $labels.namespace }}/{{ $labels.pod }} が繰り返しクラッシュしています。起動時 panic のログは Loki に届かないため、原因は kubectl logs --previous で確認する。"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/ingestor-cronjob.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/ingestor-cronjob.yaml
@@ -12,7 +12,16 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 5
+      # 実行時間の上限。通常の ingest は数秒〜数十秒で終わる。
+      # ingestor#196 で導入する Pyroscope agent の停止処理は、依存クレート内部の
+      # エラー経路で稀に無期限待機し得るため (Codex レビュー指摘)、Job 側で
+      # 確実に打ち切る (5 分周期 + startingDeadlineSeconds 240 と整合する値)
+      activeDeadlineSeconds: 240
       template:
+        metadata:
+          labels:
+            # CiliumNetworkPolicy の endpointSelector 用
+            app: seichi-timed-stats-conifers-ingestor
         spec:
           restartPolicy: OnFailure
           initContainers:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/prometheusrule.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/prometheusrule.yaml
@@ -1,0 +1,29 @@
+# seichi-timed-stats-conifers の ingest 失敗通知。
+# Sentry SDK 撤去 (seichi-timed-stats-conifers#196) 後の通知カバレッジ確保
+# (Codex レビュー指摘: 汎用の KubeJobFailed は notify=discord の opt-in
+# リストに含まれておらず、人的通知が消えていた)。
+# アラート名は kured の alertFilterRegexp にも登録している。
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: seichi-timed-stats-conifers-alerts
+  namespace: seichi-minecraft
+  labels:
+    release: prometheus
+spec:
+  groups:
+    - name: seichi-timed-stats-conifers-alerts
+      rules:
+        - alert: ConifersIngestorJobFailed
+          # backoffLimit (5) / activeDeadlineSeconds 超過で Job が失敗扱いに
+          # なったことを検知する。失敗 Job オブジェクトが残っている間 firing する
+          # (5 分周期のため、後続が成功しても失敗 Job は履歴として残る点に注意)
+          expr: |
+            kube_job_failed{namespace="seichi-minecraft", job_name=~"seichi-timed-stats-conifers-ingestor-.*", condition="true"} == 1
+          for: 1m
+          labels:
+            severity: warning
+            notify: discord
+          annotations:
+            summary: "timed-stats-conifers の ingest Job が失敗しました"
+            description: "Job {{ $labels.job_name }} が失敗しました (retry 上限または実行期限超過)。ログは Loki の {job=\"seichi-minecraft/ingestor\"} で確認する (短命 Pod のため欠落しうる。その場合は kubectl logs)。"


### PR DESCRIPTION
## 概要

Codex による観測移行 PR 群 (conifers#196 / gachadata#239 / backend#1290 / frontend#962 / #5669) のレビュー指摘のうち、インフラ側の対応をまとめたものです。アプリ側の対応 (span への秘匿情報漏洩修正・SIGTERM flush・プロファイラ起動失敗の隔離) は各 PR に push 済み。

## 変更内容

### 通知カバレッジ (should-fix: Sentry 撤去後の人的通知経路がない)
- **gachadata**: `GachadataServerCrashLoop` (PrometheusRule) + `GachadataServerPanic` / `GachadataServerErrorLogs` (Loki ruler、ERROR は低トラフィック前提で 3 件/10 分)。5xx はハンドラが ERROR ログを出すため ERROR ルールで拾える
- **conifers**: `ConifersIngestorJobFailed` (kube_job_failed のスコープ付きルール。汎用 KubeJobFailed は notify=discord の opt-in リスト外)
- kured の alertFilterRegexp に新規 2 アラートを登録 (ノード保守をブロックさせない)
- いずれも対応イメージ配備前にマージしても無害 (JSON でないログにはマッチしない / CrashLoop・Job 失敗は普遍的に有効)

### conifers の実行期限 (should-fix: Pyroscope stop のデッドロック可能性)
- CronJob に `activeDeadlineSeconds: 240` を追加し、依存クレート内部のエラー経路による無期限待機を Job 側で打ち切る

### CNP allow (should-fix: gachadata / pyroscope の許可がない)
- gachadata → alloy-receiver:4318、観測対象 4 アプリ → pyroscope:4040 の egress/ingress を既存パターンで追加 (conifers Pod に selector 用 label も付与)
- **明示 Deny 方式のままでは audit 解除時に allow が全て無効化される構造問題は #5672 として起票** (このPRのスコープ外)

## 検証

- 全 YAML / 埋め込みルールのパース確認、kube_job_failed のラベル構造は実クエリで確認
- Pyroscope / alloy-receiver の Pod ラベルは実クラスタの kube_pod_labels で確認

refs #5613, #5672

🤖 Generated with [Claude Code](https://claude.com/claude-code)