### PR TITLE
fix(alerts): ConifersIngestorJobFailed を直近 1 時間の失敗に限定する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/prometheusrule.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/prometheusrule.yaml
@@ -16,10 +16,19 @@ spec:
       rules:
         - alert: ConifersIngestorJobFailed
           # backoffLimit (5) / activeDeadlineSeconds 超過で Job が失敗扱いに
-          # なったことを検知する。失敗 Job オブジェクトが残っている間 firing する
-          # (5 分周期のため、後続が成功しても失敗 Job は履歴として残る点に注意)
+          # なったことを検知する。
+          # failedJobsHistoryLimit が最後の失敗 Job を保持し続けるため、
+          # 「失敗 Job の存在」だけを見ると何日も前の失敗に firing し続ける
+          # (2026-08-02 に 4 日前の残骸 Job で誤報した実績)。開始が直近 1 時間の
+          # Job に限定し、履歴の残骸では発火させない
           expr: |
-            kube_job_failed{namespace="seichi-minecraft", job_name=~"seichi-timed-stats-conifers-ingestor-.*", condition="true"} == 1
+            (
+              kube_job_failed{namespace="seichi-minecraft", job_name=~"seichi-timed-stats-conifers-ingestor-.*", condition="true"} == 1
+            )
+            and on (job_name)
+            (
+              time() - kube_job_status_start_time{namespace="seichi-minecraft", job_name=~"seichi-timed-stats-conifers-ingestor-.*"} < 3600
+            )
           for: 1m
           labels:
             severity: warning


### PR DESCRIPTION
## 概要

#5673 で追加した `ConifersIngestorJobFailed` が、適用直後に **4 日前 (7/29) の失敗 Job の残骸**に反応して誤報しました (failedJobsHistoryLimit がデフォルト 1 件の失敗 Job を保持し続けるため、「失敗 Job オブジェクトの存在」を条件にすると過去の失敗に firing し続ける設計不備)。

`kube_job_status_start_time` との join で **開始が直近 1 時間の Job に限定**します。修正後の式は実クエリで検証済み (現在の残骸 Job にはマッチせず 0 件)。

#monitor-k8s-grafana に飛んだ ConifersIngestorJobFailed の通知は上記の誤報です (実際の ingest は成功し続けており、たった今の新イメージ Job も正常実行中)。マージ後に resolved になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)