### PR TITLE
fix: conifers を trixie ベースの migration イメージ (sha-5fe5b38) に更新する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/ingestor-cronjob.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/ingestor-cronjob.yaml
@@ -26,7 +26,7 @@ spec:
           restartPolicy: OnFailure
           initContainers:
             - name: migration
-              image: ghcr.io/giganticminecraft/seichi-timed-stats-conifers-database-migration:sha-8cf3333@sha256:49922eb31083dcc611a976a6a9372103b6bd81eb0c2936fe6f4521d428015c33
+              image: ghcr.io/giganticminecraft/seichi-timed-stats-conifers-database-migration:sha-5fe5b38@sha256:fa3d7f33d6db8d1efeed7e184b9d6d7532e24c6c737373d3c2486b7346dbc916
               env:
                 - name: DB_HOST_AND_PORT
                   value: "mariadb:3306"
@@ -41,7 +41,7 @@ spec:
                       key: password
           containers:
             - name: ingestor
-              image: ghcr.io/giganticminecraft/seichi-timed-stats-conifers-ingestor:sha-8cf3333@sha256:4162683bcded1160700eb20eabe34753c5a23a62060fefebfbbbe72232069aeb
+              image: ghcr.io/giganticminecraft/seichi-timed-stats-conifers-ingestor:sha-5fe5b38@sha256:a3992cd8bdd198d5a0a3ce5b473f62c1dcaec7834abd972ddc999f4931a42e89
               env:
                 - name: DB_CONNECTION_HOST_AND_PORT
                   value: "mariadb:3306"


### PR DESCRIPTION
## 概要

`ConifersIngestorJobFailed`(15:45 JST から継続)の復旧・第 2 弾。#5681 (`sha-8cf3333`) でも失敗が続いた真因が判明したため、その修正版イメージへ更新する。

## 真因

**bookworm の libmariadb `1:10.11.18-0+deb12u1`(動的リンク)が MariaDB 11.x サーバーに対して文字列カラムを空文字列として読むリグレッション**(diesel-rs/diesel#5102 と同一)。`__diesel_schema_migrations` の `version` が空として読まれ、diesel_cli が適用済みマイグレーションを検出できず初回マイグレーションを再実行 → `Table already exists` で失敗していた。

ローカルの MariaDB 11.8 での再現実験により、bookworm ビルド = 誤判定を再現、trixie ビルド(libmariadb `1:11.8.6`)= 正常認識を確認済み(GiganticMinecraft/seichi-timed-stats-conifers#198 参照)。

## 変更

- migration / ingestor 両イメージを `sha-5fe5b38`(base を `rust:1.97.1-slim-trixie` に変更したビルド)+ digest ピンで更新

## 反映確認

ArgoCD sync 後、次の 5 分境界の Job で migration init コンテナが「適用済み」としてスキップし、ingestor が正常起動すれば復旧。sync 直前に生成された Job 1 個は旧イメージのまま失敗しうる(既知のすれ違い、無視してよい)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)