### PR TITLE
fix: PrometheusExporterのポート設定を修正

### DIFF
--- a/docker-images/mcservers/production/seichi-servers/common-image/additional-plugin-configs/PrometheusExporter/config.yml
+++ b/docker-images/mcservers/production/seichi-servers/common-image/additional-plugin-configs/PrometheusExporter/config.yml
@@ -1,5 +1,5 @@
 host: 0.0.0.0
-port: "${CFG_REPLACEMENT__PROMETHEUS_EXPORTER_PORT}"
+port: ${CFG_REPLACEMENT__PROMETHEUS_EXPORTER_PORT}
 enable_metrics:
   entities_total: true
   villagers_total: true


### PR DESCRIPTION
## 概要
本番MinecraftサーバーのPrometheusExporterが起動に失敗する問題を修正します。

## 原因
共通設定のポート値が引用符付き文字列として読み込まれ、Exporter v2.5.0で `String cannot be cast to Integer` が発生していました。

## 変更内容
- `port` の環境変数展開値をYAMLの数値として解釈されるよう修正

## 確認
- `jj diff -r main..fix/prometheus-exporter-port` で意図した1ファイルのみの差分を確認済み
- デプロイ後、各サーバーの `mc-metrics:9225` と `up{endpoint="mc-metrics"}` の復旧を確認する