### PR TITLE
fix: correct Minecraft StatefulSet image indentation

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/stateful-set.yaml
@@ -293,7 +293,7 @@ spec:
                 /downloaded-plugins
                 /plugins
 
-           image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_s1:1.0.0@sha256:d9ab031d260593f1ebd4ee424a4c5455cf69bf0457e89d3c30f23ad7cc31de34
+          image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_s1:1.0.0@sha256:d9ab031d260593f1ebd4ee424a4c5455cf69bf0457e89d3c30f23ad7cc31de34
           name: minecraft
           ports:
             - containerPort: 25565

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/stateful-set.yaml
@@ -293,7 +293,7 @@ spec:
                 /downloaded-plugins
                 /plugins
 
-           image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_s2:1.0.0@sha256:9ecaafc1c4b68918f40da46d90c55882b75d2df510cdda83bdcec0fcfa21e3ce
+          image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_s2:1.0.0@sha256:9ecaafc1c4b68918f40da46d90c55882b75d2df510cdda83bdcec0fcfa21e3ce
           name: minecraft
           ports:
             - containerPort: 25565

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/stateful-set.yaml
@@ -293,7 +293,7 @@ spec:
                 /downloaded-plugins
                 /plugins
 
-           image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_s3:1.0.0@sha256:a311bf9780d98a43bf29e186104d4c8e087ff1ea89cc129f7ed772c66abfcf4b
+          image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_s3:1.0.0@sha256:a311bf9780d98a43bf29e186104d4c8e087ff1ea89cc129f7ed772c66abfcf4b
           name: minecraft
           ports:
             - containerPort: 25565

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
@@ -278,7 +278,7 @@ spec:
                 /downloaded-plugins
                 /plugins
 
-           image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_s5:1.0.0@sha256:cd6166c2083335742630dfc717ed91ab02f8dd4d82a012b5493a8231685dd9a6
+          image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_s5:1.0.0@sha256:cd6166c2083335742630dfc717ed91ab02f8dd4d82a012b5493a8231685dd9a6
           name: minecraft
           ports:
             - containerPort: 25565

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/stateful-set.yaml
@@ -269,7 +269,7 @@ spec:
             - name: REMOVE_OLD_MODS
               value: "TRUE"
 
-           image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_s7:1.0.0@sha256:fd94fc521ff4bf7c3f42b5682644e15ad8ca05682285a5d391f8ea3af217ca0a
+          image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_s7:1.0.0@sha256:fd94fc521ff4bf7c3f42b5682644e15ad8ca05682285a5d391f8ea3af217ca0a
           name: minecraft
           ports:
             - containerPort: 25565

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--votelistener/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--votelistener/stateful-set.yaml
@@ -220,7 +220,7 @@ spec:
             - name: OTEL_SERVICE_NAME
               value: "mcserver-votelistener"
 
-           image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_votelistener:1.0.0@sha256:bcd888b63306a15160292b73018bbb73637ec738833d803465ac26b3c82e76a5
+          image: ghcr.io/giganticminecraft/seichi_minecraft_server_production_votelistener:1.0.0@sha256:bcd888b63306a15160292b73018bbb73637ec738833d803465ac26b3c82e76a5
           name: minecraft
           ports:
             - containerPort: 25565


### PR DESCRIPTION
## 概要
PR #5764 で反映した6つのStatefulSetについて、`image`フィールドのインデントを修正します。

## 原因
`image`行にスペースが1つ多く、YAMLとして不正になっていました。Argo CDのkustomize buildで `MalformedYAMLError` が発生していました。

## 変更対象
- s1
- s2
- s3
- s5
- s7
- votelistener