### PR TITLE
mcserver GC storm 対策: s5 に GC ログ/JFR canary 導入と JVM 予兆アラート追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
@@ -48,8 +48,9 @@ spec:
           # アプリケーションアラート (#5611, #5618, Sentry 撤去後の通知カバレッジ)。
           # アプリのエラーはノード再起動で直らないため、ノード保守をブロックさせない
           # Mcserver*: mcserver JVM の GC 予兆アラート (mcserver-jvm-alerts)。
-          # JVM 内部の状態でありノード再起動で直らない上、賑わい時間帯に warning が
-          # 長時間 firing し続けてノード保守をブロックしうるため除外する
+          # drain による Pod 再作成で heap は一旦初期化されるが根本原因は解消しない
+          # アプリ固有アラートであり、賑わい時間帯に warning が長時間 firing し続けて
+          # クラスタ全体のノード保守を止めうるため除外する
           alertFilterRegexp: "^(Watchdog|InfoInhibitor|TargetDown|KubeJobFailed|CPUThrottlingHigh|PrometheusNotConnectedToAlertmanagers|KubePodCrashLooping|KubePodNotReady|KubeDeploymentReplicasMismatch|KubeStatefulSetReplicasMismatch|KubeletTooManyPods|ThanosSidecarUploadStale|SeichiPortalHighErrorRate|SeichiPortalBackendCrashLoop|GachadataServerCrashLoop|ConifersIngestorJobFailed|ConifersIngestorStalled|ConifersMigrationJobFailed|ArgoCDAppDegraded|ArgoCDAppSyncFailed|ArgoCDAppOutOfSyncTooLong|McserverOldGenHighAfterCollection|McserverFullGcStorm|McserverMemoryNearLimit)$"
           # kubelet のパッチ更新も kured の drain + 再起動に相乗りさせる。
           # pkgs.k8s.io はマイナーごとの repo (core:/stable:/v1.3x) なので、apt で入るのは

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
@@ -47,7 +47,10 @@ spec:
           # GachadataServerCrashLoop / ConifersIngestorJobFailed / ArgoCDApp*:
           # アプリケーションアラート (#5611, #5618, Sentry 撤去後の通知カバレッジ)。
           # アプリのエラーはノード再起動で直らないため、ノード保守をブロックさせない
-          alertFilterRegexp: "^(Watchdog|InfoInhibitor|TargetDown|KubeJobFailed|CPUThrottlingHigh|PrometheusNotConnectedToAlertmanagers|KubePodCrashLooping|KubePodNotReady|KubeDeploymentReplicasMismatch|KubeStatefulSetReplicasMismatch|KubeletTooManyPods|ThanosSidecarUploadStale|SeichiPortalHighErrorRate|SeichiPortalBackendCrashLoop|GachadataServerCrashLoop|ConifersIngestorJobFailed|ConifersIngestorStalled|ConifersMigrationJobFailed|ArgoCDAppDegraded|ArgoCDAppSyncFailed|ArgoCDAppOutOfSyncTooLong)$"
+          # Mcserver*: mcserver JVM の GC 予兆アラート (mcserver-jvm-alerts)。
+          # JVM 内部の状態でありノード再起動で直らない上、賑わい時間帯に warning が
+          # 長時間 firing し続けてノード保守をブロックしうるため除外する
+          alertFilterRegexp: "^(Watchdog|InfoInhibitor|TargetDown|KubeJobFailed|CPUThrottlingHigh|PrometheusNotConnectedToAlertmanagers|KubePodCrashLooping|KubePodNotReady|KubeDeploymentReplicasMismatch|KubeStatefulSetReplicasMismatch|KubeletTooManyPods|ThanosSidecarUploadStale|SeichiPortalHighErrorRate|SeichiPortalBackendCrashLoop|GachadataServerCrashLoop|ConifersIngestorJobFailed|ConifersIngestorStalled|ConifersMigrationJobFailed|ArgoCDAppDegraded|ArgoCDAppSyncFailed|ArgoCDAppOutOfSyncTooLong|McserverOldGenHighAfterCollection|McserverFullGcStorm|McserverMemoryNearLimit)$"
           # kubelet のパッチ更新も kured の drain + 再起動に相乗りさせる。
           # pkgs.k8s.io はマイナーごとの repo (core:/stable:/v1.3x) なので、apt で入るのは
           # 同一マイナー内のパッチのみ。マイナーアップグレードは従来どおり kubeadm で手動実施し、

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/kured.yaml
@@ -46,7 +46,8 @@ spec:
           # SeichiPortalHighErrorRate / SeichiPortalBackendCrashLoop /
           # GachadataServerCrashLoop / ConifersIngestorJobFailed / ArgoCDApp*:
           # アプリケーションアラート (#5611, #5618, Sentry 撤去後の通知カバレッジ)。
