### PR TITLE
chore: update Minecraft StatefulSet image digests

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
@@ -293,7 +293,7 @@ spec:
                 /downloaded-plugins
                 /plugins
 
-          image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_s1:1.0.0@sha256:97f956cf539ba692cbfa660f9f3d0a86f8e30a65a8a3eabd99330845ec38b016
+           image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_s1:1.0.0@sha256:d9ab031d260593f1ebd4ee424a4c5455cf69bf0457e89d3c30f23ad7cc31de34
           name: minecraft
           ports:
             - containerPort: 25565

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/stateful-set.yaml
@@ -293,7 +293,7 @@ spec:
                 /downloaded-plugins
                 /plugins
 
-          image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_s2:1.0.0@sha256:961c121f2a98cd3205d0cb191182e69dbb6801792543023db7efebd934db1d22
+           image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_s2:1.0.0@sha256:9ecaafc1c4b68918f40da46d90c55882b75d2df510cdda83bdcec0fcfa21e3ce
           name: minecraft
           ports:
             - containerPort: 25565

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/stateful-set.yaml
@@ -293,7 +293,7 @@ spec:
                 /downloaded-plugins
                 /plugins
 
-          image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_s3:1.0.0@sha256:d8b9e63ce4295c8bd21c43fc4222be1c8306402bf6da50d6e895240de0216d35
+           image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_s3:1.0.0@sha256:a311bf9780d98a43bf29e186104d4c8e087ff1ea89cc129f7ed772c66abfcf4b
           name: minecraft
           ports:
             - containerPort: 25565

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
@@ -278,7 +278,7 @@ spec:
                 /downloaded-plugins
                 /plugins
 
-          image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_s5:1.0.0@sha256:017fd9ba5ec7a982462e18dcfdb7748e1a002282654db18b6fe97484a2786dd9
+           image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_s5:1.0.0@sha256:cd6166c2083335742630dfc717ed91ab02f8dd4d82a012b5493a8231685dd9a6
           name: minecraft
           ports:
             - containerPort: 25565

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/stateful-set.yaml
@@ -269,7 +269,7 @@ spec:
             - name: REMOVE_OLD_MODS
               value: "TRUE"
 
-          image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_s7:1.0.0@sha256:6c39c51cef2d1169713b398bdfe6cf53556cd2e450e887ad49e0c3132879e858
+           image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_s7:1.0.0@sha256:fd94fc521ff4bf7c3f42b5682644e15ad8ca05682285a5d391f8ea3af217ca0a
           name: minecraft
           ports:
             - containerPort: 25565

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--votelistener/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--votelistener/stateful-set.yaml
@@ -220,7 +220,7 @@ spec:
             - name: OTEL_SERVICE_NAME
               value: "mcserver-votelistener"
 
-          image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_votelistener:1.0.0@sha256:514a362ae9d8ff45ff03e86cbc55870e67f7b320e02e6def022f0deacb206f4d
+           image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_votelistener:1.0.0@sha256:bcd888b63306a15160292b73018bbb73637ec738833d803465ac26b3c82e76a5
           name: minecraft
           ports:
             - containerPort: 25565


### PR DESCRIPTION
## 概要
再ビルド済みのMinecraftサーバーイメージをStatefulSetへ反映します。

## 変更内容
- s1、s2、s3、s5、s7、votelistenerのイメージdigestを更新
- CI run: https://github.com/GiganticMinecraft/seichi_infra/actions/runs/31260740923

Lobby、Kagawa、One Day To Resetは今回再ビルド対象ではないため変更していません。