### PR TITLE
fix: s5のmemory余白とSync Window通知を調整

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
@@ -316,20 +316,6 @@ spec:
                   group_wait: 30s
                   group_interval: 5m
                   repeat_interval: 4h
-                # seichi-minecraft AppProject の allow Sync Window (毎日 07:00-08:00 JST)
-                # と同じ時間帯は、StatefulSet の更新で一時的に発火しうる memory limit
-                # アラートの Discord 通知だけを抑止する。Full GC など他の重大アラートは
-                # maintenance 中も通知する。Sync Window を変更した場合はこの interval も
-                # 同時に更新すること。
-                - receiver: "discord-infra"
-                  matchers:
-                    - notify = "discord"
-                    - namespace = "seichi-minecraft"
-                    - alertname = "McserverMemoryNearLimit"
-                  group_by: ["alertname", "namespace", "service"]
-                  group_wait: 30s
-                  group_interval: 5m
-                  repeat_interval: 4h
                   mute_time_intervals:
                     - "argocd-seichi-minecraft-sync-window"
                 - receiver: "discord-infra"
@@ -339,7 +325,13 @@ spec:
                   group_wait: 30s
                   group_interval: 5m
                   repeat_interval: 4h
+                  mute_time_intervals:
+                    - "argocd-seichi-minecraft-sync-window"
             time_intervals:
+              # seichi-minecraft AppProject の allow Sync Window と同じ時間帯は、
+              # Prometheus / Loki から Alertmanager を経由する全 Discord 通知を抑止する。
+              # アラートの評価・状態記録は継続し、window 終了後も firing なら通知する。
+              # Sync Window を変更した場合はこの interval も同時に更新すること。
               - name: "argocd-seichi-minecraft-sync-window"
                 time_intervals:
                   - times:

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
@@ -316,6 +316,22 @@ spec:
                   group_wait: 30s
                   group_interval: 5m
                   repeat_interval: 4h
+                # seichi-minecraft AppProject の allow Sync Window (毎日 07:00-08:00 JST)
+                # と同じ時間帯は、StatefulSet の更新で一時的に発火しうる memory limit
+                # アラートの Discord 通知だけを抑止する。Full GC など他の重大アラートは
+                # maintenance 中も通知する。Sync Window を変更した場合はこの interval も
+                # 同時に更新すること。
+                - receiver: "discord-infra"
+                  matchers:
+                    - notify = "discord"
+                    - namespace = "seichi-minecraft"
+                    - alertname = "McserverMemoryNearLimit"
+                  group_by: ["alertname", "namespace", "service"]
+                  group_wait: 30s
+                  group_interval: 5m
+                  repeat_interval: 4h
+                  mute_time_intervals:
+                    - "argocd-seichi-minecraft-sync-window"
                 - receiver: "discord-infra"
                   matchers:
                     - notify = "discord"
@@ -323,6 +339,13 @@ spec:
                   group_wait: 30s
                   group_interval: 5m
                   repeat_interval: 4h
+            time_intervals:
+              - name: "argocd-seichi-minecraft-sync-window"
+                time_intervals:
+                  - times:
+                      - start_time: "07:00"
+                        end_time: "08:00"
+                    location: "Asia/Tokyo"
             receivers:
               - name: "null"
               # discord_configs ではなく webhook_configs で Discord ネイティブ JSON を

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/stateful-set.yaml
@@ -94,10 +94,10 @@ spec:
         - resources:
             requests:
               cpu: 2
-              memory: 12Gi
+              memory: 16Gi
             limits:
               cpu: 4
-              memory: 12Gi
+              memory: 16Gi
           env:
             - name: MEMORY
               value: 8G


### PR DESCRIPTION
## 変更内容

- `mcserver--s5` の minecraft container の memory request / limit を 12Gi から 16Gi へ引き上げる
  - JVM heap (`MEMORY=8G`) は変更しない
- Argo CD の `seichi-minecraft` Sync Window と同じ毎日 07:00–08:00 JSTを、Alertmanagerのtime intervalとして定義する
- 上記時間帯は`notify=discord`の全通知経路をmuteする
  - `discord-portal`と`discord-infra`の両方が対象
  - PrometheusルールとLoki rulerのどちらから送信されたアラートも対象
  - アラートの評価・状態記録は継続する
  - 8:00以降もFIRINGなら通知する

## 背景

OOM対策後のs5はRSS増加が大幅に抑えられている一方、JFR・GCログ・ワールドI/O等のpage cacheを含むworking setが12Giのcgroup limit付近まで到達していた。

workerのmemory allocatableは各88.29Giで、現在のrequestsはwk-1/2/3が68.88/56.68/64.47Gi。s5を16Giへ変更して現配置のwk-1に残った場合も72.88Gi（82.5%）で、クラスタ全体は194.02/264.86Gi（73.3%）となる。s5 PVCはネットワークiSCSIでnode affinityもないため、再配置余地もある。

また、毎朝のArgo CD Sync Window中はStatefulSet更新だけでなくportal系を含む複数のアプリ更新が行われるため、この時間帯はAlertmanagerからDiscordへの通知を一律で抑止する。

## 影響

- 07:00–08:00 JSTは、portal・infra・cluster-wideを含む全Discord通知が送信されない
- Alertmanager以外の独自Discord通知処理には影響しない
- Sync Windowの時刻を変更する場合はAlertmanagerのtime intervalも同時に更新する必要がある

## 検証

- `git diff --check`
- Ruby/Psychによる変更YAMLのparse
- kube-prometheus-stack 88.2.0の`helm template`
- 生成された`notify=discord` routeがportal/infraの2本で、両方にmute intervalが設定されていることをassert
- alertname限定routeが残っていないことをassert
- Alertmanager v0.33.1の`amtool check-config`
- s5 StatefulSetのserver-side dry-run