-          # アプリのエラーはノード再起動で直らないため、ノード保守をブロックさせない
+          # drain による Pod 再作成で症状が一旦消えることはあっても根本原因は解消しない
+          # アプリ固有の問題のため、ノード保守をブロックさせない
           # Mcserver*: mcserver JVM の GC 予兆アラート (mcserver-jvm-alerts)。
           # drain による Pod 再作成で heap は一旦初期化されるが根本原因は解消しない
           # アプリ固有アラートであり、賑わい時間帯に warning が長時間 firing し続けて

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
@@ -104,10 +104,11 @@ spec:
             - name: EULA
               value: "TRUE"
 
-            # mc-server-runner が stop 命令後にサーバー終了を待つ秒数 (デフォルト 60)。
-            # 60 のままだと terminationGracePeriodSeconds を延ばしても runner が先に JVM を
-            # 強制終了して dumponexit が走らない。JVM の shutdown hook (JFR dump 含む) 用に
-            # grace 180 秒から 30 秒残した 150 に設定する。
+            # mc-server-runner は stop 送信から STOP_DURATION 秒後に Java プロセスを
+            # 強制 kill する (デフォルト 60)。サーバー停止処理と JVM shutdown hook
+            # (JFR dumponexit 含む) はこの 150 秒以内に完了する必要がある。
+            # terminationGracePeriodSeconds (180) との差 30 秒は runner 自身と Pod 終了処理の
+            # 余白であり、JVM shutdown hook 用の追加時間ではない。
             - name: STOP_DURATION
               value: "150"
 
@@ -181,9 +182,11 @@ spec:
               # - terminationGracePeriodSeconds を 180 に延長し、liveness kill 時に SIGTERM
               #   からの正常終了 (shutdown hook の dumponexit が OldObjectSample を書き出す)
               #   が完走する確率を上げる (2026-08-09 は猶予 30 秒で足りず SIGKILL された)
-              # - アラート発火中に手動で取る場合、コンテナに jcmd はない (JRE イメージ) ので
-              #   JMC を JMX (10.96.118.86:32000) につなぐか、kubectl debug --target=minecraft
-              #   で JDK イメージの jcmd を使う。アラート起点の自動 dump は今後の課題
+              # - アラート発火中に手動で取る場合は JMC を JMX (10.96.118.86:32000) につないで
+              #   recording "continuous" を dump する。コンテナは JRE イメージで jcmd がなく、
+              #   kubectl debug --target も PID namespace しか共有せず attach socket
+              #   (/tmp/.java_pid*) が debug container から見えないため使えない。
+              #   FlightRecorderMXBean によるアラート起点の自動 dump は今後の課題
               value: >-
                 -XX:ErrorFile=/data/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError
                 -XX:HeapDumpPath=/data/ -XX:+CreateCoredumpOnCrash

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
@@ -125,6 +125,29 @@ spec:
               # MaxDirectMemorySize: 未設定だとデフォルトで Xmx と同じ 8G まで direct buffer が
               # 伸びられるため、コンテナの memory limit を超えうる。実測ピークは ~450MiB のため
               # 2 倍のマージンを取って 1G に制限する。
