### PR TITLE
fix(kubechecks): keep image tag label-safe

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -159,13 +159,13 @@
   customManagers: [
     {
       // Helm values が YAML block scalar 内にあるため、組み込みの kubernetes manager
-      // では検出できない kubechecks の tag と digest を追従する。
+      // では検出できない kubechecks の tag を追従する。
       customType: 'regex',
       managerFilePatterns: [
         '/^seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/apps[.]yaml$/',
       ],
       matchStrings: [
-        '# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\n\\s+tag: "(?<currentValue>[^@"]+)@(?<currentDigest>sha256:[a-f0-9]+)"',
+        '# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)[\\s\\S]*?tag: "(?<currentValue>[^"]+)"',
       ],
       versioningTemplate: 'semver-coerced',
     },

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/apps.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/apps.yaml
@@ -273,7 +273,9 @@ spec:
             pullPolicy: IfNotPresent
             name: ghcr.io/zapier/kubechecks
             # renovate: datasource=docker depName=ghcr.io/zapier/kubechecks
-            tag: "v3.2.1@sha256:505bd90a29fd472741bbbe7ae2c58a7bf31f3cb405ca8ae2a0a8442bbd4a342b"
+            # kubechecks chart 3.0.0 は tag を app.kubernetes.io/version にも使うため、
+            # digest を連結すると Kubernetes の label 制約を満たさない。
+            tag: "v3.2.1"
           envFrom:
             - secretRef:
                 name: kubechecks-github-app-secret


### PR DESCRIPTION
## Summary

- keep the kubechecks image on the stable `v3.2.1` tag without appending the digest
- update the custom Renovate manager to track the tag without expecting a digest

## Root cause

kubechecks chart 3.0.0 uses `deployment.image.tag` both to build the container image reference and as the `app.kubernetes.io/version` label on its resources. Appending `@sha256:...` pinned the image, but generated an invalid Kubernetes label because the value contained `@`, `:`, and exceeded 63 characters.

The chart has no separate `image.digest` value and always renders the image as `name:tag`, so digest pinning cannot be expressed safely through the current chart values.

## Impact

This restores Argo CD synchronization for the kubechecks ServiceAccount, ConfigMap, Service, and Deployment. Renovate continues to track stable kubechecks releases by tag.

## Validation

- rendered chart labels are `v3.2.1`
- rendered image is `ghcr.io/zapier/kubechecks:v3.2.1`
- Kubernetes server-side dry-run passed for all rendered chart resources
- Renovate config validation passed
- Renovate extract dry-run detected `ghcr.io/zapier/kubechecks` at `v3.2.1`
- `git diff --check` passed
