### PR TITLE
improve: Discord アラート通知の可読性を改善する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
@@ -350,11 +350,14 @@ spec:
                     # "%.Ns" による各フィールドの切り詰めと併用)
                     max_alerts: 5
                     payload:
-                      content: '<@&532704116799963168> {{ template "__subject" . }}'
+                      # デフォルトの __subject は末尾に CommonLabels - GroupLabels を
+                      # 括弧で列挙する (condition/container/endpoint/... のダンプに
+                      # なって読めない) ため、alertname と namespace だけの自作にする
+                      content: '<@&532704116799963168> {{ if eq .Status "firing" }}[FIRING:{{ .Alerts.Firing | len }}]{{ else }}[RESOLVED]{{ end }} {{ .GroupLabels.alertname }}{{ with .GroupLabels.namespace }} ({{ . }}){{ end }}'
                       allowed_mentions:
                         roles: ["532704116799963168"]
                       embeds:
-                        - title: '{{ if eq .Status "firing" }}🔥 [FIRING:{{ .Alerts.Firing | len }}]{{ else }}✅ [RESOLVED]{{ end }} {{ printf "%.200s" (.GroupLabels.SortedPairs.Values | join " ") }}'
+                        - title: '{{ if eq .Status "firing" }}🔥 [FIRING:{{ .Alerts.Firing | len }}]{{ else }}✅ [RESOLVED]{{ end }} {{ .GroupLabels.alertname }}{{ with .GroupLabels.namespace }} ({{ . }}){{ end }}'
                           description: |-
                             {{ range .Alerts }}**{{ .Labels.alertname }}** ({{ .Status }}){{ with .Annotations.summary }} — {{ printf "%.200s" . }}{{ end }}
                             {{ with .Annotations.description }}{{ printf "%.500s" . }}
@@ -364,11 +367,14 @@ spec:
                   - url_file: /etc/alertmanager/secrets/infra-alert-discord/webhook-url
                     max_alerts: 5
                     payload:
-                      content: '<@&532704116799963168> {{ template "__subject" . }}'
+                      # デフォルトの __subject は末尾に CommonLabels - GroupLabels を
+                      # 括弧で列挙する (condition/container/endpoint/... のダンプに
+                      # なって読めない) ため、alertname と namespace だけの自作にする
+                      content: '<@&532704116799963168> {{ if eq .Status "firing" }}[FIRING:{{ .Alerts.Firing | len }}]{{ else }}[RESOLVED]{{ end }} {{ .GroupLabels.alertname }}{{ with .GroupLabels.namespace }} ({{ . }}){{ end }}'
                       allowed_mentions:
                         roles: ["532704116799963168"]
                       embeds:
-                        - title: '{{ if eq .Status "firing" }}🔥 [FIRING:{{ .Alerts.Firing | len }}]{{ else }}✅ [RESOLVED]{{ end }} {{ printf "%.200s" (.GroupLabels.SortedPairs.Values | join " ") }}'
+                        - title: '{{ if eq .Status "firing" }}🔥 [FIRING:{{ .Alerts.Firing | len }}]{{ else }}✅ [RESOLVED]{{ end }} {{ .GroupLabels.alertname }}{{ with .GroupLabels.namespace }} ({{ . }}){{ end }}'
                           description: |-
                             {{ range .Alerts }}**{{ .Labels.alertname }}** ({{ .Status }}){{ with .Annotations.summary }} — {{ printf "%.200s" . }}{{ end }}
                             {{ with .Annotations.description }}{{ printf "%.500s" . }}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/prometheusrule.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/prometheusrule.yaml
@@ -20,19 +20,22 @@ spec:
           # failedJobsHistoryLimit が最後の失敗 Job を保持し続けるため、
           # 「失敗 Job の存在」だけを見ると何日も前の失敗に firing し続ける
           # (2026-08-02 に 4 日前の残骸 Job で誤報した実績)。開始が直近 1 時間の
-          # Job に限定し、履歴の残骸では発火させない
+          # Job に限定し、履歴の残骸では発火させない。
+          # job_name を残すと 5 分ごとの Job 1 個につき 1 アラートになり、
+          # 失敗が続くと Discord 通知が同文の羅列になる (2026-08-02 実績) ため
+          # count で単一インスタンスに集約し、失敗数は $value で伝える
           expr: |
-            (
+            count by (namespace) (
               kube_job_failed{namespace="seichi-minecraft", job_name=~"seichi-timed-stats-conifers-ingestor-.*", condition="true"} == 1
-            )
-            and on (job_name)
-            (
-              time() - kube_job_status_start_time{namespace="seichi-minecraft", job_name=~"seichi-timed-stats-conifers-ingestor-.*"} < 3600
-            )
+              and on (job_name)
+              (
+                time() - kube_job_status_start_time{namespace="seichi-minecraft", job_name=~"seichi-timed-stats-conifers-ingestor-.*"} < 3600
+              )
+            ) > 0
           for: 1m
           labels:
             severity: warning
             notify: discord
           annotations:
             summary: "timed-stats-conifers の ingest Job が失敗しました"
-            description: "Job {{ $labels.job_name }} が失敗しました (retry 上限または実行期限超過)。ログは Loki の {job=\"seichi-minecraft/ingestor\"} で確認する (短命 Pod のため欠落しうる。その場合は kubectl logs)。"
+            description: "直近 1 時間に {{ $value }} 個の ingest Job が失敗しています (retry 上限または実行期限超過)。ログは Loki の {job=\"seichi-minecraft/ingestor\"} で確認する (短命 Pod のため欠落しうる。その場合は kubectl logs)。"


### PR DESCRIPTION
## 背景

2026-08-02 の `ConifersIngestorJobFailed` 対応中、Discord 通知が読みづらいという指摘があった:

- タイトル末尾に `(true kube-state-metrics http kube-state-metrics discord monitoring/prometheus-kube-prometheus-prometheus warning)` のようなラベル値ダンプが付く
- 本文にほぼ同文のアラートブロックが max_alerts (5) 個並ぶ

## 変更内容

### 1. 通知タイトルのラベルダンプ除去(prometheus-operator.yaml)

原因は Alertmanager デフォルトの `__subject` テンプレートで、末尾に「CommonLabels − GroupLabels」を括弧で列挙する仕様。`content` と embed `title` を alertname + namespace のみの自作テンプレートに置き換える(portal / infra 両 receiver):

```
[FIRING:2] ConifersIngestorJobFailed (seichi-minecraft)
```

### 2. ConifersIngestorJobFailed の単一インスタンス化(prometheusrule.yaml)

job_name ごとに 1 アラートが発火するため、失敗が続くと同文ブロックの羅列になっていた。`count by (namespace)` で集約して常に 1 インスタンスとし、失敗数は `$value` で伝える:

> 直近 1 時間に 3 個の ingest Job が失敗しています (retry 上限または実行期限超過)。…

`concurrencyPolicy: Replace` で失敗 Job がすぐ消されることによる job_name ごとの firing/resolved の出入り(通知のチカチカ)も収まる。

## 影響範囲

- テンプレート変更は notify=discord の全アラートの通知形式に適用(グルーピングキーは変更なし)
- ルール変更は ConifersIngestorJobFailed のみ。アラート名は変わらないため kured の alertFilterRegexp への影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)