### PR TITLE
seichi-portal を最新版へ更新して検索障害時の稼働を維持する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
@@ -29,13 +29,14 @@ spec:
     spec:
       containers:
         - name: seichi-portal-backend
-          image: ghcr.io/giganticminecraft/seichi-portal-backend:0.2.6@sha256:b56414440c27d68d5853aa36bee32c169c8b0d9802a2c37d85adf02e936248a8
+          image: ghcr.io/giganticminecraft/seichi-portal-backend:0.2.7@sha256:b69c3203efb564580a734217d48018a5bda1071936c0b7de154c9b6898c366f0
           ports:
             - name: http
               containerPort: 9000
               protocol: TCP
-          # /health は MariaDB、Meilisearch、RabbitMQ、DiscordBot まで確認する。
-          # rollout 中は依存先を含めて利用可能になった Pod だけを Service に載せる。
+          # /health は MariaDB と Valkey を必須依存として確認する。
+          # Meilisearch、RabbitMQ、Discord Bot の障害は degraded として報告されるが、
+          # 主要機能を提供できる Pod は Service から外さない。
           readinessProbe:
             httpGet:
               path: /health

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-frontend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-frontend/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: seichi-portal-frontend
-          image: ghcr.io/giganticminecraft/seichi-portal-frontend:0.3.9@sha256:fc5bebd0fc36844b9e6542c5aefc0ea1edde64791ac2cd48c3645b9d7e503377
+          image: ghcr.io/giganticminecraft/seichi-portal-frontend:0.3.11@sha256:a9b9d9b4b90b00567fe7ab94b37415387cbdeeb9c7a9ee43da5ca30440654034
           ports:
             - name: http
               containerPort: 3000


### PR DESCRIPTION
## 概要

- seichi-portal-backend を 0.2.7、seichi-portal-frontend を 0.3.11 へ更新する
- backend 0.2.7 の health check 改善を反映し、Meilisearch、RabbitMQ、Discord Bot の障害時も主要機能を提供できる Pod を Service の通信経路に残す
- readiness probe のコメントを、MariaDB と Valkey が必須依存で、その他は degraded として扱う新しい契約へ合わせる

## 確認事項

- Argo CD で、現行 backend Pod は Running だが 0/1 Ready、frontend Pod は 1/1 Ready であることを確認した
- backend Pod のイベントで `/health` が 503 を返して readiness probe に失敗していること、ログで Meilisearch の `/stats` への接続が失敗していることを確認した
- Meilisearch Pod が CrashLoopBackOff で、再起動を繰り返していることを確認した
- backend 0.2.7 のリリース内容に、任意依存の障害を許容する readiness、Meilisearch/RabbitMQ の障害で起動を止めない変更、検索障害を 503 に限定する変更が含まれることを確認した
- GHCR の OCI index digest が、backend 0.2.7 は `sha256:b69c3203efb564580a734217d48018a5bda1071936c0b7de154c9b6898c366f0`、frontend 0.3.11 は `sha256:a9b9d9b4b90b00567fe7ab94b37415387cbdeeb9c7a9ee43da5ca30440654034` であることを確認した
- `yq` で変更した 2 ファイルを読み込み、YAML の構文に問題がないことを確認した
- `git diff --check` が成功した

## 補足

- PR 作成時点ではマニフェストをクラスタへ適用していないため、更新後の rollout と readiness の回復は未確認

🤖 Generated with Codex