### PR TITLE
feat: conifers の migration を ArgoCD PreSync hook のリリース単位 Job に分離する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
@@ -47,7 +47,7 @@ spec:
           # GachadataServerCrashLoop / ConifersIngestorJobFailed:
           # アプリケーションアラート (#5611, #5618, Sentry 撤去後の通知カバレッジ)。
           # アプリのエラーはノード再起動で直らないため、ノード保守をブロックさせない
-          alertFilterRegexp: "^(Watchdog|InfoInhibitor|TargetDown|KubeJobFailed|CPUThrottlingHigh|PrometheusNotConnectedToAlertmanagers|KubePodCrashLooping|KubePodNotReady|KubeDeploymentReplicasMismatch|KubeStatefulSetReplicasMismatch|KubeletTooManyPods|ThanosSidecarUploadStale|SeichiPortalHighErrorRate|SeichiPortalBackendCrashLoop|GachadataServerCrashLoop|ConifersIngestorJobFailed|ConifersIngestorStalled)$"
+          alertFilterRegexp: "^(Watchdog|InfoInhibitor|TargetDown|KubeJobFailed|CPUThrottlingHigh|PrometheusNotConnectedToAlertmanagers|KubePodCrashLooping|KubePodNotReady|KubeDeploymentReplicasMismatch|KubeStatefulSetReplicasMismatch|KubeletTooManyPods|ThanosSidecarUploadStale|SeichiPortalHighErrorRate|SeichiPortalBackendCrashLoop|GachadataServerCrashLoop|ConifersIngestorJobFailed|ConifersIngestorStalled|ConifersMigrationJobFailed)$"
           # kubelet のパッチ更新も kured の drain + 再起動に相乗りさせる。
           # pkgs.k8s.io はマイナーごとの repo (core:/stable:/v1.3x) なので、apt で入るのは
           # 同一マイナー内のパッチのみ。マイナーアップグレードは従来どおり kubeadm で手動実施し、

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/ingestor-cronjob.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/ingestor-cronjob.yaml
@@ -24,21 +24,9 @@ spec:
             app: seichi-timed-stats-conifers-ingestor
         spec:
           restartPolicy: OnFailure
-          initContainers:
-            - name: migration
-              image: ghcr.io/giganticminecraft/seichi-timed-stats-conifers-database-migration:sha-35af1fb@sha256:05139d5006e8301855007416cbdc1849d25d4366d4aae8d34ea7e70d272c35d2
-              env:
-                - name: DB_HOST_AND_PORT
-                  value: "mariadb:3306"
-                - name: DB_USER
-                  value: "seichi-timed-stats-conifers"
-                - name: DB_DATABASE_NAME
-                  value: "seichi-timed-stats-conifers"
-                - name: DB_PASSWORD
-                  valueFrom:
-                    secretKeyRef:
-                      name: seichi-timed-stats-conifers-db-credentials
-                      key: password
+          # migration は initContainer ではなく ArgoCD の PreSync hook
+          # (migration-job.yaml) で sync 時に 1 回だけ実行する (infra#5693)。
+          # migration の障害が 5 分ごとの全 ingest を止めないようにするため
           containers:
             - name: ingestor
               image: ghcr.io/giganticminecraft/seichi-timed-stats-conifers-ingestor:sha-5fe5b38@sha256:a3992cd8bdd198d5a0a3ce5b473f62c1dcaec7834abd972ddc999f4931a42e89

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/migration-job.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/migration-job.yaml
@@ -1,0 +1,49 @@
+# DB マイグレーションを ArgoCD の PreSync hook として実行する (infra#5693)。
+#
+# 以前は ingestor CronJob の initContainer で 5 分ごとに migration を実行して
+# いたが、migration の依存障害がそのまま全 ingest 停止に直結した
+# (2026-08-02 インシデントの影響拡大要因)。PreSync 化により:
+# - migration はこの app の sync 時のみ実行される (リリース単位)
+# - hook が失敗すると sync 全体が中断され、CronJob は旧イメージのまま
+#   → ingest は旧バージョンで継続する
+# - 「migration 成功 → 新 ingestor 配備」の順序が ArgoCD により保証される
+#
+# 運用ルール: sync 中〜完了までは旧バージョンの ingestor が動き続けるため、
+# マイグレーションは直前バージョンの ingestor と互換であること
+# (expand-contract。破壊的変更は 2 リリースに分割する)。
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: seichi-timed-stats-conifers-migration
+  namespace: seichi-minecraft
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    # 次の sync 開始時に前回の Job を削除してから作り直す。
+    # 失敗した Job は次の sync まで残るためログを調査できる
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  backoffLimit: 2
+  activeDeadlineSeconds: 300
+  template:
+    metadata:
+      labels:
+        # CiliumNetworkPolicy の endpointSelector 用。ingestor と同一ラベルに
+        # することで mariadb への通信条件を揃える
+        app: seichi-timed-stats-conifers-ingestor
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: migration
+          image: ghcr.io/giganticminecraft/seichi-timed-stats-conifers-database-migration:sha-35af1fb@sha256:05139d5006e8301855007416cbdc1849d25d4366d4aae8d34ea7e70d272c35d2
+          env:
+            - name: DB_HOST_AND_PORT
+              value: "mariadb:3306"
+            - name: DB_USER
+              value: "seichi-timed-stats-conifers"
+            - name: DB_DATABASE_NAME
+              value: "seichi-timed-stats-conifers"
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: seichi-timed-stats-conifers-db-credentials
+                  key: password

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/prometheusrule.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-timed-stats-conifers/prometheusrule.yaml
@@ -67,3 +67,25 @@ spec:
           annotations:
             summary: "timed-stats-conifers の ingest が停止しています"
             description: "最後に成功した ingest から {{ $value | humanizeDuration }} 経過しています (平常は 5 分周期)。Job の状態は kubectl get jobs -n seichi-minecraft、ログは Loki の {job=\"seichi-minecraft/ingestor\"} で確認する。"
