### PR TITLE
fix(loki-alert-rules): SeichiPortalBackendErrorLogs から pyroscope-rs のノイズを除外する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/loki-alert-rules/seichi-portal-backend.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/loki-alert-rules/seichi-portal-backend.yaml
@@ -41,10 +41,21 @@ data:
           # level=ERROR の頻発を通知する (panic とは別ルールに分ける)。
           # 閾値 10 件/10 分は暫定値。backend 0.2.1 デプロイ後の実データで見直し、
           # ノイズになる既知エラーが出たら行フィルタや json フィールド条件で除外を積む
+          #
+          # 除外: pyroscope-rs (log_module_path =~ "pyroscope::.*")
+          #   backend に組み込まれたプロファイリング用ライブラリであり、アプリの
+          #   コードではない。pyroscope サーバの segment-writer が block を
+          #   Garage (S3) へアップロードする際に稀に約 2 秒のデッドラインを超過し、
+          #   push が 500 "service is unavailable" を返す。クライアントはこれを
+          #   ERROR として記録するが、Garage は健全で PUT は継続的に成功しており、
+          #   アプリの動作にも利用者にも影響はない。2026-08-04 にこの経路のみで
+          #   本アラートが発火したため除外する。
+          #   注意: json parser はキー名の "." を "_" に変換するため、ログ上の
+          #   "log.module_path" は LogQL では log_module_path として参照する。
           - alert: SeichiPortalBackendErrorLogs
             expr: |
               sum by (service_name) (
-                count_over_time({job="seichi-minecraft/seichi-portal-backend"} | json | level="ERROR" | panic!="true" [10m])
+                count_over_time({job="seichi-minecraft/seichi-portal-backend"} | json | level="ERROR" | panic!="true" | log_module_path !~ `pyroscope::.*` [10m])
               ) > 10
             labels:
               severity: warning


### PR DESCRIPTION
## 背景

2026-08-04 に `SeichiPortalBackendErrorLogs` が発火しましたが、閾値を超えた ERROR ログは**すべて backend に組み込まれた pyroscope-rs プロファイリングクライアント由来**で、アプリのコードが出したものではありませんでした。

```json
{"level":"ERROR","log.module_path":"pyroscope::session",
 "message":"Sending Session failed 500 {\"code\":\"unknown\",\"message\":\"rpc error: code = Unavailable desc = service is unavailable\"}"}
```

直近 2 時間で pyroscope 以外の WARN/ERROR はゼロ、Pod は Ready・再起動 0 回、ArgoCD も Synced/Healthy でした。

## 原因

1. backend の pyroscope-rs が 10 秒ごとに `pyroscope.monitoring:4040` へ push
2. pyroscope の segment-writer が block を Garage (S3) へアップロード
3. その PUT が稀に約 2 秒のデッドラインを超過し `context deadline exceeded`
4. push が 500 `service is unavailable` を返し、クライアントが ERROR を記録

Garage 自体は 3 ノードとも HEALTHY・空き 84%・CPU 13〜20m で、PUT は継続的に成功しています。間欠的なレイテンシスパイクであり、障害ではありません。アプリの動作にも利用者にも影響はありません。

## 変更内容

ルール既存のコメントにある方針

> ノイズになる既知エラーが出たら行フィルタや json フィールド条件で除外を積む

に従い、`log_module_path` が `pyroscope::*` のログを除外します。session 以外のモジュールも将来同様のノイズを出しうるため、クレート全体を対象にしています。

なお Loki の json parser はキー名の `.` を `_` に変換するため、ログ上の `log.module_path` は LogQL では `log_module_path` として参照します（実データで確認済み）。

## 検証

| 式 | 期間 | 結果 |
|---|---|---|
| 除外後 | 2026-08-03T00:00Z 〜 2026-08-04T13:20Z | **0 件** |
| 除外前 | 同期間（10 分窓） | 最大 **16 件**（閾値 10 超過） |

同期間にアプリ由来の ERROR は存在しないため、本変更で失われる検知はありません。`SeichiPortalBackendPanic` ルールは変更していません。

## 残課題（本 PR の対象外）

- **ログスパム**: backend のログ量が 8/2 15:00 UTC の Pod 起動を境に約 450 倍（1〜11 行/時 → 約 720 行/時）になっています。pyroscope が 10 秒ごとに出す `Creating Session` / `Sending Session` の INFO が中身なく積み上がっており、Loki のストレージを圧迫します。backend リポジトリ側で当該クレートのログレベルを下げるのが妥当です。
- **iSCSI レイテンシ**: 2 秒超えの PUT が発生する根本原因。緊急性は低いです。
- pyroscope の compaction worker が、アップロードに失敗した block を探して `Key not found` で失敗しています。metastore が `compacted blocks are missing; skipping` でスキップするため自己解決しますが、ログノイズになっています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
