### PR TITLE
fix: gachadata-server を span 秘匿対応済みイメージ (sha-2f3cd4d) に更新する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/gachadata-server/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/gachadata-server/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: gachadata-server
-          image: ghcr.io/giganticminecraft/gachadata-server:sha-b04366a@sha256:56f200eb6597cfe01902df4272de112ae0cf47ea77aac14b6096db11f2aa0fce
+          image: ghcr.io/giganticminecraft/gachadata-server:sha-2f3cd4d@sha256:777dfab96121f307fe4a2e3372a2b77996d75966ba45b42d66dc28c4d99b0ddc
           resources:
             requests:
               cpu: 15m


### PR DESCRIPTION
## ⚠️ 至急マージ推奨(秘匿情報が Tempo へ送信され続けています)

#5674 で参照した `sha-b04366a` は、`#[tracing::instrument]` が引数を skip しない [gachadata-server#239](https://github.com/GiganticMinecraft/gachadata-server/pull/239) 時点のコードです。#5669/#5674 で OTLP endpoint が有効化されたため、現在クラスタではリクエストごとに以下が span 属性として Tempo へ送信されています(auto-sync 済みであることを実機確認):

- `MYSQL_PASSWORD`(`mcserver` ユーザーの実パスワード)
- キャッシュ済み gachadata dump の SQL 全文

修正([gachadata-server#240](https://github.com/GiganticMinecraft/gachadata-server/pull/240): skip + Debug redact + graceful flush)を含む `sha-2f3cd4d`(Build and release 成功済み、digest は GHCR から取得)へ更新します。

## マージ後の対応(別途)

- Tempo の retention は 24h のため、漏えい済み span は 1 日で消えるが、閲覧可能な間は Grafana (Tempo) 上に `mcserver` のパスワードが存在する
- 念のため `mcserver` ユーザーのパスワードローテーションを推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)