### PR TITLE
feat(seichi-portal): Turnstile 対応と frontend 0.3.7 更新

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/default-deny-policy/allow--from-seichi-portal-backend--to-cloudflare-turnstile.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/default-deny-policy/allow--from-seichi-portal-backend--to-cloudflare-turnstile.yaml
@@ -1,0 +1,28 @@
+# seichi-portal-backend が Turnstile Siteverify を呼び出すための egress 許可。
+# kube-dns への DNS (53/ANY) と challenges.cloudflare.com への HTTPS (443/TCP) に限定する。
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow--from-seichi-portal-backend--to-cloudflare-turnstile
+spec:
+  endpointSelector:
+    matchLabels:
+      app: seichi-portal-backend
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: ANY
+          rules:
+            dns:
+              - matchName: challenges.cloudflare.com
+    - toFQDNs:
+        - matchName: challenges.cloudflare.com
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
@@ -80,6 +80,15 @@ spec:
               value: production
             - name: FRONTEND_URL
               value: https://portal.seichi.click
+            - name: TURNSTILE_ENABLED
+              value: "true"
+            - name: TURNSTILE_ALLOWED_HOSTNAMES
+              value: portal.seichi.click
+            - name: TURNSTILE_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: seichi-portal-backend-secrets
+                  key: TURNSTILE_SECRET_KEY
             - name: REDIS_HOST
               value: seichi-portal-valkey
             - name: REDIS_PORT

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-frontend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-frontend/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: seichi-portal-frontend
-          image: ghcr.io/giganticminecraft/seichi-portal-frontend:0.3.4@sha256:60a99a5784543891933cff43b809adf0f1b9cf6dd1fdd1029ae3177d4b61d8c9
+          image: ghcr.io/giganticminecraft/seichi-portal-frontend:0.3.7@sha256:df9b46df28492149e606724aba7ca734e9d03cf1e0f2c48542a6b7a93fddfd85
           ports:
             - name: http
               containerPort: 3000
@@ -32,6 +32,11 @@ spec:
               cpu: 100m
               memory: 256Mi
           env:
+            - name: TURNSTILE_SITE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: seichi-portal-frontend-secrets
+                  key: TURNSTILE_SITE_KEY
             - name: MS_APP_CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/terraform/cloudflare_turnstile.tf