+
+        - alert: ConifersMigrationJobFailed
+          # ArgoCD PreSync hook の migration Job (migration-job.yaml,
+          # infra#5693) の失敗検知。hook 失敗 = sync 中断であり、ingest は
+          # 旧イメージで継続しているが、新リリースの配備が止まっている。
+          # 失敗した hook Job は次の sync まで残るため、直近 1 時間の開始に
+          # 限定して残骸での発火を防ぐ (ConifersIngestorJobFailed と同じ方式)
+          expr: |
+            count by (namespace) (
+              kube_job_failed{namespace="seichi-minecraft", job_name="seichi-timed-stats-conifers-migration", condition="true"} == 1
+              and on (job_name)
+              (
+                time() - kube_job_status_start_time{namespace="seichi-minecraft", job_name="seichi-timed-stats-conifers-migration"} < 3600
+              )
+            ) > 0
+          for: 1m
+          labels:
+            severity: warning
+            notify: discord
+          annotations:
+            summary: "timed-stats-conifers の migration Job が失敗しました"
+            description: "ArgoCD PreSync の migration Job が失敗し、sync が中断されています (ingest は旧イメージで継続中)。ログは kubectl logs job/seichi-timed-stats-conifers-migration -n seichi-minecraft、sync 状態は ArgoCD の seichi-minecraft-seichi-timed-stats-conifers を確認する。"


### PR DESCRIPTION
infra#5693(2026-08-02 インシデントの恒久対策 #4。ポストモーテム: #5691)の実装。反映確認後に issue をクローズする(自動クローズはしない)。

## 設計

**方式: ArgoCD PreSync hook Job**

| 要件(issue の完了条件) | 実現方法 |
|---|---|
| migration 完了 → 新 ingestor 配備の順序保証 | PreSync hook は本体 sync より前に完走が要求される(ArgoCD の仕様) |
| migration 失敗時に旧 ingest が継続 | **hook 失敗 = sync 全体が中断され本体リソースは未適用のまま**(公式ドキュメント明記)→ CronJob は旧イメージのまま 5 分ごとの ingest を継続 |
| 旧版互換 | sync 中は旧 ingestor が動くため、「マイグレーションは直前バージョンの ingestor と互換(expand-contract、破壊的変更は 2 リリース分割)」を運用ルールとして manifest コメントに明記 |

## 変更内容

1. **`migration-job.yaml` 新設**(PreSync hook、`hook-delete-policy: BeforeHookCreation` = 失敗した Job は次の sync まで残りログ調査可能)。migration イメージ参照はここへ移動(単一参照を維持、Renovate/bump 手順は従来通り)
2. **CronJob から initContainer を削除** — 5 分ごとの実行は ingestor 単体になり、migration は sync 時のみ実行される
3. **`ConifersMigrationJobFailed` アラート追加** — hook 失敗 = リリース中断の検知(直近 1 時間の開始に限定する既存方式)。kured の alertFilterRegexp にも登録

## ファクトチェック(実装前に確認済み)

- PreSync の失敗時挙動: 公式ドキュメントに「If any of them fails the whole sync process will stop and will be marked as failed」と明記
- hook は automated sync でも実行される(除外は selective sync のみ)
- ネットワーク: hook Pod に ingestor と同一の `app` ラベルを付与。現行 initContainer が同ラベルの Pod で mariadb に到達できている実績があるため、CNP 条件は同一になる
- 検証: 3 manifest の server-side dry-run パス、アラート式の構文を実データで確認

## 反映確認(マージ後)

1. 最初の sync で PreSync hook が実行され(no-op、数秒)、その後 CronJob から initContainer が消える
2. 以降の 5 分ごとの Job は ingestor 単体(migration なし)で成功する
3. hook は次の app 変更まで再実行されない

確認後、infra#5693 をクローズする。

## トレードオフ(既知)

- この app の manifest 変更(ingestor bump、アラート変更等)のたびに hook が実行されるが、適用済み DB への実行は no-op(~1 秒、検証済み)であり実害なし
- selfHeal による drift 修正 sync でも hook が実行される(同上)

🤖 Generated with [Claude Code](https://claude.com/claude-code)