### PR TITLE
chore(deps): seichi-portal-frontend を 0.3.4 に更新

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-frontend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-frontend/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: seichi-portal-frontend
-          image: ghcr.io/giganticminecraft/seichi-portal-frontend:0.3.3@sha256:4b10f8e1e0932d64e6d7ea40369d593754e59cf8bd8d608f609e02da1e09ae47
+          image: ghcr.io/giganticminecraft/seichi-portal-frontend:0.3.4@sha256:60a99a5784543891933cff43b809adf0f1b9cf6dd1fdd1029ae3177d4b61d8c9
           ports:
             - name: http
               containerPort: 3000


### PR DESCRIPTION
## 概要
- seichi-portal-frontend を 0.3.3 から 0.3.4 に更新
- GHCR の multi-platform manifest digest も更新し、immutable なイメージ参照を維持

## 確認事項
- GHCR の `0.3.4` manifest を確認し、digest `sha256:60a99a5784543891933cff43b809adf0f1b9cf6dd1fdd1029ae3177d4b61d8c9` を設定
- `git diff --check` が成功
- Deployment のイメージ参照のみの変更のため、アプリケーションテストは未実施

🤖 Generated with Codex