+              #
+              # --- 以下 2026-08-09 GC storm 調査用の canary (s5 のみ) ---
+              # 2026-08-09 17:27 の liveness kill は、collection 後の Old 使用量が約 70 分で
+              # 2.5→7.96GiB (ほぼ満杯) に増大し Full GC 連発 (17:20-25 の 5 分で 271 秒) に
+              # 陥ったことが原因。Old に何が保持されていたかは未特定のため、GC ログと
+              # 継続 JFR を /data (PVC) に永続化して次回発生時に特定できるようにする。
+              #
+              # GC ログ: %t なしだと liveness kill 直後の再起動で直前のログが失われるため
+              # %t を付ける。その代償として filecount の rotation は JVM 起動を跨いで効かない
+              # (起動ごとに別 basename になる) ので、全台展開の前に日数/容量ベースの掃除を
+              # 用意すること。canary では 200Gi PVC に対し最大 500MB/起動なので許容する。
+              # gc+age は MaxTenuringThreshold=1 の再評価、gc+humongous は G1HeapRegionSize
+              # 16M 化の要否判断、safepoint は watchdog の停止時間との照合に使う。
+              #
+              # JFR: SIGKILL では dumponexit が発火しないため、repository を PVC 上に置く。
+              # kill 後は `jfr assemble /data/jfr-repository/<subdir> out.jfr` で chunk から復元
+              # できる (未完了の .part は除外される)。repository ディレクトリは JFR が自動作成
+              # する (jdk.jfr.internal.Repository が createDirectories を呼ぶ)。
+              # OldObjectSample は default 設定でも有効 (allocation stack trace なし) のため、
+              # stackTrace のみ追加で有効化する (JDK 17 の CLI イベント設定オーバーライド)。
+              # settings=profile を常用しないのは短期解析向けで default より負荷が高いため。
+              # 注意: path-to-gc-roots は dump 実行時にしか収集されないので、SIGKILL 時の
+              # chunk には保持経路は残らない (クラス名と allocation stack までが取れる)。
               value: >-
                 -XX:ErrorFile=/data/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError
                 -XX:HeapDumpPath=/data/ -XX:+CreateCoredumpOnCrash
@@ -135,6 +158,9 @@ spec:
                 -XX:MaxMetaspaceSize=384m
                 -XX:G1PeriodicGCInterval=60000
                 -XX:MaxDirectMemorySize=1g
+                -Xlog:gc*,gc+heap=debug,gc+age=debug,gc+humongous=debug,safepoint=info:file=/data/gc-%t.log:time,uptime,level,tags:filecount=10,filesize=50m
+                -XX:FlightRecorderOptions=repository=/data/jfr-repository,stackdepth=128
+                -XX:StartFlightRecording:name=continuous,disk=true,maxage=6h,maxsize=1g,dumponexit=true,filename=/data/jfr-exit.jfr,settings=default,jdk.OldObjectSample#stackTrace=true
 
             - name: ENABLE_JMX
               value: "true"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
@@ -19,6 +19,10 @@ spec:
         app: mcserver--s5
         mcserver: s5
     spec:
+      # liveness kill 時に SIGTERM からの正常終了 (JFR dumponexit が OldObjectSample を
+      # 書き出す) が完走する確率を上げる。デフォルト 30 秒では 2026-08-09 の GC storm 時に
+      # 足りず SIGKILL された。正常時の停止は数十秒で終わるため日次再起動には影響しない。
+      terminationGracePeriodSeconds: 180
       initContainers:
         - name: mod-downloader
           image: ghcr.io/giganticminecraft/mod-downloader:1.0.0@sha256:fab675dfa2bb2ae0ca8ab17a0b12bebfae977a8d8ac9c8a5306fd479e53bb32c
@@ -69,6 +73,23 @@ spec:
             - name: mod-downloader-volume
               mountPath: /downloaded-plugins
 
+        # GC storm 調査用テレメトリの掃除 (canary)。
+        # GC ログは %t 付き basename のため JVM の filecount rotation が起動を跨いで効かず、
+        # JFR repository は SIGKILL で残った旧 subdirectory (最大 ~1GiB/回) を次の JVM が
+        # 削除しないため、どちらも起動時にここで削除する。
+        - name: gc-telemetry-cleanup
+          image: busybox:1.38.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - |
+              find /data -maxdepth 1 -name 'gc-*.log*' -mtime +14 -exec rm -f {} + || true
+              [ -d /data/jfr-repository ] && find /data/jfr-repository -mindepth 1 -maxdepth 1 -mtime +7 -exec rm -rf {} + || true
+          volumeMounts:
+            - name: mcserver--s5-data
+              mountPath: /data
+
       containers:
         - resources:
             requests:
