### PR TITLE
feat(backup): proxmox-backup-client を焼き込んだ pbs-client イメージを追加

### DIFF
--- a/.github/workflows/pbs_client.yaml
+++ b/.github/workflows/pbs_client.yaml
@@ -1,0 +1,138 @@
+name: pbs-client image
+on:
+  push:
+    paths:
+      - ".github/workflows/pbs_client.yaml"
+      - "docker-images/pbs-client/**"
+  # Debian ベースのイメージなので、base image の脆弱性修正を取り込むために
+  # 定期的にリビルドする (毎週月曜 04:00 JST = 19:00 UTC 日曜)
+  schedule:
+    - cron: "0 19 * * 0"
+  workflow_dispatch:
+
+env:
+  IMAGE: ghcr.io/giganticminecraft/pbs-client
+
+jobs:
+  build-image:
+    name: Build docker image (and publish on main)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      security-events: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        with:
+          images: ${{ env.IMAGE }}
+          # 1.0.0 は再 push される安定タグ。マニフェスト側は 1.0.0@sha256:... で参照し、
+          # digest の更新は Renovate が追従する (mod-downloader / mcserver 系と同じ方式)
+          tags: |
+            type=sha,prefix=sha-,suffix=,format=short
+            type=schedule,pattern={{date 'YYYYMMDD'}}
+            type=raw,value=1.0.0
+
+      # push 前に、ワークフローが実際に使うコマンドが動くことを確認する。
+      # ここで load したイメージはローカルタグで、push されるものとは別。
+      - name: Build for smoke test
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: ./docker-images/pbs-client/
+          builder: ${{ steps.buildx.outputs.name }}
+          load: true
+          tags: pbs-client:smoke-test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test
+        run: |
+          set -eux
+          # --network none で起動し、実行時に一切ネットワークへ出ずに
+          # 各ワークフローが呼ぶコマンドが動くことを確認する。
+          # 「実行時に Proxmox の CDN へ触れない」ことが本イメージの存在意義なので、
+          # ここがこの CI で最も重要な検証になる。
+          docker run --rm --network none pbs-client:smoke-test sh -eux -c '
+            proxmox-backup-client version
+            aws --version
+            zstd --version
+            python3 -V
+            tar --version
+          '
+
+          # 焼き込んだバージョンが Dockerfile の指定どおりであること
+          docker run --rm --network none pbs-client:smoke-test \
+            proxmox-backup-client version | grep -F "$(grep -oP '^ARG PBS_CLIENT_VERSION=\K[\d.]+(?=-)' docker-images/pbs-client/Dockerfile)"
+
+      - name: Build (and push if on main)
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: ./docker-images/pbs-client/
+          builder: ${{ steps.buildx.outputs.name }}
+          push: ${{ github.ref == 'refs/heads/main' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          sbom: true
+          provenance: true
+          cache-from: type=gha
+          # すべてのビルドステージのすべてのレイヤーをキャッシュして欲しいのでmode=max
+          cache-to: type=gha,mode=max
+
+      - name: Sign container image with Cosign
+        if: github.ref == 'refs/heads/main'
+        run: |
+          # ghcr.io は OCI 1.1 referrers API 非対応で、cosign v3 デフォルトの bundle 形式の
+          # 署名は Kyverno が発見できないため、レガシー形式 (.sig タグ) で署名する
+          cosign sign --yes --new-bundle-format=false --use-signing-config=false \
+            ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
+        env:
+          COSIGN_EXPERIMENTAL: 1
+
+      # Kyverno のポリシー (verify-image-signatures.yaml) と同じ条件で検証し、
+      # 署名と検証側のモードがズレた瞬間に CI を fail させる。
+      - name: Verify signature like Kyverno does
+        if: github.ref == 'refs/heads/main'
+        run: |
+          cosign verify \
+            --certificate-identity-regexp 'https://github\.com/GiganticMinecraft/.+' \
+            --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+            ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
+
+          # 素の cosign verify は bundle 形式も透過的に読めてしまい形式のズレを
+          # 検出できないため、レガシー形式 (.sig タグ) の存在も別途確認する
+          docker buildx imagetools inspect "$(cosign triangulate ${{ env.IMAGE }}@${{ steps.build.outputs.digest }})"
+
+      - name: Run Trivy vulnerability scanner
+        if: steps.build.outputs.digest != ''
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          ignore-unfixed: true
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        if: always() && steps.build.outputs.digest != ''
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/docker-images/pbs-client/Dockerfile
+++ b/docker-images/pbs-client/Dockerfile
@@ -1,0 +1,86 @@
+# syntax=docker/dockerfile:1
+
+# Argo Workflows のバックアップ/リストア用イメージ。
+#
+# 以前は各ワークフローが実行時に download.proxmox.com / enterprise.proxmox.com から
+# proxmox-backup-client を apt install していたが、Proxmox の GeoDNS が疎通しない CDN
+# ノード (sg2.cdn.proxmox.com = 117.120.5.0/24, 2400:ed00:3::/64) を一定確率で返すため、
+# バックアップが確率的に失敗していた (garage のバックアップで 51/185 = 27.6% が失敗)。
+# 依存をイメージに焼き込むことで、実行時に Proxmox の CDN へ触れないようにする。
+
+# AWS CLI v2 は self-contained bundle (専用の Python 同梱) なので、
+# builder で展開して成果物だけを最終イメージに持ち込む。
+FROM mirror.gcr.io/debian:13 AS awscli-builder
+
+# renovate: datasource=github-releases depName=aws/aws-cli
+ARG AWSCLI_VERSION=2.36.34
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    set -eux; \
+    printf 'Acquire::Retries "8";\nAcquire::ForceIPv4 "true";\n' > /etc/apt/apt.conf.d/99-retries; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl unzip; \
+    # curl の --retry は使わない。curl は 1 プロセス内で名前解決をキャッシュするため、
+    # --retry では同じ IP を引き続けてしまう (Debian の curl は名前解決キャッシュを
+    # 無効化する --dns-cache-timeout を持たない)。プロセスごと起動し直すことで
+    # 毎回 DNS を引き直し、別の CDN ノードに当たる機会を作る。
+    for i in 1 2 3 4 5 6 7 8; do \
+      curl -fsSL --connect-timeout 10 --max-time 300 \
+        "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip" \
+        -o /tmp/awscliv2.zip && break; \
+      echo "retry ${i}: awscli download"; \
+      sleep 3; \
+    done; \
+    # for ループの失敗は set -e で拾えないので、成果物の有無で明示的に検証する
+    test -s /tmp/awscliv2.zip; \
+    unzip -q /tmp/awscliv2.zip -d /tmp; \
+    /tmp/aws/install; \
+    rm -rf /tmp/awscliv2.zip /tmp/aws
+
+FROM mirror.gcr.io/debian:13
+
+LABEL org.opencontainers.image.authors="outductor <inductor.kela+seichi@gmail.com>"
+LABEL org.opencontainers.image.url="https://github.com/GiganticMinecraft/seichi_infra"
+LABEL org.opencontainers.image.source="https://github.com/GiganticMinecraft/seichi_infra/blob/main/docker-images/pbs-client/Dockerfile"
+LABEL org.opencontainers.image.description="proxmox-backup-client, AWS CLI v2, zstd, python3 を同梱した Argo Workflows のバックアップ/リストア用イメージ"
+
+# renovate: datasource=deb depName=proxmox-backup-client
+ARG PBS_CLIENT_VERSION=4.2.5-1
+
+# ビルド時は Proxmox の CDN に触れざるを得ないため、リトライを厚くしておく。
+# ここでコケても CI を再実行すれば済み、バックアップ本番には影響しない。
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    set -eux; \
+    printf 'Acquire::Retries "8";\nAcquire::ForceIPv4 "true";\n' > /etc/apt/apt.conf.d/99-retries; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl; \
+    # 死んだ CDN ノードを掴んだときに別ノードを引き直せるよう、プロセスごとリトライする
+    # (理由は awscli-builder ステージのコメントを参照)
+    for i in 1 2 3 4 5 6 7 8; do \
+      curl -fsSL --connect-timeout 10 --max-time 120 \
+        https://enterprise.proxmox.com/debian/proxmox-release-trixie.gpg \
+        -o /etc/apt/trusted.gpg.d/proxmox-release-trixie.gpg && break; \
+      echo "retry ${i}: proxmox release key"; \
+      sleep 3; \
+    done; \
+    test -s /etc/apt/trusted.gpg.d/proxmox-release-trixie.gpg; \
+    echo "deb http://download.proxmox.com/debian/pbs-client trixie main" \
+      > /etc/apt/sources.list.d/pbs-client.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+      "proxmox-backup-client=${PBS_CLIENT_VERSION}" \
+      python3 \
+      zstd
+
+# /usr/local/bin/aws は bundle 内へのシンボリックリンクであり、COPY するとリンクが
+# 解決されて実体がコピーされてしまう。すると PyInstaller 製の aws が自分の隣
+# (/usr/local/bin) に libpython を探しに行って起動できなくなるため、bundle 本体だけを
+# 持ち込んでリンクは張り直す。
+COPY --link --from=awscli-builder /usr/local/aws-cli /usr/local/aws-cli
+RUN ln -s /usr/local/aws-cli/v2/current/bin/aws /usr/local/bin/aws
+
+# ワークフローは script テンプレートから /bin/sh を明示的に呼ぶが、
+# 単体で docker run したときに壊れて見えないようにしておく
+CMD ["/bin/sh"]

--- a/renovate.json5
+++ b/renovate.json5
@@ -205,6 +205,35 @@
       depNameTemplate: 'giganticminecraft/SrvStopper',
       versioningTemplate: 'semver',
     },
+    // pbs-client イメージが焼き込む proxmox-backup-client を追従する。
+    // Proxmox の apt リポジトリは公式 datasource が無いため deb datasource で直接読む。
+    // (実行時 apt install をやめた代わりに、バージョン更新はここに集約される)
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^docker-images/pbs-client/Dockerfile$/',
+      ],
+      matchStrings: [
+        '# renovate: datasource=deb depName=proxmox-backup-client\\nARG PBS_CLIENT_VERSION=(?<currentValue>[\\d.-]+)',
+      ],
+      datasourceTemplate: 'deb',
+      depNameTemplate: 'proxmox-backup-client',
+      registryUrlTemplate: 'http://download.proxmox.com/debian/pbs-client?suite=trixie&components=main&binaryArch=amd64',
+      versioningTemplate: 'deb',
+    },
+    // pbs-client イメージが焼き込む AWS CLI v2 を追従する
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^docker-images/pbs-client/Dockerfile$/',
+      ],
+      matchStrings: [
+        '# renovate: datasource=github-releases depName=aws/aws-cli\\nARG AWSCLI_VERSION=(?<currentValue>[\\d.]+)',
+      ],
+      datasourceTemplate: 'github-releases',
+      depNameTemplate: 'aws/aws-cli',
+      versioningTemplate: 'semver',
+    },
     // ノードの containerd / runc のピン留めバージョンを更新する
     // (node-runtime-updater DaemonSet がノード上のバイナリを追従させ、kured が再起動する)
     {


### PR DESCRIPTION
## 背景

バックアップ/リストア系の Argo Workflows が `run-backup` で確率的に失敗していた件の根本対策です。

失敗の直接原因は、各ワークフローが**実行時に** Proxmox の CDN から `proxmox-backup-client` を apt install していることでした。Proxmox の GeoDNS が **疎通しない CDN ノード** (`sg2.cdn.proxmox.com` = `117.120.5.0/24`, `2400:ed00:3::/64`) を一定確率で返すため、そこを掴んだ実行が落ちていました。

```
curl: (28) Failed to connect to enterprise.proxmox.com port 443 after 135155 ms
```
```
Err:4 http://download.proxmox.com/debian/pbs-client trixie InRelease
  Could not connect to download.proxmox.com:80 (117.120.5.231), connection timed out
Error: Unable to locate package proxmox-backup-client
```

### 確率の裏付け

権威 DNS に 30 回問い合わせた結果:

| ホスト | 死亡ノードを返す割合 |
|---|---|
| `enterprise.proxmox.com` | 2/30 (7%) → curl が exit 28 |
| `download.proxmox.com` | 6/30 (20%) → apt が exit 100 |

ワークフローは両方に依存するため、予測失敗率は `1 - 0.93 × 0.80 = 25.6%`。実測の `51/185 = 27.6%` とほぼ一致します。CNAME チェーンの TTL は 52 秒なので、1 実行の中でもリクエストごとに引き直されます。

死亡ノードは**ホームラボ外の別ネットワークからも 100% packet loss** であり、Proxmox 側の CDN ノード障害です。こちらから直せるものではないため、実行時に CDN へ触れない構成にします。

## 変更内容

| ファイル | 内容 |
|---|---|
| `docker-images/pbs-client/Dockerfile` | `proxmox-backup-client` 4.2.5-1 + AWS CLI v2 + zstd + python3 を同梱 (459MB) |
| `.github/workflows/pbs_client.yaml` | buildx → スモークテスト → cosign 署名 → Kyverno 同条件 verify → Trivy |
| `renovate.json5` | `deb` datasource で PBC、`github-releases` で AWS CLI を追従 |

- `proxmox-backup-client` はマニフェスト側で `4.0.14-1` に固定されたまま **18 バージョン塩漬け**になっていたため、最新の `4.2.5-1` に更新したうえで Renovate の追従対象にしました。
- Debian ベースなので、base image の脆弱性修正を取り込めるよう**週次リビルド**トリガーを設定しています。
- 署名は既存イメージと同じくレガシー Cosign 形式です (Kyverno `verify-ghcr-image-signatures` が `verifyDigest: true` で検証するため)。

## ビルド時の CDN 対策

ビルド時だけは CDN に触れざるを得ないため、リトライを厚くしています。

ここで一点ハマりどころがありました。**curl の `--retry` は効きません** — curl は 1 プロセス内で名前解決をキャッシュするため、リトライしても同じ死んだ IP を引き続けます。Debian の curl はキャッシュを無効化する `--dns-cache-timeout` を持たない (ビルドオプション外) ので、**プロセスごと起動し直すシェルループ**にして毎回 DNS を引き直すようにしました。apt 側は `Acquire::Retries "8"` と `Acquire::ForceIPv4 "true"` (IPv6 経路が無く先頭の試行が必ず無駄になるため)。

なお、ビルドがここでコケても CI を再実行すれば済み、**バックアップ本番には影響しません**。

## 検証

ローカルビルドで確認済みです。`--network none` で起動し、実行時にネットワークへ一切出ずに全コマンドが動くことがこのイメージの存在意義なので、CI のスモークテストもその形にしています。

```
client version: 4.2.5
aws-cli/2.36.34 Python/3.14.6 Linux/6.10.14-linuxkit exe/x86_64.debian.13
*** Zstandard CLI (64-bit) v1.5.7 ***
Python 3.13.5
tar (GNU tar) 1.35
```

`renovate.json5` は公式バリデータ v44.52.1 で `Config validated successfully` を確認しました。

## このあと

このPRがマージされて GHCR に `1.0.0` が push され digest が確定したら、11 個のマニフェストを本イメージ参照に移行する PR を出します (Kyverno の `verifyDigest: true` を満たすため digest 確定が先に必要)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017awcQ8pfQ98AJ6L4z3xbLy