### PR TITLE
fix: mcserver-backupでreplicas復旧後にArgo CD Syncを実行

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/workflow-template.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/workflow-template.yaml
@@ -72,8 +72,8 @@ spec:
             dependencies:
               - wait-for-scale-to-0
 
-          - name: argocd-sync
-            template: argocd-sync
+          - name: patch-statefulset-to-1
+            template: patch-statefulset-to-1
             arguments:
               parameters:
                 - name: statefulset-name
@@ -81,6 +81,24 @@ spec:
             dependencies:
               - run-backup
               - delete-coreprotect-db
+
+          - name: wait-for-scale-to-1
+            template: wait-for-scale-to-1
+            arguments:
+              parameters:
+                - name: statefulset-name
+                  value: "{{inputs.parameters.statefulset-name}}"
+            dependencies:
+              - patch-statefulset-to-1
+
+          - name: argocd-sync
+            template: argocd-sync
+            arguments:
+              parameters:
+                - name: statefulset-name
+                  value: "{{inputs.parameters.statefulset-name}}"
+            dependencies:
+              - wait-for-scale-to-1
 
     - name: check-maintenance-mode
       script:
@@ -130,6 +148,35 @@ spec:
             sleep 5
           done
           echo "Scale-down confirmed!"
+
+    - name: patch-statefulset-to-1
+      inputs:
+        parameters:
+          - name: statefulset-name
+      script:
+        image: alpine/kubectl:1.36.3
+        command: ["/bin/sh", "-c"]
+        source: |
+          kubectl patch statefulset {{inputs.parameters.statefulset-name}} -n seichi-minecraft --type='merge' -p '{"spec": {"replicas": 1}}'
+
+    - name: wait-for-scale-to-1
+      inputs:
+        parameters:
+          - name: statefulset-name
+      script:
+        image: alpine/kubectl:1.36.3
+        command: ["/bin/sh", "-c"]
+        source: |
+          echo "Waiting for statefulset to scale up..."
+          while true; do
+            replicas=$(kubectl get statefulset {{inputs.parameters.statefulset-name}} -n seichi-minecraft -o jsonpath='{.status.availableReplicas}')
+            if [ "${replicas:-0}" -eq 1 ]; then
+              break
+            fi
+            echo "Still scaling up..."
+            sleep 5
+          done
+          echo "Scale-up confirmed!"
 
     - name: run-backup
       inputs:
@@ -276,4 +323,3 @@ spec:
           argocd app sync "seichi-minecraft-{{inputs.parameters.statefulset-name}}" \
             --insecure \
             --timeout 300
-


### PR DESCRIPTION
## Summary

- バックアップ完了後にStatefulSetの`replicas`を明示的に`1`へ戻す
- `availableReplicas=1`になるまで待機する
- その後、既存の`argocd app sync`を実行する

## Background

PR #4620 では、`kubectl patch`によるreplicas復旧でArgo CDにドリフトが検出され、Sync Window中に不要な再起動が発生する問題を避けるため、復旧処理を`argocd app sync`へ変更した。

その後、PR #5742 でMinecraft StatefulSetの`/spec/replicas`が`ignoreDifferences`対象となり、`RespectIgnoreDifferences=true`も設定されたため、現在の`argocd app sync`ではreplicasが復旧しない状態になっている。

本変更では、replicasの復旧とArgo CD Syncを分離することで、以下を両立する。

- バックアップ後にサーバーを確実に起動する
- PR #4620 の意図どおり、Syncによって他のドリフトを解消する
- PR #5742 のreplicas管理方針を維持する

## Test plan

- [x] Workflow YAMLの構文検証
- [ ] バックアップWorkflowを手動実行
- [ ] `patch-statefulset-to-1`が成功することを確認
- [ ] `wait-for-scale-to-1`完了後に`argocd-sync`が実行されることを確認
- [ ] 翌日のSync Windowで不要な再起動が発生しないことを確認