@@ -82,6 +103,13 @@ spec:
               value: 8G
             - name: EULA
               value: "TRUE"
+
+            # mc-server-runner が stop 命令後にサーバー終了を待つ秒数 (デフォルト 60)。
+            # 60 のままだと terminationGracePeriodSeconds を延ばしても runner が先に JVM を
+            # 強制終了して dumponexit が走らない。JVM の shutdown hook (JFR dump 含む) 用に
+            # grace 180 秒から 30 秒残した 150 に設定する。
+            - name: STOP_DURATION
+              value: "150"
 
             # glibc の malloc arena の数を制限する。
             # arena の上限はデフォルトで「CPU コア数 × 8」だが、glibc は cgroup を認識しないため
@@ -134,20 +162,28 @@ spec:
               #
               # GC ログ: %t なしだと liveness kill 直後の再起動で直前のログが失われるため
               # %t を付ける。その代償として filecount の rotation は JVM 起動を跨いで効かない
-              # (起動ごとに別 basename になる) ので、全台展開の前に日数/容量ベースの掃除を
-              # 用意すること。canary では 200Gi PVC に対し最大 500MB/起動なので許容する。
+              # (起動ごとに別 basename になる) ので、gc-telemetry-cleanup initContainer が
+              # 起動時に古いファイルを掃除する。
               # gc+age は MaxTenuringThreshold=1 の再評価、gc+humongous は G1HeapRegionSize
               # 16M 化の要否判断、safepoint は watchdog の停止時間との照合に使う。
               #
-              # JFR: SIGKILL では dumponexit が発火しないため、repository を PVC 上に置く。
-              # kill 後は `jfr assemble /data/jfr-repository/<subdir> out.jfr` で chunk から復元
-              # できる (未完了の .part は除外される)。repository ディレクトリは JFR が自動作成
-              # する (jdk.jfr.internal.Repository が createDirectories を呼ぶ)。
-              # OldObjectSample は default 設定でも有効 (allocation stack trace なし) のため、
+              # JFR: repository を PVC 上に置くことで、SIGKILL 後も完成済み chunk を
+              # `jfr assemble /data/jfr-repository/<subdir> out.jfr` で連結して読める
+              # (未完了の .part は除外される)。repository ディレクトリは JFR が自動作成する。
+              # OldObjectSample は default 設定でも有効だが allocation stack trace がないため
               # stackTrace のみ追加で有効化する (JDK 17 の CLI イベント設定オーバーライド)。
               # settings=profile を常用しないのは短期解析向けで default より負荷が高いため。
