### PR TITLE
fix(seichi-portal): backend rollout と CrashLoop 通知条件を改善

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-alerts/prometheusrule.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-alerts/prometheusrule.yaml
@@ -40,12 +40,21 @@ spec:
         # file tailer に拾われる前に書き終わるため、Loki ruler の panic ルール (#5618)
         # では検知できない (2026-08-01 実測: 0.2.0 の起動時 panic ログは Loki に
         # 1 行も届いていない)。Sentry が担っていた「起動不能の即時通知」は
-        # この CrashLoop アラートで代替する
+        # この CrashLoop アラートで代替する。rollout 中に旧 Pod がサービスを継続
+        # できている場合は通知せず、Service の ready endpoint が 0 の場合だけ通知する
         - alert: SeichiPortalBackendCrashLoop
           expr: |
-            max by (namespace, pod, container) (
-              max_over_time(kube_pod_container_status_waiting_reason{namespace="seichi-minecraft", container="seichi-portal-backend", reason="CrashLoopBackOff", job="kube-state-metrics"}[5m])
-            ) >= 1
+            (
+              max by (namespace, pod, container) (
+                max_over_time(kube_pod_container_status_waiting_reason{namespace="seichi-minecraft", container="seichi-portal-backend", reason="CrashLoopBackOff", job="kube-state-metrics"}[5m])
+              ) >= 1
+            )
+            and on (namespace)
+            (
+              kube_service_info{namespace="seichi-minecraft", service="seichi-portal-backend", job="kube-state-metrics"}
+              unless on (namespace)
+              kube_endpointslice_endpoints{namespace="seichi-minecraft", endpointslice=~"seichi-portal-backend-.*", ready="true", job="kube-state-metrics"}
+            )
           for: 5m
           labels:
             severity: critical
@@ -53,4 +62,4 @@ spec:
             team: portal
           annotations:
             summary: "seichi-portal-backend が CrashLoopBackOff です"
-            description: "Pod {{ $labels.namespace }}/{{ $labels.pod }} が繰り返しクラッシュしています。起動時 panic のログは Loki に届かないため、原因は kubectl logs --previous で確認する。"
+            description: "Pod {{ $labels.namespace }}/{{ $labels.pod }} が繰り返しクラッシュしており、Service seichi-portal-backend に ready endpoint がありません。起動時 panic のログは Loki に届かないため、原因は kubectl logs --previous で確認する。"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
@@ -9,6 +9,13 @@ metadata:
     reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
+  # 単一 replica でも、新 Pod が安定して Ready になるまでは旧 Pod を残す。
+  minReadySeconds: 30
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: seichi-portal-backend
@@ -23,6 +30,27 @@ spec:
       containers:
         - name: seichi-portal-backend
           image: ghcr.io/giganticminecraft/seichi-portal-backend:0.2.5@sha256:724f4faf56119005bbb20a3c03201f3f918f2d5c0fd4e58f485f2a2a57a2928a
+          ports:
+            - name: http
+              containerPort: 9000
+              protocol: TCP
+          # /health は MariaDB、Meilisearch、RabbitMQ、DiscordBot まで確認する。
+          # rollout 中は依存先を含めて利用可能になった Pod だけを Service に載せる。
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 2
+          # 依存サービスの障害では再起動させず、HTTP listener 自体の停止だけを検知する。
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           resources:
             # OTel exporter のオーバーヘッド吸収のため limit を 100m から 300m へ増強
             # (seichi-game-data-publisher が exporter 導入時に 50m→300m へ増強した実績に倣う)


### PR DESCRIPTION
## 概要

- seichi-portal-backend に readiness / liveness probe を追加
- `minReadySeconds: 30` と `maxUnavailable: 0` / `maxSurge: 1` を明示し、壊れた新 Pod が正常な旧 Pod を押し出さないようにする
- `SeichiPortalBackendCrashLoop` を、CrashLoopBackOff に加えて Service の ready endpoint が 0 の場合だけ通知する条件へ変更

## 背景

readiness probe がなく `minReadySeconds` も 0 だったため、新 Pod が一瞬起動しただけで Available と判定され、旧 Pod が縮退した後に新 Pod が CrashLoopBackOff となっていました。

また、rollout 中に新 Pod がクラッシュしても旧 Pod が Service を継続できている場合は利用者影響がないため、カスタム Discord 通知を Service の ready endpoint の有無で絞ります。

Turnstile の設定や現在の `TURNSTILE_ENABLED is not set` の修正は、この PR のスコープ外です。

## 影響

- 将来の rollout では、新 Pod が依存サービスを含む `/health` を30秒間満たすまで旧 Podを維持
- 依存サービス障害時は readiness のみ失敗させ、TCP liveness では不要な再起動を避ける
- CrashLoopBackOff があっても Service に ready endpoint が残っていれば Discord 通知しない
- 現在の Turnstile 設定不足による起動不能は別途対応が必要

## 検証

- `git diff --check`
- 対象差分に Turnstile 関連変更がないことを確認
- `kubectl apply --dry-run=server` で Deployment / PrometheusRule の両方が成功
- Grafana MCP から変更後の PromQL を実データに対して評価し、現在の CrashLoopBackOff + ready endpoint なしを1件検出