+++ b/terraform/cloudflare_turnstile.tf
@@ -1,0 +1,10 @@
+# Cloudflare Dashboardに既存Widgetがある場合は、新規作成前に以下でStateへ取り込む。
+# terraform -chdir=terraform import cloudflare_turnstile_widget.seichi_portal <account_id>/<sitekey>
+# import後は plan で差分・置換の有無を確認してから apply する。
+resource "cloudflare_turnstile_widget" "seichi_portal" {
+  account_id = local.cloudflare_account_id
+  name       = "seichi-portal"
+  domains    = ["portal.seichi.click"]
+  mode       = "managed"
+  region     = "world"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -608,12 +608,6 @@ variable "seichi_portal_backend__discord_bot_token" {
   sensitive   = true
 }
 
-variable "seichi_portal_backend__turnstile_secret_key" {
-  description = "Cloudflare Turnstile secret key for seichi-portal-backend"
-  type        = string
-  sensitive   = true
-}
-
 #endregion
 
 #region seichi-portal-frontend secrets
@@ -632,12 +626,6 @@ variable "seichi_portal_frontend__discord_client_id" {
 
 variable "seichi_portal_frontend__discord_client_secret" {
   description = "Discord application client secret for seichi-portal-frontend"
-  type        = string
-  sensitive   = true
-}
-
-variable "seichi_portal_frontend__turnstile_site_key" {
-  description = "Cloudflare Turnstile site key for seichi-portal-frontend"
   type        = string
   sensitive   = true
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -608,6 +608,12 @@ variable "seichi_portal_backend__discord_bot_token" {
   sensitive   = true
 }
 
+variable "seichi_portal_backend__turnstile_secret_key" {
+  description = "Cloudflare Turnstile secret key for seichi-portal-backend"
+  type        = string
+  sensitive   = true
+}
+
 #endregion
 
 #region seichi-portal-frontend secrets
@@ -626,6 +632,12 @@ variable "seichi_portal_frontend__discord_client_id" {
 
 variable "seichi_portal_frontend__discord_client_secret" {
   description = "Discord application client secret for seichi-portal-frontend"
+  type        = string
+  sensitive   = true
+}
+
+variable "seichi_portal_frontend__turnstile_site_key" {
+  description = "Cloudflare Turnstile site key for seichi-portal-frontend"
   type        = string
   sensitive   = true
 }

--- a/terraform/onp_cluster_minecraft_secrets.tf
+++ b/terraform/onp_cluster_minecraft_secrets.tf
@@ -281,7 +281,7 @@ resource "kubernetes_secret_v1" "seichi_portal_backend_secrets" {
   data = {
     DISCORD_BOT_TOKEN    = var.seichi_portal_backend__discord_bot_token
     SEICHI_PROXY_SECRET  = random_password.seichi_portal_proxy_secret.result
-    TURNSTILE_SECRET_KEY = var.seichi_portal_backend__turnstile_secret_key
+    TURNSTILE_SECRET_KEY = cloudflare_turnstile_widget.seichi_portal.secret
     MINECRAFT_BANS_DATABASE_URL = format(
       "mysql://litebans:%s@mariadb:3306/litebans_gigantic_prod",
       urlencode(random_password.minecraft__prod_mariadb_litebans_password.result),
@@ -304,7 +304,7 @@ resource "kubernetes_secret_v1" "seichi_portal_frontend_secrets" {
     DISCORD_CLIENT_ID     = var.seichi_portal_frontend__discord_client_id
     DISCORD_CLIENT_SECRET = var.seichi_portal_frontend__discord_client_secret
     SEICHI_PROXY_SECRET   = random_password.seichi_portal_proxy_secret.result
-    TURNSTILE_SITE_KEY    = var.seichi_portal_frontend__turnstile_site_key
+    TURNSTILE_SITE_KEY    = cloudflare_turnstile_widget.seichi_portal.sitekey
   }
 
   type = "Opaque"

--- a/terraform/onp_cluster_minecraft_secrets.tf
+++ b/terraform/onp_cluster_minecraft_secrets.tf
@@ -279,8 +279,9 @@ resource "kubernetes_secret_v1" "seichi_portal_backend_secrets" {
   }
 
   data = {
-    DISCORD_BOT_TOKEN   = var.seichi_portal_backend__discord_bot_token
-    SEICHI_PROXY_SECRET = random_password.seichi_portal_proxy_secret.result
+    DISCORD_BOT_TOKEN    = var.seichi_portal_backend__discord_bot_token
+    SEICHI_PROXY_SECRET  = random_password.seichi_portal_proxy_secret.result
+    TURNSTILE_SECRET_KEY = var.seichi_portal_backend__turnstile_secret_key
     MINECRAFT_BANS_DATABASE_URL = format(
       "mysql://litebans:%s@mariadb:3306/litebans_gigantic_prod",
       urlencode(random_password.minecraft__prod_mariadb_litebans_password.result),
@@ -303,6 +304,7 @@ resource "kubernetes_secret_v1" "seichi_portal_frontend_secrets" {
     DISCORD_CLIENT_ID     = var.seichi_portal_frontend__discord_client_id
     DISCORD_CLIENT_SECRET = var.seichi_portal_frontend__discord_client_secret
     SEICHI_PROXY_SECRET   = random_password.seichi_portal_proxy_secret.result
+    TURNSTILE_SITE_KEY    = var.seichi_portal_frontend__turnstile_site_key
   }
 
   type = "Opaque"


### PR DESCRIPTION
## 概要

- Turnstile 対応済みの seichi-portal-frontend 0.3.7 を digest 固定で反映
- backend のイメージは更新せず、Turnstile の有効化設定・Secret・Siteverify egress を追加
- Cloudflare Turnstile Widgetを `cloudflare_turnstile_widget` としてTerraform管理
- Widgetの `sitekey`／`secret` を用途別のKubernetes Secretへ直接配線し、手動のTerraform変数を削除

## 確認事項

- `git diff --check` 成功
- `terraform -chdir=terraform fmt -check` 成功
- backend image 行に変更がないこと、frontend/backendのSecretが分離されていることを差分確認
- 独立レビューでTerraform配線のMUST FIXなし
- `terraform validate` はローカルProviderバイナリのplugin handshakeエラーで未完了
- Cloudflareへの実際のplan/applyと実クラスタ疎通は未実施
- 恒久テストは追加せず、CIのvalidate/plan/applyと適用後の実経路確認で担保

## 適用前の確認

- 本番Cloudflareに既存Widgetがある場合は、apply前に `terraform -chdir=terraform import cloudflare_turnstile_widget.seichi_portal <account_id>/<sitekey>` を実行し、その後planで差分・置換の有無を確認する
- Cloudflareの認証情報にTurnstile Sites Write相当の権限が必要
- WidgetのsecretはTerraform stateとKubernetes Secretへ保存されるため、既存のstateアクセス管理を前提とする
- 旧 `TF_VAR_*TURNSTILE*` GitHub Actions Secretはコードから参照されなくなるため、適用確認後に削除可能
- 既存のCilium default-denyは変更していない。現在audit modeのため、enforcement移行時は既存 #5672の整理が別途必要

🤖 Generated with Codex