-              # 注意: path-to-gc-roots は dump 実行時にしか収集されないので、SIGKILL 時の
-              # chunk には保持経路は残らない (クラス名と allocation stack までが取れる)。
+              #
+              # 重要な制約: OldObjectSample イベントは recording の stop/dump 時にしか
+              # chunk へ書き出されない (PlatformRecorder.stop の実装)。SIGKILL で残る chunk に
+              # 含まれるのは GC/safepoint/ObjectAllocationSample 等の通常イベントのみで、
+              # 「生存オブジェクトの allocation stack」(保持元特定に必要) は残らない。対策:
+              # - terminationGracePeriodSeconds を 180 に延長し、liveness kill 時に SIGTERM
+              #   からの正常終了 (shutdown hook の dumponexit が OldObjectSample を書き出す)
+              #   が完走する確率を上げる (2026-08-09 は猶予 30 秒で足りず SIGKILL された)
+              # - アラート発火中に手動で取る場合、コンテナに jcmd はない (JRE イメージ) ので
+              #   JMC を JMX (10.96.118.86:32000) につなぐか、kubectl debug --target=minecraft
+              #   で JDK イメージの jcmd を使う。アラート起点の自動 dump は今後の課題
               value: >-
                 -XX:ErrorFile=/data/hs_err_pid%p.log -XX:+HeapDumpOnOutOfMemoryError
                 -XX:HeapDumpPath=/data/ -XX:+CreateCoredumpOnCrash

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver-jvm-alerts/prometheusrule.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver-jvm-alerts/prometheusrule.yaml
@@ -1,0 +1,66 @@
+# mcserver JVM の GC 予兆アラート。
+# 2026-08-09 17:27 の mcserver--s5 liveness kill (collection 後 Old 使用量が
+# 約 70 分で 2.5→7.96GiB に増大 → Full GC 連発 → mc-health タイムアウト) では、
+# 予兆 (collection 後 Old 使用率の上昇) が kill の 30-40 分前から現れていたのに
+# アラートがなく、発見が 2 時間後の手動確認だった。s3 でも 2026-07-29 / 08-06 に
+# 同様の Full GC 多発が観測されている (このときは自然回復)。
+# 瞬間の heap used はノコギリ波の頂点で常に高く誤検知するため、
+# 「collection 後」の使用量 (jvm_memory_pool_collection_used_bytes) を使う。
+# アラート名は kured の alertFilterRegexp にも登録している。変えたら kured 側も更新すること。
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: mcserver-jvm-alerts
+  namespace: seichi-minecraft
+  labels:
+    release: prometheus
+spec:
+  groups:
+    - name: mcserver-jvm-alerts
+      rules:
+        # 2026-08-09 の実測では 16:40 頃からこの比率が持続的に上昇し、
+        # 85% 超えは kill の 30-40 分前 → 先行検知として機能する
+        - alert: McserverOldGenHighAfterCollection
+          expr: |
+            jvm_memory_pool_collection_used_bytes{namespace="seichi-minecraft", pool="G1 Old Gen"}
+              / jvm_memory_pool_max_bytes{namespace="seichi-minecraft", pool="G1 Old Gen"} > 0.85
+          for: 10m
+          labels:
+            severity: warning
+            notify: discord
+          annotations:
+            summary: "{{ $labels.pod }} の GC 後 Old 世代使用率が 85% を超えています"
+            description: "Pod {{ $labels.pod }} で GC (mixed/Full) 後も Old 世代が {{ $value | humanizePercentage }} 残っています。回収不能な保持が増えており、放置すると Full GC 連発 → liveness kill に至る可能性があります (2026-08-09 s5 と同型)。s5 なら /data の GC ログと JFR repository (jfr assemble で復元) で保持元を確認する。"
+
+        # Full GC (jmx exporter では gc="G1 Old Generation") は平常時ほぼ 0 回のため
+        # 閾値 30 秒/10 分でも誤検知しない。発火時点で既にプレイヤー影響が出ている
+        - alert: McserverFullGcStorm
+          expr: |
+            sum by (namespace, pod) (
+              increase(jvm_gc_collection_seconds_sum{namespace="seichi-minecraft", gc="G1 Old Generation"}[10m])
+            ) > 30
+          for: 5m
+          labels:
+            severity: critical
+            notify: discord
+          annotations:
+            summary: "{{ $labels.pod }} で Full GC が多発しています"
+            description: "Pod {{ $labels.pod }} が直近 10 分で Full GC に {{ $value | humanize }} 秒を費やしています。GC 停止で watchdog/liveness タイムアウト → 再起動に至る可能性が高い状態です。"
+
+        # 2026-08-09 は working set が limit 12Gi 比 99.9% まで達していた。
+        # ここが張り付いたまま Xmx を上げると OOMKill するため、容量変更の判断材料にもなる
+        - alert: McserverMemoryNearLimit
+          expr: |
+            max by (namespace, pod, container) (
+              container_memory_working_set_bytes{namespace="seichi-minecraft", container="minecraft"}
+            )
+              / max by (namespace, pod, container) (
+              kube_pod_container_resource_limits{namespace="seichi-minecraft", container="minecraft", resource="memory"}
+            ) > 0.95
+          for: 10m
+          labels:
+            severity: warning
+            notify: discord
+          annotations:
+            summary: "{{ $labels.pod }} の working set が memory limit の 95% を超えています"
+            description: "Pod {{ $labels.pod }} の {{ $labels.container }} コンテナの working set が limit 比 {{ $value | humanizePercentage }} です。cgroup OOMKill が近い、または page cache まで含めて逼迫しています。"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver-jvm-alerts/prometheusrule.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver-jvm-alerts/prometheusrule.yaml
@@ -39,7 +39,7 @@ spec:
             notify: discord
           annotations:
             summary: "{{ $labels.pod }} の GC 後 Old 世代使用率が 85% を超えています"
