### PR TITLE
feat(argocd): add operational guardrails

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -33,6 +33,20 @@
       ],
     },
     {
+      // chart の patch 更新でも Argo CD 本体の minor 更新を含みうるため、
+      // 汎用の Terraform グループから分離して appVersion の確認を促す。
+      matchManagers: [
+        'terraform',
+      ],
+      matchPackageNames: [
+        'argo-cd',
+      ],
+      groupName: 'Argo CD',
+      prBodyNotes: [
+        ':warning: Helm chart のバージョンだけでなく、Chart.yaml の appVersion と Argo CD の upgrade notes を確認してください。',
+      ],
+    },
+    {
       matchManagers: [
         'dockerfile',
         'kubernetes',
@@ -143,6 +157,18 @@
     ],
   },
   customManagers: [
+    {
+      // Helm values が YAML block scalar 内にあるため、組み込みの kubernetes manager
+      // では検出できない kubechecks の tag と digest を追従する。
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/apps[.]yaml$/',
+      ],
+      matchStrings: [
+        '# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\n\\s+tag: "(?<currentValue>[^@"]+)@(?<currentDigest>sha256:[a-f0-9]+)"',
+      ],
+      versioningTemplate: 'semver-coerced',
+    },
     {
       customType: 'regex',
       managerFilePatterns: [

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
@@ -44,10 +44,10 @@ spec:
           # wk-2 の再起動を 3 周期 (約 40 分) ブロックした実績)。アラート式側に > 0 ガードを入れて
           # 根治したが、本物の停滞時も再起動の保留ではアップロードは復旧しないため除外は維持する
           # SeichiPortalHighErrorRate / SeichiPortalBackendCrashLoop /
-          # GachadataServerCrashLoop / ConifersIngestorJobFailed:
+          # GachadataServerCrashLoop / ConifersIngestorJobFailed / ArgoCDApp*:
           # アプリケーションアラート (#5611, #5618, Sentry 撤去後の通知カバレッジ)。
           # アプリのエラーはノード再起動で直らないため、ノード保守をブロックさせない
-          alertFilterRegexp: "^(Watchdog|InfoInhibitor|TargetDown|KubeJobFailed|CPUThrottlingHigh|PrometheusNotConnectedToAlertmanagers|KubePodCrashLooping|KubePodNotReady|KubeDeploymentReplicasMismatch|KubeStatefulSetReplicasMismatch|KubeletTooManyPods|ThanosSidecarUploadStale|SeichiPortalHighErrorRate|SeichiPortalBackendCrashLoop|GachadataServerCrashLoop|ConifersIngestorJobFailed|ConifersIngestorStalled|ConifersMigrationJobFailed)$"
+          alertFilterRegexp: "^(Watchdog|InfoInhibitor|TargetDown|KubeJobFailed|CPUThrottlingHigh|PrometheusNotConnectedToAlertmanagers|KubePodCrashLooping|KubePodNotReady|KubeDeploymentReplicasMismatch|KubeStatefulSetReplicasMismatch|KubeletTooManyPods|ThanosSidecarUploadStale|SeichiPortalHighErrorRate|SeichiPortalBackendCrashLoop|GachadataServerCrashLoop|ConifersIngestorJobFailed|ConifersIngestorStalled|ConifersMigrationJobFailed|ArgoCDAppDegraded|ArgoCDAppSyncFailed|ArgoCDAppOutOfSyncTooLong)$"
           # kubelet のパッチ更新も kured の drain + 再起動に相乗りさせる。
           # pkgs.k8s.io はマイナーごとの repo (core:/stable:/v1.3x) なので、apt で入るのは
           # 同一マイナー内のパッチのみ。マイナーアップグレードは従来どおり kubeadm で手動実施し、

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/argocd-alerts/prometheusrule.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/argocd-alerts/prometheusrule.yaml
@@ -1,0 +1,43 @@
+# Argo CD の異常だけを既存の Alertmanager -> Discord 経路へ通知する。
+# seichi-minecraft の OutOfSync は sync window 中の想定状態なので即時通知せず、
+# 次の allow window を越えて残る 25 時間継続だけを検知する。
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: argocd-alerts
+  namespace: argocd
+  labels:
+    release: prometheus
+spec:
+  groups:
+    - name: argocd-alerts
+      rules:
+        - alert: ArgoCDAppDegraded
+          expr: argocd_app_info{health_status="Degraded"} == 1
+          for: 10m
+          labels:
+            severity: warning
+            notify: discord
+          annotations:
+            summary: "Argo CD Application {{ $labels.name }} が Degraded です"
+            description: "Application {{ $labels.namespace }}/{{ $labels.name }} (project={{ $labels.project }}) が10分以上 Degradedです。"
+
+        - alert: ArgoCDAppSyncFailed
+          expr: increase(argocd_app_sync_total{phase=~"Error|Failed"}[15m]) > 0
+          for: 1m
+          labels:
+            severity: warning
+            notify: discord
+          annotations:
+            summary: "Argo CD Application {{ $labels.name }} の同期に失敗しました"
+            description: "Application {{ $labels.namespace }}/{{ $labels.name }} (project={{ $labels.project }}) で直近15分に {{ $labels.phase }} の同期が発生しました。"
+
+        - alert: ArgoCDAppOutOfSyncTooLong
+          expr: argocd_app_info{sync_status="OutOfSync"} == 1
+          for: 25h
+          labels:
+            severity: warning
+            notify: discord
+          annotations:
+            summary: "Argo CD Application {{ $labels.name }} の OutOfSync が次の同期窓を越えています"
+            description: "Application {{ $labels.namespace }}/{{ $labels.name }} (project={{ $labels.project }}) が25時間以上 OutOfSyncです。日次の allow window で解消されなかった差分を確認してください。"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/apps.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/apps.yaml
@@ -192,12 +192,52 @@ spec:
           allowEmpty: true
         syncOptions:
           - ServerSideApply=true
+          - RespectIgnoreDifferences=true
         retry:
           limit: -1
           backoff:
             duration: 5s
             factor: 2
             maxDuration: 2m
+      # backup/start-stop Workflow と KEDA が replicas を制御する StatefulSet に限定する。
+      # Argo CD はその他の StatefulSet の replicas drift を引き続き検知する。
+      ignoreDifferences:
+        - group: apps
+          kind: StatefulSet
+          name: mcserver--s1
+          jsonPointers: [/spec/replicas]
+        - group: apps
+          kind: StatefulSet
+          name: mcserver--s2
+          jsonPointers: [/spec/replicas]
+        - group: apps
+          kind: StatefulSet
+          name: mcserver--s3
+          jsonPointers: [/spec/replicas]
+        - group: apps
+          kind: StatefulSet
+          name: mcserver--s5
+          jsonPointers: [/spec/replicas]
+        - group: apps
+          kind: StatefulSet
+          name: mcserver--s7
+          jsonPointers: [/spec/replicas]
+        - group: apps
+          kind: StatefulSet
+          name: mcserver--lobby
+          jsonPointers: [/spec/replicas]
+        - group: apps
+          kind: StatefulSet
+          name: mcserver--votelistener
+          jsonPointers: [/spec/replicas]
+        - group: apps
+          kind: StatefulSet
+          name: mcserver--kagawa
+          jsonPointers: [/spec/replicas]
+        - group: apps
+          kind: StatefulSet
+          name: mcserver--one-day-to-reset
+          jsonPointers: [/spec/replicas]
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -229,6 +269,11 @@ spec:
           create: false
 
         deployment:
+          image:
+            pullPolicy: IfNotPresent
+            name: ghcr.io/zapier/kubechecks
+            # renovate: datasource=docker depName=ghcr.io/zapier/kubechecks
+            tag: "v3.2.1@sha256:505bd90a29fd472741bbbe7ae2c58a7bf31f3cb405ca8ae2a0a8442bbd4a342b"
           envFrom:
             - secretRef:
                 name: kubechecks-github-app-secret
@@ -335,9 +380,20 @@ spec:
           allowEmpty: true
         syncOptions:
           - ServerSideApply=true
+          - RespectIgnoreDifferences=true
         retry:
           limit: -1
           backoff:
             duration: 5s
             factor: 2
             maxDuration: 2m
+      # seichiassist-downloader Workflow が replicas を制御する対象だけを除外する。
+      ignoreDifferences:
+        - group: apps
+          kind: StatefulSet
+          name: mcserver--debug-s1
+          jsonPointers: [/spec/replicas]
+        - group: apps
+          kind: StatefulSet
+          name: mcserver--debug-s2
+          jsonPointers: [/spec/replicas]

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/argocd-helm-chart-values.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/argocd-helm-chart-values.yaml
@@ -176,6 +176,8 @@ applicationSet:
         release: prometheus
 
 notifications:
+  # 通知テンプレート内の Application リンクに実際の外部 URL を使う。
+  argocdUrl: https://argocd.onp-k8s.admin.seichi.click
   resources:
     requests:
       cpu: 15m


### PR DESCRIPTION
## Summary

- ignore `/spec/replicas` only for Minecraft StatefulSets controlled by Argo Workflows or KEDA, and make sync respect those exclusions
- pin kubechecks v3.2.1 by digest and add Renovate tracking
- add Argo CD health/sync/long-lived OutOfSync alerts through the existing Alertmanager → Discord route
- fix the notifications dashboard URL and isolate Argo CD chart upgrades from the generic Terraform Renovate group

## Why

The Argo CD v3.5 review found intentional replica ownership outside Argo CD, a floating kubechecks image, no Argo CD-specific alert rules, a placeholder notifications URL, and chart patch updates capable of carrying Argo CD minor upgrades.

The current 12 OutOfSync Applications were checked with `argocd --core app diff`; all currently differ on image digests and are expected to reconcile in the daily allow window. The new 25-hour alert only catches drift that survives the next window.

## Deliberately not included

- `syncOverrun`: recorded syncs top out at 611 seconds overall and 150 seconds for Minecraft, so there is no evidence that the one-hour allow window is too short
- removal of old `kubectl.kubernetes.io/restartedAt`: all affected StatefulSets use RollingUpdate, so deleting the pod-template annotation would restart servers
- webhook secret: it requires coordinated configuration of the same value at the GitHub webhook and cannot be completed safely as a repository-only change

## Validation

- Kubernetes server-side dry-run passed for the ApplicationSets and PrometheusRule
- Helm rendering produced the pinned kubechecks image and the correct Argo CD URL
- Prometheus accepted all three alert expressions
- Renovate config validator passed
- Renovate extraction detected the kubechecks tag/digest and the Terraform `argo-cd` package
- YAML parsing and `git diff --check` passed