### PR TITLE
chore: conifers の migration イメージをビルド入力固定版 (sha-58b84f1) に更新する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/ingestor-cronjob.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/ingestor-cronjob.yaml
@@ -26,7 +26,7 @@ spec:
           restartPolicy: OnFailure
           initContainers:
             - name: migration
-              image: ghcr.io/giganticminecraft/seichi-timed-stats-conifers-database-migration:sha-5fe5b38@sha256:fa3d7f33d6db8d1efeed7e184b9d6d7532e24c6c737373d3c2486b7346dbc916
+              image: ghcr.io/giganticminecraft/seichi-timed-stats-conifers-database-migration:sha-58b84f1@sha256:2da36394a784cd95deabb69c6b553b5c6adbebe9754530c0d6fc4705cad9069b
               env:
                 - name: DB_HOST_AND_PORT
                   value: "mariadb:3306"


### PR DESCRIPTION
## 概要

GiganticMinecraft/seichi-timed-stats-conifers#202(2026-08-02 インシデントの恒久対策 conifers#200: ビルド入力の固定 + migration 二重実行の回帰テスト)を含む migration イメージへ更新する。

- 変更は base の digest 固定と COPY の必要ファイル限定のみで、**マイグレーション内容に変更はない**。CI の回帰テスト(MariaDB 11.8 で 2 回実行 → 2 回目 no-op)を通過したイメージ
- **今回から migration イメージはビルド入力の変更時のみ新タグが作られる**ため、ingestor(`sha-5fe5b38` のまま)とはタグが独立する。ingestor は内容が変わっていないため据え置き

## 反映確認

sync 後の次の 5 分境界の Job で、migration init コンテナが「適用済み」としてスキップ(no-op)し ingest が継続すれば OK。

🤖 Generated with [Claude Code](https://claude.com/claude-code)