-            description: "Pod {{ $labels.pod }} で GC (mixed/Full) 後の Old 世代使用量が高止まりしています (直近 15 分のピーク: Old max 比 {{ $value | humanizePercentage }})。放置すると Full GC 連発 → liveness kill に至る可能性があります (2026-08-09 s5 と同型)。保持元の特定には JVM が応答するうちに JFR dump を取ること。コンテナに jcmd はない (JRE イメージ) ため、JMC を JMX につなぐか kubectl debug --target=minecraft (JDK イメージ) の jcmd で name=continuous を /data に dump する。"
+            description: "Pod {{ $labels.pod }} で GC (mixed/Full) 後の Old 世代使用量が高止まりしています (直近 15 分のピーク: Old max 比 {{ $value | humanizePercentage }})。放置すると Full GC 連発 → liveness kill に至る可能性があります (2026-08-09 s5 と同型)。保持元の特定には JVM が応答するうちに JFR dump を取ること。コンテナに jcmd はない (JRE イメージ) ため、JMC を JMX (ClusterIP 10.96.118.86:32000) につなぎ recording continuous を dump する。"
 
         # Full GC (jmx exporter では gc="G1 Old Generation") は平常時ほぼ 0 回のため
         # 閾値 30 秒/10 分でも誤検知しない。発火時点で既にプレイヤー影響が出ている

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver-jvm-alerts/prometheusrule.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver-jvm-alerts/prometheusrule.yaml
@@ -18,26 +18,35 @@ spec:
   groups:
     - name: mcserver-jvm-alerts
       rules:
-        # 2026-08-09 の実測では 16:40 頃からこの比率が持続的に上昇し、
-        # 85% 超えは kill の 30-40 分前 → 先行検知として機能する
+        # GC (mixed/Full) 後も Old 使用量が高止まりしている状態を検知する。
+        # 素の比率は mixed GC の成功でノコギリ波状に閾値を跨ぐため (2026-08-09 の実測では
+        # >0.85 の連続は最長 4 分で、素の式 + for: 10m は一度も発火しない)、
+        # max_over_time の 15 分窓で平滑化し、scrape 欠損 (JVM フリーズ中に発生) も窓で吸収する。
+        # バックテスト (60 秒評価、alert state 込み):
+        # - 2026-08-09 s5: 16:33 発火 = liveness kill (17:27) の 54 分前。mixed GC が
+        #   一時回復した 17:00-17:18 に resolve→17:24 再発火のフラップが 1 回ある (許容する)
+        # - 同日 13:10-15:00 の自然回復した前駆エピソード、2026-08-06 s3 の
+        #   Full GC 多発 (218 回/日) も検知する。直近 3 日の平常時間帯に誤検知なし
         - alert: McserverOldGenHighAfterCollection
           expr: |
-            jvm_memory_pool_collection_used_bytes{namespace="seichi-minecraft", pool="G1 Old Gen"}
-              / jvm_memory_pool_max_bytes{namespace="seichi-minecraft", pool="G1 Old Gen"} > 0.85
-          for: 10m
+            max_over_time((
+              jvm_memory_pool_collection_used_bytes{namespace="seichi-minecraft", job=~"mcserver--.*", pool="G1 Old Gen"}
+                / jvm_memory_pool_max_bytes{namespace="seichi-minecraft", job=~"mcserver--.*", pool="G1 Old Gen"}
+            )[15m:1m]) > 0.85
+          for: 5m
           labels:
             severity: warning
             notify: discord
           annotations:
             summary: "{{ $labels.pod }} の GC 後 Old 世代使用率が 85% を超えています"
