### PR TITLE
fix(kubechecks): CRD schemasとfallback versionを設定

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/apps.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/apps.yaml
@@ -260,7 +260,11 @@ spec:
             KUBECHECKS_ARGOCD_API_SERVER_ADDR: "argocd-server.argocd:443"
             KUBECHECKS_ARGOCD_API_INSECURE: "true"
             KUBECHECKS_WEBHOOK_URL_BASE: "https://kubechecks.onp-k8s.admin.seichi.click"
-            KUBECHECKS_FALLBACK_K8S_VERSION: "1.32.1"
+            KUBECHECKS_FALLBACK_K8S_VERSION: "1.36.2"
+            # kubeconform の標準 registry に含まれない CRD
+            # (PrometheusRule / CiliumNetworkPolicy など)を検証する。
+            # CI の結果が外部 repository の更新だけで変わらないよう commit を固定する。
+            KUBECHECKS_SCHEMAS_LOCATION: "https://raw.githubusercontent.com/datreeio/CRDs-catalog/52b0261318acc7dd0b66e032759b1f218216b980/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
             KUBECHECKS_TIDY_OUTDATED_COMMENTS_MODE: "delete"
             KUBECHECKS_LOG_LEVEL: "info"
             KUBECHECKS_MONITOR_ALL_APPLICATIONS: "true"


### PR DESCRIPTION
## 概要

- kubechecksへDatree CRDs Catalogのschema locationを追加
- schema catalogのcommitを固定し、外部更新によるCI結果の変動を防止
- fallback Kubernetes versionを現在のクラスタに合わせて1.32.1から1.36.2へ更新

## 背景

PR #5782のkubechecksで、標準Kubernetes schemaに含まれない`PrometheusRule`と`CiliumNetworkPolicy`が`could not find schema`となっていました。

kubechecks v3.3.1はmissing schemaをエラーとして扱うため、kubeconform公式READMEで案内されているCRD catalog形式のURL templateを追加します。

## 影響

- PrometheusRuleとCiliumNetworkPolicyを含むPRでkubeconform validationを実行可能
- Argo CDからクラスタversionを取得できない場合も、現在のKubernetes 1.36.2をfallbackとして使用
- kubechecks ConfigMapのchecksum変更により、Argo CD sync時にkubechecks Podがrollout

Webhook署名secretはGitHub App側との同時設定が必要なため、このPRには含めません。

## 検証

- `git diff --check`
- embedded Helm valuesを`yq`でparse
- kubechecks Helm chart 3.0.0をrenderし、template文字列がConfigMapへ保持されることを確認
- kubeconform v0.7.0 / Kubernetes 1.36.2 / strict modeで以下がvalid
  - `PrometheusRule/seichi-portal-alerts`
  - `CiliumNetworkPolicy/allow--from-seichi-portal-initial-admin--to-mariadb`
- `kubectl apply --dry-run=server -f seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/apps.yaml`

Follow-up to #5782.
