### PR TITLE
fix: separate portal browser alert fingerprints

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/loki-alert-rules/seichi-portal-browser.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/loki-alert-rules/seichi-portal-browser.yaml
@@ -17,14 +17,19 @@ data:
       - name: seichi-portal-browser-exceptions
         interval: 1m
         rules:
-          # type (JS の例外クラス名: TypeError 等) ごとに集計して通知する。
-          # type の値域はブラウザ組み込み例外クラス + アプリ定義例外程度で
-          # 低カーディナリティ。ルール群全体の安全弁は loki の limits_config
-          # (ruler_max_rules_per_rule_group / ruler_max_rule_groups_per_tenant)
+          # type (JS の例外クラス名) だけでは異なる原因が同じ通知に混ざるため、
+          # Faro receiver が付与する hash まで含めて例外を分離する。
+          # 発生元をブラウザの same-origin policy により特定できない Script error.
+          # は単一クライアントで大量発生しうるため、下の低優先度ルールで扱う。
           - alert: SeichiPortalBrowserException
             expr: |
-              sum by (type) (
-                count_over_time({app_name="seichi-portal-browser", kind="exception"} | logfmt [10m])
+              sum by (type, hash) (
+                count_over_time(
+                  {app_name="seichi-portal-browser", kind="exception"}
+                    | logfmt
+                    | value != "Script error."
+                  [10m]
+                )
               ) > 0
             labels:
               severity: warning
@@ -33,4 +38,28 @@ data:
               service: seichi-portal-browser
             annotations:
               summary: seichi-portal のブラウザで {{ $labels.type }} が発生しています
-              description: 直近 10 分間にブラウザ例外 ({{ $labels.type }}) が記録されました。詳細は Loki で {app_name="seichi-portal-browser", kind="exception"} を実行して確認する。
+              description: 直近 10 分間にブラウザ例外 ({{ $labels.type }}, hash={{ $labels.hash }}) が記録されました。詳細は Loki で {app_name="seichi-portal-browser", kind="exception"} | logfmt | hash="{{ $labels.hash }}" を実行して確認する。
+
+          # Script error. はクロスオリジン等のため詳細を取得できない不透明な例外。
+          # 1セッション内の画面遷移ごとの連発では通知せず、30分内に異なる3つ以上の
+          # Faro session で観測された場合だけ、広範な障害の兆候として通知する。
+          - alert: SeichiPortalBrowserOpaqueScriptError
+            expr: |
+              count(
+                sum by (session_id) (
+                  count_over_time(
+                    {app_name="seichi-portal-browser", kind="exception"}
+                      | logfmt
+                      | value = "Script error."
+                    [30m]
+                  )
+                )
+              ) >= 3
+            labels:
+              severity: info
+              notify: discord
+              team: portal
+              service: seichi-portal-browser
+            annotations:
+              summary: seichi-portal の不透明な Script error. が複数セッションで発生しています
+              description: 直近 30 分間に Script error. が3つ以上のブラウザセッションで記録されました。詳細は Loki で {app_name="seichi-portal-browser", kind="exception"} | logfmt | value="Script error." を実行して確認する。


### PR DESCRIPTION
## 概要

- 通常のブラウザ例外を `type` だけでなくFaro receiverの `hash` ごとに分離し、異なる原因が同じ通知へ混ざらないようにしました。
- 発生元を特定できない `Script error.` を通常warningから除外しました。
- `Script error.` は30分内に異なる3つ以上のFaro sessionで観測された場合だけ、独立したinfo通知にします。

アプリ側のTurnstile競合修正とテレメトリのURLサニタイズは GiganticMinecraft/seichi-portal-frontend#1019 で対応しています。

## 根本原因と閾値の根拠

2026-08-11 13:05〜15:14 JSTの通知をGrafana/Lokiで調査すると、20例外中19件が同じhashの `Script error.` でした。これらはFirefox 153.2 / iOS 18.7の同系統クライアントに集中し、画面遷移ごとに1セッションから最大16件発生していました。

一方、同時間帯の通常例外は別hashのTurnstile初期化失敗1件でした。従来は両方とも `type=Error` だけで集約されるため、原因も対応優先度も異なる例外が同じalert instanceに混在していました。

MDNのsame-origin policyでも、cross-origin scriptのsyntax error detailsは同一originの場合に限って取得できると説明されています: https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Same-origin_policy#cross-origin_script_api_access

## 検証

- Grafana MCPで両方のLogQLを実Lokiに対して実行
  - 通常ルールは対象時刻でTurnstile例外1件を `type + hash` 付きで返す
  - opaqueルールは昨日の単一クライアント集中を閾値未満として扱う
- `kubectl create --dry-run=client -f ... -o yaml` でConfigMapをparse
- `git diff --check`