-            description: "Pod {{ $labels.pod }} で GC (mixed/Full) 後も Old 世代が {{ $value | humanizePercentage }} 残っています。回収不能な保持が増えており、放置すると Full GC 連発 → liveness kill に至る可能性があります (2026-08-09 s5 と同型)。s5 なら /data の GC ログと JFR repository (jfr assemble で復元) で保持元を確認する。"
+            description: "Pod {{ $labels.pod }} で GC (mixed/Full) 後の Old 世代使用量が高止まりしています (直近 15 分のピーク: Old max 比 {{ $value | humanizePercentage }})。放置すると Full GC 連発 → liveness kill に至る可能性があります (2026-08-09 s5 と同型)。保持元の特定には JVM が応答するうちに JFR dump を取ること。コンテナに jcmd はない (JRE イメージ) ため、JMC を JMX につなぐか kubectl debug --target=minecraft (JDK イメージ) の jcmd で name=continuous を /data に dump する。"
 
         # Full GC (jmx exporter では gc="G1 Old Generation") は平常時ほぼ 0 回のため
         # 閾値 30 秒/10 分でも誤検知しない。発火時点で既にプレイヤー影響が出ている
         - alert: McserverFullGcStorm
           expr: |
             sum by (namespace, pod) (
-              increase(jvm_gc_collection_seconds_sum{namespace="seichi-minecraft", gc="G1 Old Generation"}[10m])
+              increase(jvm_gc_collection_seconds_sum{namespace="seichi-minecraft", job=~"mcserver--.*", gc="G1 Old Generation"}[10m])
             ) > 30
           for: 5m
           labels:


### PR DESCRIPTION
## 背景

2026-08-09 17:27 JST、mcserver--s5-0 が liveness probe (`mc-health`) 3 連続タイムアウトで kubelet に kill された (exit 137)。調査の結果:

- collection 後の Old 世代使用量が 16:10 の 2.5GiB から約 70 分で 7.96GiB (Old max 比 ≒100%) まで増大
- 17:00〜17:15 は mixed GC がまだ 4.4〜4.9GiB まで戻せていたが、17:18 以降は戻らなくなり Full GC 連発 (17:20〜25 の 5 分間で 271 秒) に陥った
- JNI critical section による GCLocker がストールを増幅し、Server thread 停止 → watchdog 発報 → liveness kill
- **Old に何が保持されていたかは現状のテレメトリでは特定できない**(humongous 断片化説・負荷急増説・DB 起因説はデータで棄却済み)
- s3 でも 2026-07-29 (Full GC 465 回/日)・08-06 (218 回/日) に同症状が観測されており再発性がある

次回発生時に保持元を特定できるようにする計装 (s5 canary) と、予兆アラートを追加する。

## 変更内容

### 1. s5 canary: GC ログ永続化 + 継続 JFR (`mcserver--s5/stateful-set.yaml`)

- `-Xlog:gc*,gc+heap=debug,gc+age=debug,gc+humongous=debug,safepoint=info` を `/data/gc-%t.log` へ (rotation 10×50m)
- `-XX:FlightRecorderOptions=repository=/data/jfr-repository,stackdepth=128` + `-XX:StartFlightRecording:disk=true,maxage=6h,maxsize=1g,dumponexit=true,settings=default,jdk.OldObjectSample#stackTrace=true`
- **OldObjectSample の制約**: このイベントは recording の stop/dump 時にしか chunk へ書き出されない (PlatformRecorder.stop)。SIGKILL で残る chunk から `jfr assemble` で読めるのは GC/safepoint/ObjectAllocationSample 等の通常イベントのみで、保持元特定に必要な「生存オブジェクトの allocation stack」は含まれない。対策として:
  - `terminationGracePeriodSeconds: 180` + `STOP_DURATION: 150` — liveness kill 時に SIGTERM からの正常終了 (dumponexit が OldObjectSample を書き出す) が完走する確率を上げる (今回は猶予 30 秒で足りず SIGKILL)。なお mc-server-runner は stop 送信から 150 秒後に Java プロセスを強制 kill するため、**サーバー停止処理と JVM shutdown hook (dumponexit) はこの 150 秒以内に完了する必要がある**。grace との差 30 秒は runner/Pod 終了処理の余白
  - アラート発火中の手動 dump は **JMC over JMX (ClusterIP:32000) に一本化** (コンテナは JRE で jcmd なし。`kubectl debug --target` は PID namespace しか共有せず attach socket /tmp/.java_pid* が見えないため不可)
  - FlightRecorderMXBean によるアラート起点の自動 dump は follow-up
