### PR TITLE
fix(loki-alert-rules): GachadataServerErrorLogs から pyroscope-rs のノイズを除外する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/loki-alert-rules/gachadata-server.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/loki-alert-rules/gachadata-server.yaml
@@ -33,10 +33,22 @@ data:
               description: 直近 5 分間に panic ログが記録されました。詳細は Loki で {job="seichi-minecraft/gachadata-server"} | json | panic="true" を実行して確認する。
           # level=ERROR の頻発を通知する。低トラフィックサービスのため閾値は低め。
           # dump 失敗・DB 接続失敗は error_handler が ERROR ログを出すためここで拾える
+          #
+          # 除外: pyroscope-rs (log_module_path =~ "pyroscope::.*")
+          #   backend に組み込まれたプロファイリング用ライブラリであり、アプリの
+          #   コードではない。pyroscope サーバの segment-writer が block を
+          #   Garage (S3) へアップロードする際に稀に約 2 秒のデッドラインを超過し、
+          #   push が 500 "service is unavailable" を返す。クライアントはこれを
+          #   ERROR として記録するが、Garage は健全で PUT は継続的に成功しており、
+          #   アプリの動作にも利用者にも影響はない。seichi-portal-backend でも同時期
+          #   に同じ経路で発火し除外済み ( SeichiPortalBackendErrorLogs, 2026-08-04)。
+          #   2026-08-05 にこの経路のみで本アラートが発火したため除外する。
+          #   注意: json parser はキー名の "." を "_" に変換するため、ログ上の
+          #   "log.module_path" は LogQL では log_module_path として参照する。
           - alert: GachadataServerErrorLogs
             expr: |
               sum by (service_name) (
-                count_over_time({job="seichi-minecraft/gachadata-server"} | json | level="ERROR" | panic!="true" [10m])
+                count_over_time({job="seichi-minecraft/gachadata-server"} | json | level="ERROR" | panic!="true" | log_module_path !~ `pyroscope::.*` [10m])
               ) > 3
             labels:
               severity: warning


### PR DESCRIPTION
## Summary
- `GachadataServerErrorLogs` が発火したが、対象の ERROR ログはすべて backend に組み込まれた pyroscope-rs プロファイリングクライアントが出したもので、アプリのコード由来ではなかった
- 原因は Pyroscope サーバの segment-writer が block を Garage (S3) へアップロードする際、稀に約2秒のデッドラインを超過し push が 500 "service is unavailable" を返すこと。Garage 自体は3ノードとも HEALTHY で PUT は継続的に成功しており、アプリの動作にも利用者にも影響はない
- 同時間帯に seichi-portal-backend でも同数の同種ログが出ており、2026-08-04 に対処済みの `SeichiPortalBackendErrorLogs` (#5717) と同一原因と確認した
- `SeichiPortalBackendErrorLogs` と同じパターンで `log_module_path !~ "pyroscope::.*"` を除外条件に追加

## Test plan
- [x] Loki 上で除外前の式を実行し、直近30分で4件ヒット(全て `pyroscope::session` 由来、閾値3件を超過してアラート発火)することを確認
- [x] panic ログ (`panic="true"`) が直近6時間でゼロ件であることを確認 — アプリ由来の異常ではない
- [x] 除外後の式を直近24時間に対して実行し、ゼロ件であることを確認 — 本変更で失われる検知はない
- [x] gachadata-server Pod が Running / Restarts 0 / Ready であることを確認 — アプリ自体は健全

🤖 Generated with [Claude Code](https://claude.com/claude-code)