### PR TITLE
fix: conifers を migration 版数不一致修正済みイメージ (sha-8cf3333) に更新する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/ingestor-cronjob.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/ingestor-cronjob.yaml
@@ -26,7 +26,7 @@ spec:
           restartPolicy: OnFailure
           initContainers:
             - name: migration
-              image: ghcr.io/giganticminecraft/seichi-timed-stats-conifers-database-migration:sha-ee9e979@sha256:314db782a0ff5cead9d721667d47981575aa57350665f642eb6699dd77714215
+              image: ghcr.io/giganticminecraft/seichi-timed-stats-conifers-database-migration:sha-8cf3333@sha256:49922eb31083dcc611a976a6a9372103b6bd81eb0c2936fe6f4521d428015c33
               env:
                 - name: DB_HOST_AND_PORT
                   value: "mariadb:3306"
@@ -41,7 +41,7 @@ spec:
                       key: password
           containers:
             - name: ingestor
-              image: ghcr.io/giganticminecraft/seichi-timed-stats-conifers-ingestor:sha-ee9e979@sha256:430c10b3e05d6637cbf1fb69d4a0520e611e7c255fc50d6e7bf04df634072ce0
+              image: ghcr.io/giganticminecraft/seichi-timed-stats-conifers-ingestor:sha-8cf3333@sha256:4162683bcded1160700eb20eabe34753c5a23a62060fefebfbbbe72232069aeb
               env:
                 - name: DB_CONNECTION_HOST_AND_PORT
                   value: "mariadb:3306"


### PR DESCRIPTION
## 概要

2026-08-02 15:45 JST から継続している `ConifersIngestorJobFailed`(ingestor CronJob の全実行失敗)の復旧。

- 原因: #5674 で入った `sha-ee9e979` イメージの migration init コンテナが、未固定 `cargo install diesel_cli` の最新化に伴う版数解釈変更で、適用済みの初回マイグレーション(DB 記録 `20230524025310`)をディレクトリ名 `2023-05-24-025310` と不一致のため未適用と誤判定 → `Table 'break_count_full_snapshot_point' already exists` で失敗
- 修正: GiganticMinecraft/seichi-timed-stats-conifers#197(ディレクトリ名をハイフン無し版数へリネーム + diesel_cli を 2.3.11 に固定)を含む `sha-8cf3333` に migration / ingestor 両イメージを更新

## 反映確認

ArgoCD sync 後、次の 5 分境界の Job で init コンテナ `migration` が「マイグレーション適用済み」として素通りし、ingestor が正常起動すれば復旧。

## 補足

- `sha-8cf3333` も cosign 未署名のため Kyverno の署名検証 (Audit) には失敗し続ける。アプリ repo の workflow に署名ステップがそもそも無いため、別途フォローアップが必要
- 15:45〜復旧までの統計スナップショットは欠損(diff ベースのため次回成功時からの差分は記録される)

🤖 Generated with [Claude Code](https://claude.com/claude-code)