### PR TITLE
feat: conifers の migration を純 Rust 実装イメージ (sha-35af1fb) に更新する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/ingestor-cronjob.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/ingestor-cronjob.yaml
@@ -26,7 +26,7 @@ spec:
           restartPolicy: OnFailure
           initContainers:
             - name: migration
-              image: ghcr.io/giganticminecraft/seichi-timed-stats-conifers-database-migration:sha-58b84f1@sha256:2da36394a784cd95deabb69c6b553b5c6adbebe9754530c0d6fc4705cad9069b
+              image: ghcr.io/giganticminecraft/seichi-timed-stats-conifers-database-migration:sha-35af1fb@sha256:05139d5006e8301855007416cbdc1849d25d4366d4aae8d34ea7e70d272c35d2
               env:
                 - name: DB_HOST_AND_PORT
                   value: "mariadb:3306"


### PR DESCRIPTION
## 概要

GiganticMinecraft/seichi-timed-stats-conifers#205(2026-08-02 インシデントの恒久対策 conifers#201)を含む migration イメージへ更新する。

- diesel_cli + libmysqlclient(C 動的リンク)を廃止し、純 Rust の `database-migrator`(diesel-async 0.9.2 `AsyncMigrationHarness` + `embed_migrations!`)へ置き換えたイメージ。**OS パッケージのクライアントライブラリのリグレッション(今回のインシデントの原因クラス)の影響を構造的に受けない**
- 状態テーブル(`__diesel_schema_migrations`)・version 記録形式(`20230524025310`)・出力形式は旧 CLI と互換。**既存 DB はそのまま「適用済み」と認識される**(CI とローカルの両方で MariaDB 11.8 の二重実行テストを通過)
- runtime は distroless/cc-debian13(digest ピン・nonroot)。シェル・APT・C クライアントライブラリなし

## 反映確認

sync 後の次の 5 分境界の Job で、migration init コンテナが no-op(出力なしで即終了)→ ingestor が通常実行すれば OK。

これがマージ・反映されると、インシデントの根本原因(C クライアント依存)は排除完了となる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)