### PR TITLE
chore(seichi-portal): レートリミット対応イメージと環境変数を更新

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: seichi-portal-backend
-          image: ghcr.io/giganticminecraft/seichi-portal-backend:0.2.3@sha256:168afa73c5dc86205c1801e5a5205805960620bcfde388f2e87142cc9c754df3
+          image: ghcr.io/giganticminecraft/seichi-portal-backend:0.2.4@sha256:e62e66626d5186f4eab36853e6d6d0b5442b9b3ae625c27a77638e886076144d
           resources:
             # OTel exporter のオーバーヘッド吸収のため limit を 100m から 300m へ増強
             # (seichi-game-data-publisher が exporter 導入時に 50m→300m へ増強した実績に倣う)
@@ -56,6 +56,11 @@ spec:
               value: seichi-portal-valkey
             - name: REDIS_PORT
               value: "6379"
+            - name: SEICHI_PROXY_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: seichi-portal-backend-secrets
+                  key: SEICHI_PROXY_SECRET
             - name: MEILISEARCH_HOST
               value: http://seichi-portal-meilisearch:7700
             - name: MEILISEARCH_API_KEY

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-frontend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-frontend/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: seichi-portal-frontend
-          image: ghcr.io/giganticminecraft/seichi-portal-frontend:0.3.2@sha256:9d65f9089513367d260b7c3671d101947ad16a95cc115ddbb73748839f7feb5f
+          image: ghcr.io/giganticminecraft/seichi-portal-frontend:0.3.3@sha256:4b10f8e1e0932d64e6d7ea40369d593754e59cf8bd8d608f609e02da1e09ae47
           ports:
             - name: http
               containerPort: 3000
@@ -41,6 +41,13 @@ spec:
               value: https://portal.seichi.click
             - name: BACKEND_SERVER_URL
               value: http://seichi-portal-backend:80
+            - name: SEICHI_PROXY_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: seichi-portal-frontend-secrets
+                  key: SEICHI_PROXY_SECRET
+            - name: SEICHI_CLIENT_IP_HEADER
+              value: CF-Connecting-IP
             - name: DISCORD_CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/terraform/onp_cluster_minecraft_secrets.tf
+++ b/terraform/onp_cluster_minecraft_secrets.tf
@@ -265,6 +265,11 @@ resource "kubernetes_secret_v1" "seichi_portal_meilisearch_master_key" {
   type = "Opaque"
 }
 
+resource "random_password" "seichi_portal_proxy_secret" {
+  length  = 32
+  special = false
+}
+
 resource "kubernetes_secret_v1" "seichi_portal_backend_secrets" {
   depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 
@@ -274,7 +279,8 @@ resource "kubernetes_secret_v1" "seichi_portal_backend_secrets" {
   }
 
   data = {
-    DISCORD_BOT_TOKEN = var.seichi_portal_backend__discord_bot_token
+    DISCORD_BOT_TOKEN   = var.seichi_portal_backend__discord_bot_token
+    SEICHI_PROXY_SECRET = random_password.seichi_portal_proxy_secret.result
     MINECRAFT_BANS_DATABASE_URL = format(
       "mysql://litebans:%s@mariadb:3306/litebans_gigantic_prod",
       urlencode(random_password.minecraft__prod_mariadb_litebans_password.result),
@@ -296,6 +302,7 @@ resource "kubernetes_secret_v1" "seichi_portal_frontend_secrets" {
     MS_APP_CLIENT_ID      = var.seichi_portal_frontend__ms_app_client_id
     DISCORD_CLIENT_ID     = var.seichi_portal_frontend__discord_client_id
     DISCORD_CLIENT_SECRET = var.seichi_portal_frontend__discord_client_secret
+    SEICHI_PROXY_SECRET   = random_password.seichi_portal_proxy_secret.result
   }
 
   type = "Opaque"


### PR DESCRIPTION
## 概要

- レートリミット機能を含む seichi-portal-backend v0.2.4 と seichi-portal-frontend v0.3.3 のイメージへ更新
- backend と frontend の間でクライアント IP を安全に転送するため、Terraform で共有 `SEICHI_PROXY_SECRET` を生成し、両方の Secret から環境変数として供給
- frontend に `SEICHI_CLIENT_IP_HEADER=CF-Connecting-IP` を追加

## 確認事項

- `terraform fmt -check` が成功
- `terraform validate` が成功
- `git diff --check` が成功
- 更新後の multi-platform image manifest digest を確認
- `kubectl apply --dry-run=client` はローカル Kubernetes API がないため完了せず

🤖 Generated with Codex