### PR TITLE
feat(observability): OTel/Pyroscope 対応イメージへ更新し観測を有効化する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/gachadata-server/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/gachadata-server/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: gachadata-server
-          image: ghcr.io/giganticminecraft/gachadata-server:sha-23f6394@sha256:49030b16f117fad17228ada213bdce3e10bad7bbea26ffeb005e9eb53ec70762
+          image: ghcr.io/giganticminecraft/gachadata-server:sha-b04366a@sha256:56f200eb6597cfe01902df4272de112ae0cf47ea77aac14b6096db11f2aa0fce
           resources:
             requests:
               cpu: 15m

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
@@ -99,3 +99,9 @@ spec:
             # OTel resource に埋め込むのが正
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: "service.namespace=seichi-portal,deployment.environment=production,deployment.environment.name=production"
+            # 継続プロファイリング (seichi-portal-backend#1290)。
+            # 対応前のイメージはこの env を読まないため先行供給しても無害
+            - name: PYROSCOPE_SERVER_ADDRESS
+              value: "http://pyroscope.monitoring.svc.cluster.local:4040"
+            - name: PYROSCOPE_APPLICATION_NAME
+              value: "seichi-portal-backend"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-frontend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-frontend/deployment.yaml
@@ -66,3 +66,9 @@ spec:
               value: "parentbased_always_on"
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: "service.namespace=seichi-portal,deployment.environment=production,deployment.environment.name=production"
+            # 継続プロファイリング (seichi-portal-frontend#962)。
+            # 対応前のイメージはこの env を読まないため先行供給しても無害
+            - name: PYROSCOPE_SERVER_ADDRESS
+              value: "http://pyroscope.monitoring.svc.cluster.local:4040"
+            - name: PYROSCOPE_APPLICATION_NAME
+              value: "seichi-portal-frontend"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/ingestor-cronjob.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/ingestor-cronjob.yaml
@@ -26,7 +26,7 @@ spec:
           restartPolicy: OnFailure
           initContainers:
             - name: migration
-              image: ghcr.io/giganticminecraft/seichi-timed-stats-conifers-database-migration:sha-9cb78a5@sha256:afbbd5a2a6d467f4a19247e403a202c7d5659e1c29cc62463a71376be33c0e2d
+              image: ghcr.io/giganticminecraft/seichi-timed-stats-conifers-database-migration:sha-ee9e979@sha256:314db782a0ff5cead9d721667d47981575aa57350665f642eb6699dd77714215
               env:
                 - name: DB_HOST_AND_PORT
                   value: "mariadb:3306"
@@ -41,7 +41,7 @@ spec:
                       key: password
           containers:
             - name: ingestor
-              image: ghcr.io/giganticminecraft/seichi-timed-stats-conifers-ingestor:sha-9cb78a5@sha256:2c62e95dace3d8321dd884c4b4f07fa7623a19094abf4115143cd95b738258ae
+              image: ghcr.io/giganticminecraft/seichi-timed-stats-conifers-ingestor:sha-ee9e979@sha256:430c10b3e05d6637cbf1fb69d4a0520e611e7c255fc50d6e7bf04df634072ce0
               env:
                 - name: DB_CONNECTION_HOST_AND_PORT
                   value: "mariadb:3306"
@@ -62,7 +62,8 @@ spec:
                   value: "debug,h2::codec::framed_read=info"
                 - name: RUST_BACKTRACE
                   value: "1"
-                - name: SENTRY_ENVIRONMENT_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
+                # 継続プロファイリング (conifers#196 で Sentry から移行)
+                - name: PYROSCOPE_SERVER_ADDRESS
+                  value: "http://pyroscope.monitoring.svc.cluster.local:4040"
+                - name: PYROSCOPE_APPLICATION_NAME
+                  value: "seichi-timed-stats-conifers-ingestor"


### PR DESCRIPTION
## 概要

マージ済みの観測移行 PR 群を実際に有効化するイメージ更新 + env 供給です。

| 対象 | 変更 | 効果 |
|---|---|---|
| conifers | `sha-ee9e979` へ更新 + `SENTRY_ENVIRONMENT_NAME` 削除 + `PYROSCOPE_*` 供給 | Sentry 依存の完全除去 (#5613 の残タスク) + プロファイリング開始。**イメージと env を同一 PR で入れ替えるためマージ順の事故なし** |
| gachadata | `sha-b04366a` へ更新 | OTel トレース/JSON ログ/プロファイリング開始 (env は #5669 で供給済み、**span への秘匿情報漏洩修正込みのイメージ**) |
| portal backend/frontend | `PYROSCOPE_*` を先行供給 | 現行イメージは読まないため無害。backend#1290 / frontend#962 を含む次リリースで自動的に有効化 |

- digest は ghcr registry API (匿名 pull token) から取得。Renovate が同じ bump の PR を後追いで開いた場合は close してください
- マージ後の反映: seichi-minecraft プロジェクトの sync window (07:00-08:00 JST) 待ち。急ぐ場合は ArgoCD で手動 sync
- 反映後、Pyroscope の service_name に conifers/gachadata が現れることを確認します (私が実施)

refs #5613

🤖 Generated with [Claude Code](https://claude.com/claude-code)