- `gc-telemetry-cleanup` initContainer (busybox): %t 付き GC ログ (JVM の filecount rotation は起動を跨いで効かない) と SIGKILL で残る JFR repository subdirectory (最大 ~1GiB/異常終了) を起動時に掃除

### 2. PrometheusRule `mcserver-jvm-alerts` 新設

60 秒評価・alert state (`for` 継続) 込みでバックテスト済み:

- **`McserverOldGenHighAfterCollection`** (warning): `max_over_time((collection 後 Old / Old max)[15m:1m]) > 0.85` for 5m
  素の比率はノコギリ波で >0.85 の連続が最長 4 分しかなく `for: 10m` では発火しないため、15 分窓の max で平滑化 (scrape 欠損も窓で吸収)。バックテスト結果 (レビュー側でも再現確認済み): 条件成立 16:28 → **16:33 発火 = kill の 54 分前** → resolve 17:00 → 再成立 17:19 → 再発火 17:24。mixed GC が一時回復した期間の resolve→再発火フラップ 1 回は許容。同日 13:10〜15:00 の自然回復した前駆エピソードと 2026-08-06 s3 の Full GC 多発 (218 回/日) も検知。直近 3 日の平常時間帯に誤検知なし
- **`McserverFullGcStorm`** (critical): Full GC 時間 > 30 秒/10 分 for 5m — 今回は 16:35 頃発火
- **`McserverMemoryNearLimit`** (warning): working set / memory limit > 95% for 10m — 今回の障害では発火しない (7 月の native メモリリーク型を対象とした安全網)

いずれも JVM 系列は `job=~"mcserver--.*"` で絞り、同 namespace に別 JVM exporter が増えた場合の誤検知を防ぐ。

### 3. kured の `alertFilterRegexp` に 3 アラートを登録

drain による Pod 再作成で heap は一旦初期化されるものの根本原因は解消しないアプリ固有アラートであり、賑わい時間帯に warning が長時間 firing してクラスタ全体のノード保守を止めないよう除外する。

## マージ後の検証手順 (canary)

- [ ] ArgoCD sync 後、mcserver--s5-0 が Running/Ready になり、`ps` で新フラグが JVM に渡っていること
- [ ] `/data/gc-<timestamp>.log` が生成され、gc/safepoint 行があること (rotation は filesize 到達後に確認)
- [ ] `/data/jfr-repository/<subdir>/` に chunk (.jfr) が生成され、`jfr assemble` で読めること
- [ ] 日次再起動 (正常終了) 後に `/data/jfr-exit.jfr` が生成され、OldObjectSample イベントが含まれること
- [ ] JMC を JMX (ClusterIP:32000) につなぎ recording continuous を手動 dump できること (手動手順の完走確認)
- [ ] **observer effect の確認**: 導入前後で CPU 使用率・/data への書込レイテンシ (stackdepth=128 + 同期 GC ログ書込の影響) に有意な劣化がないこと
- [ ] Prometheus の /alerts に 3 ルールが載っていること (PromQL は実データでバックテスト済み)
- [ ] 日次再起動の所要時間が従来と変わらないこと (terminationGracePeriodSeconds 延長は異常時のみ効く想定)

## 留意点

- Old ratio アラートは GC が一時回復すると resolve → 再発火するフラップがあり得る (2026-08-09 の再現では 1 回)。フラップ自体も不安定な状態の情報として許容する設計
- `G1HeapRegionSize` 16M 化は gc+humongous ログで humongous region 数が確認できた場合のみ s5 で試験する。`MaxTenuringThreshold=1` の見直しも gc+age の tenuring 分布を見てから行う
- 全台展開時は cleanup initContainer ごと横展開する

🤖 Generated with [Claude Code](https://claude.com/claude-code)