### PR TITLE
feat: conifers ingest の成功途絶を検知する ConifersIngestorStalled を追加する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
@@ -47,7 +47,7 @@ spec:
           # GachadataServerCrashLoop / ConifersIngestorJobFailed:
           # アプリケーションアラート (#5611, #5618, Sentry 撤去後の通知カバレッジ)。
           # アプリのエラーはノード再起動で直らないため、ノード保守をブロックさせない
-          alertFilterRegexp: "^(Watchdog|InfoInhibitor|TargetDown|KubeJobFailed|CPUThrottlingHigh|PrometheusNotConnectedToAlertmanagers|KubePodCrashLooping|KubePodNotReady|KubeDeploymentReplicasMismatch|KubeStatefulSetReplicasMismatch|KubeletTooManyPods|ThanosSidecarUploadStale|SeichiPortalHighErrorRate|SeichiPortalBackendCrashLoop|GachadataServerCrashLoop|ConifersIngestorJobFailed)$"
+          alertFilterRegexp: "^(Watchdog|InfoInhibitor|TargetDown|KubeJobFailed|CPUThrottlingHigh|PrometheusNotConnectedToAlertmanagers|KubePodCrashLooping|KubePodNotReady|KubeDeploymentReplicasMismatch|KubeStatefulSetReplicasMismatch|KubeletTooManyPods|ThanosSidecarUploadStale|SeichiPortalHighErrorRate|SeichiPortalBackendCrashLoop|GachadataServerCrashLoop|ConifersIngestorJobFailed|ConifersIngestorStalled)$"
           # kubelet のパッチ更新も kured の drain + 再起動に相乗りさせる。
           # pkgs.k8s.io はマイナーごとの repo (core:/stable:/v1.3x) なので、apt で入るのは
           # 同一マイナー内のパッチのみ。マイナーアップグレードは従来どおり kubeadm で手動実施し、

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/prometheusrule.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/prometheusrule.yaml
@@ -2,7 +2,7 @@
 # Sentry SDK 撤去 (seichi-timed-stats-conifers#196) 後の通知カバレッジ確保
 # (Codex レビュー指摘: 汎用の KubeJobFailed は notify=discord の opt-in
 # リストに含まれておらず、人的通知が消えていた)。
-# アラート名は kured の alertFilterRegexp にも登録している。
+# 各アラート名は kured の alertFilterRegexp にも登録している。
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -39,3 +39,31 @@ spec:
           annotations:
             summary: "timed-stats-conifers の ingest Job が失敗しました"
             description: "直近 1 時間に {{ $value }} 個の ingest Job が失敗しています (retry 上限または実行期限超過)。ログは Loki の {job=\"seichi-minecraft/ingestor\"} で確認する (短命 Pod のため欠落しうる。その場合は kubectl logs)。"
+
+        - alert: ConifersIngestorStalled
+          # 「失敗 Job の存在」(上記) とは独立に、成功の途絶そのものを検知する
+          # (infra#5692、2026-08-02 インシデントの恒久対策)。
+          # Job オブジェクトは concurrencyPolicy: Replace や履歴 limit ですぐ
+          # 消されるため、JobFailed だけでは長時間停止が resolve 済みに見える
+          # ことがある。最後の成功からの経過時間なら Job の残骸に依存しない。
+          # 閾値 30 分 = 5 分周期の 6 回分。suspend 中 (計画停止) は発火させない。
+          # max による集約は kube-state-metrics の pod 入れ替わりでアラート
+          # インスタンスが変わって通知が乱れるのを防ぐため。
+          # kube-state-metrics 自体の停止・欠落は汎用の TargetDown 等が検知する
+          expr: |
+            (
+              time()
+              - max by (namespace, cronjob) (kube_cronjob_status_last_successful_time{namespace="seichi-minecraft", cronjob="seichi-timed-stats-conifers-ingestor"})
+              > 1800
+            )
+            and on (namespace, cronjob)
+            (
+              max by (namespace, cronjob) (kube_cronjob_spec_suspend{namespace="seichi-minecraft", cronjob="seichi-timed-stats-conifers-ingestor"}) == 0
+            )
+          for: 5m
+          labels:
+            severity: warning
+            notify: discord
+          annotations:
+            summary: "timed-stats-conifers の ingest が停止しています"
+            description: "最後に成功した ingest から {{ $value | humanizeDuration }} 経過しています (平常は 5 分周期)。Job の状態は kubectl get jobs -n seichi-minecraft、ログは Loki の {job=\"seichi-minecraft/ingestor\"} で確認する。"


### PR DESCRIPTION
Closes #5692(2026-08-02 インシデントの恒久対策 #1。ポストモーテム: #5691)

## 背景

既存の `ConifersIngestorJobFailed` は「失敗 Job の存在」の検知。Job オブジェクトは `concurrencyPolicy: Replace` と履歴 limit ですぐ消されるため、長時間停止でも resolve 済みに見えることがある(今回のインシデントで実証済み)。成功の途絶そのものを見るアラートを追加する。

## 変更内容

- `ConifersIngestorStalled`: `time() - max by (namespace, cronjob) (kube_cronjob_status_last_successful_time{...}) > 1800`(30 分 = 5 分周期 6 回分)+ `for: 5m`
  - **suspend ガード**: `kube_cronjob_spec_suspend == 0` を and 条件にし、計画停止中は発火させない
  - **max 集約**: kube-state-metrics の pod 入れ替わりでラベルが変わりアラートインスタンスが変動する問題(バックテストで実際に観測)を防ぐ。インスタンスは常に 1 個、ラベルは namespace/cronjob のみ
- kured の `alertFilterRegexp` に追加(アプリ系アラートはノード保守をブロックさせない既存方針)

## 検証(完了条件との対応)

| ケース | 検証方法・結果 |
|---|---|
| 失敗(発火) | **2026-08-02 の実データでバックテスト**: 障害区間で 07:10 UTC 頃から条件成立(経過 2,389 秒〜29,389 秒まで単調増加)し連続 firing 相当 |
| 復旧(解消) | 同バックテストで 14:50 UTC の復旧時点でシリーズ消滅(= resolve) |
| 時系列欠落 | kube-state-metrics 停止時は式が empty になり本アラートは沈黙する設計。KSM 自体の欠落は汎用の TargetDown 等が検知する(ルール内コメントに明記)。KSM の pod 入れ替わり(部分的な系列切り替わり)は max 集約で吸収し、バックテスト期間中の実際の pod 交代でも単一シリーズを維持 |
| CronJob suspend | `==0` 側は現行実データでガード通過を確認。`==1`(抑止)側は suspend 中の CronJob がクラスタに存在せず、本番 CronJob を suspend すると ingest 実行スキップの副作用があるため実地テストは未実施。kube-state-metrics 標準のブール gauge セマンティクスに依拠(レビューで実地テスト要否の判断を仰ぎたい) |

現在の健全状態では経過 ~170-220 秒で閾値未満(発火しない)ことも確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)