### PR TITLE
fix(seichi-minecraft): s2/s3 のメモリ余白を拡大

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/stateful-set.yaml
@@ -73,10 +73,10 @@ spec:
         - resources:
             requests:
               cpu: 3
-              memory: 16Gi
+              memory: 18Gi
             limits:
               cpu: 4
-              memory: 16Gi
+              memory: 18Gi
           env:
             - name: MEMORY
               value: 10G

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/stateful-set.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/stateful-set.yaml
@@ -73,10 +73,10 @@ spec:
         - resources:
             requests:
               cpu: 2
-              memory: 16Gi
+              memory: 18Gi
             limits:
               cpu: 4
-              memory: 16Gi
+              memory: 18Gi
           env:
             - name: MEMORY
               value: 10G


### PR DESCRIPTION
## 概要

- s2/s3 の Minecraft コンテナの memory requests/limits を 16Gi から 18Gi に変更
- `MEMORY=10G` は維持し、heap 以外の native memory に 2Gi 分の余白を追加
- 8/23 の Full GC storm で heap が約99.5%まで達した一方、container working set は約74%だったため、cgroup OOM 余裕を確保する

## 確認事項

- Grafana で worker-1/2 の allocatable/request を確認。現状の request slack は wk-1 約29.6Gi、wk-2 約35.2Gi
- `git diff --check` を実行
- 対象 YAML の差分を確認

## 補足

- この変更は Full GC/Old Gen の根本原因を解消するものではなく、native memory と cgroup OOM の余裕を増やすもの
- s2/s3 には node affinity がないため、適用時は一台ずつ rollout 状態と Pod の配置を確認する
- JFR/GC ログ導入と liveness probe の見直しは別 PR

🤖 Generated with Codex