### PR TITLE
feat(backup): バックアップ/リストアを pbs-client イメージへ移行

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/argo-workflows-backup.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/argo-workflows-backup.yaml
@@ -41,7 +41,7 @@ spec:
         # proxmox-backup-client と AWS CLI は pbs-client イメージに焼き込まれている。
         # 実行時に Proxmox の CDN へ取りに行くと、疎通しない CDN ノードを掴んだときに
         # バックアップごと落ちるため (詳細は docker-images/pbs-client/Dockerfile)。
-        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
+        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:054a8803d9d9a9ba855ee232128490432d5979c707b28155135de3a9000f1a4f
         command: ["/bin/sh", "-c"]
         source: |
           set -e

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/argo-workflows-backup.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/argo-workflows-backup.yaml
@@ -38,26 +38,13 @@ spec:
 
     - name: run-backup
       script:
-        image: debian:13
+        # proxmox-backup-client と AWS CLI は pbs-client イメージに焼き込まれている。
+        # 実行時に Proxmox の CDN へ取りに行くと、疎通しない CDN ノードを掴んだときに
+        # バックアップごと落ちるため (詳細は docker-images/pbs-client/Dockerfile)。
+        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
         command: ["/bin/sh", "-c"]
         source: |
           set -e
-
-          echo "=== Installing dependencies ==="
-          apt-get update
-          apt-get install -y curl unzip
-
-          # AWS CLI のインストール
-          curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
-          unzip -q /tmp/awscliv2.zip -d /tmp
-          /tmp/aws/install
-          rm -rf /tmp/awscliv2.zip /tmp/aws
-
-          # Proxmox Backup Client のインストール
-          echo "deb http://download.proxmox.com/debian/pbs-client trixie main" > /etc/apt/sources.list.d/pbs-client.list
-          curl -fsSL https://enterprise.proxmox.com/debian/proxmox-release-trixie.gpg -o /etc/apt/trusted.gpg.d/proxmox-release-trixie.gpg
-          apt-get update
-          apt-get install -y proxmox-backup-client
 
           echo "=== Dumping all Garage buckets via S3 API ==="
           date

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/argo-workflows-restore.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/argo-workflows-restore.yaml
@@ -26,26 +26,13 @@ spec:
 
     - name: run-restore
       script:
-        image: debian:13
+        # proxmox-backup-client と AWS CLI は pbs-client イメージに焼き込まれている。
+        # 実行時に Proxmox の CDN へ取りに行くと、疎通しない CDN ノードを掴んだときに
+        # リストアごと落ちるため (詳細は docker-images/pbs-client/Dockerfile)。
+        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
         command: ["/bin/sh", "-c"]
         source: |
           set -e
-
-          echo "=== Installing dependencies ==="
-          apt-get update
-          apt-get install -y curl unzip
-
-          # AWS CLI のインストール
-          curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
-          unzip -q /tmp/awscliv2.zip -d /tmp
-          /tmp/aws/install
-          rm -rf /tmp/awscliv2.zip /tmp/aws
-
-          # Proxmox Backup Client のインストール
-          echo "deb http://download.proxmox.com/debian/pbs-client trixie main" > /etc/apt/sources.list.d/pbs-client.list
-          curl -fsSL https://enterprise.proxmox.com/debian/proxmox-release-trixie.gpg -o /etc/apt/trusted.gpg.d/proxmox-release-trixie.gpg
-          apt-get update
-          apt-get install -y proxmox-backup-client
 
           echo "=== Restoring from PBS ==="
           RESTORE_DIR="/data/garage-restore"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/argo-workflows-restore.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-backup-to-pbs/argo-workflows-restore.yaml
@@ -29,7 +29,7 @@ spec:
         # proxmox-backup-client と AWS CLI は pbs-client イメージに焼き込まれている。
         # 実行時に Proxmox の CDN へ取りに行くと、疎通しない CDN ノードを掴んだときに
         # リストアごと落ちるため (詳細は docker-images/pbs-client/Dockerfile)。
-        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
+        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:054a8803d9d9a9ba855ee232128490432d5979c707b28155135de3a9000f1a4f
         command: ["/bin/sh", "-c"]
         source: |
           set -e

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/upload-world-to-garage/workflow-template.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/upload-world-to-garage/workflow-template.yaml
@@ -53,7 +53,7 @@ spec:
         # proxmox-backup-client / AWS CLI / zstd / python3 は pbs-client イメージに
         # 焼き込まれている。実行時に Proxmox の CDN へ取りに行くと、疎通しない
         # CDN ノードを掴んだときに落ちるため (詳細は docker-images/pbs-client/Dockerfile)。
-        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
+        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:054a8803d9d9a9ba855ee232128490432d5979c707b28155135de3a9000f1a4f
         command: ["/bin/sh", "-c"]
         source: |
           set -e

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/upload-world-to-garage/workflow-template.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-debug-minecraft/upload-world-to-garage/workflow-template.yaml
@@ -50,24 +50,16 @@ spec:
         parameters:
           - name: server-name
       script:
-        image: debian:13
+        # proxmox-backup-client / AWS CLI / zstd / python3 は pbs-client イメージに
+        # 焼き込まれている。実行時に Proxmox の CDN へ取りに行くと、疎通しない
+        # CDN ノードを掴んだときに落ちるため (詳細は docker-images/pbs-client/Dockerfile)。
+        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
         command: ["/bin/sh", "-c"]
         source: |
           set -e
 
           rm -rf /work/restore /work/pbs-cache
           mkdir -p /work/restore /work/pbs-cache
-
-          echo "=== Installing proxmox-backup-client ==="
-          apt update
-          apt install -y curl zstd python3
-
-          echo "Adding Proxmox Backup Client repository..."
-          echo "deb http://download.proxmox.com/debian/pbs-client trixie main" > /etc/apt/sources.list.d/pbs-client.list
-          curl -fsSL https://enterprise.proxmox.com/debian/proxmox-release-trixie.gpg -o /etc/apt/trusted.gpg.d/proxmox-release-trixie.gpg
-
-          apt update
-          apt install -y proxmox-backup-client=4.0.14-1
 
           echo "=== Finding latest {{inputs.parameters.server-name}} snapshot ==="
           LATEST_SNAPSHOT=$(proxmox-backup-client snapshot list \
@@ -95,13 +87,6 @@ spec:
 
           echo "=== Restore contents ==="
           ls -la /work/restore/
-
-          echo "=== Installing AWS CLI ==="
-          apt install -y unzip
-          curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
-          unzip -q /tmp/awscliv2.zip -d /tmp
-          /tmp/aws/install
-          rm -rf /tmp/awscliv2.zip /tmp/aws
 
           echo "=== Compressing and uploading each world ==="
           WORLD_NAMES="world_2 world_2_the_end world_SW world_SW_2 world_SW_3 world_SW_4 world_SW_nether world_SW_the_end"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/argo-workflows-backup.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/argo-workflows-backup.yaml
@@ -96,7 +96,7 @@ spec:
         # proxmox-backup-client は pbs-client イメージに焼き込まれている。
         # 実行時に Proxmox の CDN へ取りに行くと、疎通しない CDN ノードを掴んだ
         # ときにジョブごと落ちるため (詳細は docker-images/pbs-client/Dockerfile)。
-        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
+        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:054a8803d9d9a9ba855ee232128490432d5979c707b28155135de3a9000f1a4f
         command: ["/bin/sh", "-c"]
         source: |
           set -e

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/argo-workflows-backup.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/argo-workflows-backup.yaml
@@ -93,26 +93,13 @@ spec:
 
     - name: run-backup
       script:
-        image: debian:13
+        # proxmox-backup-client は pbs-client イメージに焼き込まれている。
+        # 実行時に Proxmox の CDN へ取りに行くと、疎通しない CDN ノードを掴んだ
+        # ときにジョブごと落ちるため (詳細は docker-images/pbs-client/Dockerfile)。
+        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
         command: ["/bin/sh", "-c"]
         source: |
           set -e
-
-          echo "Updating package lists..."
-          apt update
-
-          echo "Installing packages..."
-          apt install -y curl
-
-          echo "Adding Proxmox restore Client repository..."
-          echo "deb http://download.proxmox.com/debian/pbs-client trixie main" > /etc/apt/sources.list.d/pbs-client.list
-          curl -fsSL https://enterprise.proxmox.com/debian/proxmox-release-trixie.gpg -o /etc/apt/trusted.gpg.d/proxmox-release-trixie.gpg
-
-          echo "Updating package lists..."
-          apt update
-
-          echo "Installing proxmox-backup-client version 4.0.14-1..."
-          apt install -y proxmox-backup-client=4.0.14-1
 
           echo "Running backup..."
           proxmox-backup-client backup "${BACKUP_NAME}" \

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/argo-workflows-restore.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/argo-workflows-restore.yaml
@@ -72,7 +72,7 @@ spec:
         # proxmox-backup-client は pbs-client イメージに焼き込まれている。
         # 実行時に Proxmox の CDN へ取りに行くと、疎通しない CDN ノードを掴んだ
         # ときにジョブごと落ちるため (詳細は docker-images/pbs-client/Dockerfile)。
-        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
+        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:054a8803d9d9a9ba855ee232128490432d5979c707b28155135de3a9000f1a4f
         command: ["/bin/sh", "-c"]
         source: |
           set -e

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/argo-workflows-restore.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--lobby/argo-workflows-restore.yaml
@@ -69,26 +69,13 @@ spec:
 
     - name: run-restore
       script:
-        image: debian:13
+        # proxmox-backup-client は pbs-client イメージに焼き込まれている。
+        # 実行時に Proxmox の CDN へ取りに行くと、疎通しない CDN ノードを掴んだ
+        # ときにジョブごと落ちるため (詳細は docker-images/pbs-client/Dockerfile)。
+        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
         command: ["/bin/sh", "-c"]
         source: |
           set -e
-
-          echo "Updating package lists..."
-          apt update
-
-          echo "Installing packages..."
-          apt install -y curl
-
-          echo "Adding Proxmox restore Client repository..."
-          echo "deb http://download.proxmox.com/debian/pbs-client trixie main" > /etc/apt/sources.list.d/pbs-client.list
-          curl -fsSL https://enterprise.proxmox.com/debian/proxmox-release-trixie.gpg -o /etc/apt/trusted.gpg.d/proxmox-release-trixie.gpg
-
-          echo "Updating package lists..."
-          apt update
-
-          echo "Installing proxmox-backup-client version 4.0.14-1..."
-          apt install -y proxmox-backup-client=4.0.14-1
 
           echo "Deleting RESTORE_TARGET_DIR before restore..."
           rm -vrf ${RESTORE_TARGET_DIR}/*

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/argo-workflows-restore.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/argo-workflows-restore.yaml
@@ -72,7 +72,7 @@ spec:
         # proxmox-backup-client は pbs-client イメージに焼き込まれている。
         # 実行時に Proxmox の CDN へ取りに行くと、疎通しない CDN ノードを掴んだ
         # ときにジョブごと落ちるため (詳細は docker-images/pbs-client/Dockerfile)。
-        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
+        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:054a8803d9d9a9ba855ee232128490432d5979c707b28155135de3a9000f1a4f
         command: ["/bin/sh", "-c"]
         source: |
           set -e

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/argo-workflows-restore.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s1/argo-workflows-restore.yaml
@@ -69,26 +69,13 @@ spec:
 
     - name: run-restore
       script:
-        image: debian:13
+        # proxmox-backup-client は pbs-client イメージに焼き込まれている。
+        # 実行時に Proxmox の CDN へ取りに行くと、疎通しない CDN ノードを掴んだ
+        # ときにジョブごと落ちるため (詳細は docker-images/pbs-client/Dockerfile)。
+        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
         command: ["/bin/sh", "-c"]
         source: |
           set -e
-
-          echo "Updating package lists..."
-          apt update
-
-          echo "Installing packages..."
-          apt install -y curl
-
-          echo "Adding Proxmox restore Client repository..."
-          echo "deb http://download.proxmox.com/debian/pbs-client trixie main" > /etc/apt/sources.list.d/pbs-client.list
-          curl -fsSL https://enterprise.proxmox.com/debian/proxmox-release-trixie.gpg -o /etc/apt/trusted.gpg.d/proxmox-release-trixie.gpg
-
-          echo "Updating package lists..."
-          apt update
-
-          echo "Installing proxmox-backup-client version 4.0.14-1..."
-          apt install -y proxmox-backup-client=4.0.14-1
 
           echo "Deleting RESTORE_TARGET_DIR before restore..."
           rm -vrf ${RESTORE_TARGET_DIR}/*

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/argo-workflows-restore.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/argo-workflows-restore.yaml
@@ -72,7 +72,7 @@ spec:
         # proxmox-backup-client は pbs-client イメージに焼き込まれている。
         # 実行時に Proxmox の CDN へ取りに行くと、疎通しない CDN ノードを掴んだ
         # ときにジョブごと落ちるため (詳細は docker-images/pbs-client/Dockerfile)。
-        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
+        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:054a8803d9d9a9ba855ee232128490432d5979c707b28155135de3a9000f1a4f
         command: ["/bin/sh", "-c"]
         source: |
           set -e

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/argo-workflows-restore.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s2/argo-workflows-restore.yaml
@@ -69,26 +69,13 @@ spec:
 
     - name: run-restore
       script:
-        image: debian:13
+        # proxmox-backup-client は pbs-client イメージに焼き込まれている。
+        # 実行時に Proxmox の CDN へ取りに行くと、疎通しない CDN ノードを掴んだ
+        # ときにジョブごと落ちるため (詳細は docker-images/pbs-client/Dockerfile)。
+        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
         command: ["/bin/sh", "-c"]
         source: |
           set -e
-
-          echo "Updating package lists..."
-          apt update
-
-          echo "Installing packages..."
-          apt install -y curl
-
-          echo "Adding Proxmox restore Client repository..."
-          echo "deb http://download.proxmox.com/debian/pbs-client trixie main" > /etc/apt/sources.list.d/pbs-client.list
-          curl -fsSL https://enterprise.proxmox.com/debian/proxmox-release-trixie.gpg -o /etc/apt/trusted.gpg.d/proxmox-release-trixie.gpg
-
-          echo "Updating package lists..."
-          apt update
-
-          echo "Installing proxmox-backup-client version 4.0.14-1..."
-          apt install -y proxmox-backup-client=4.0.14-1
 
           echo "Deleting RESTORE_TARGET_DIR before restore..."
           rm -vrf ${RESTORE_TARGET_DIR}/*

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/argo-workflows-restore.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/argo-workflows-restore.yaml
@@ -72,7 +72,7 @@ spec:
         # proxmox-backup-client は pbs-client イメージに焼き込まれている。
         # 実行時に Proxmox の CDN へ取りに行くと、疎通しない CDN ノードを掴んだ
         # ときにジョブごと落ちるため (詳細は docker-images/pbs-client/Dockerfile)。
-        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
+        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:054a8803d9d9a9ba855ee232128490432d5979c707b28155135de3a9000f1a4f
         command: ["/bin/sh", "-c"]
         source: |
           set -e

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/argo-workflows-restore.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s3/argo-workflows-restore.yaml
@@ -69,26 +69,13 @@ spec:
 
     - name: run-restore
       script:
-        image: debian:13
+        # proxmox-backup-client は pbs-client イメージに焼き込まれている。
+        # 実行時に Proxmox の CDN へ取りに行くと、疎通しない CDN ノードを掴んだ
+        # ときにジョブごと落ちるため (詳細は docker-images/pbs-client/Dockerfile)。
+        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
         command: ["/bin/sh", "-c"]
         source: |
           set -e
-
-          echo "Updating package lists..."
-          apt update
-
-          echo "Installing packages..."
-          apt install -y curl
-
-          echo "Adding Proxmox restore Client repository..."
-          echo "deb http://download.proxmox.com/debian/pbs-client trixie main" > /etc/apt/sources.list.d/pbs-client.list
-          curl -fsSL https://enterprise.proxmox.com/debian/proxmox-release-trixie.gpg -o /etc/apt/trusted.gpg.d/proxmox-release-trixie.gpg
-
-          echo "Updating package lists..."
-          apt update
-
-          echo "Installing proxmox-backup-client version 4.0.14-1..."
-          apt install -y proxmox-backup-client=4.0.14-1
 
           echo "Deleting RESTORE_TARGET_DIR before restore..."
           rm -vrf ${RESTORE_TARGET_DIR}/*

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/argo-workflows-restore.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/argo-workflows-restore.yaml
@@ -73,7 +73,7 @@ spec:
         # proxmox-backup-client は pbs-client イメージに焼き込まれている。
         # 実行時に Proxmox の CDN へ取りに行くと、疎通しない CDN ノードを掴んだ
         # ときにジョブごと落ちるため (詳細は docker-images/pbs-client/Dockerfile)。
-        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
+        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:054a8803d9d9a9ba855ee232128490432d5979c707b28155135de3a9000f1a4f
         command: ["/bin/sh", "-c"]
         source: |
           set -e

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/argo-workflows-restore.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s5/argo-workflows-restore.yaml
@@ -70,26 +70,13 @@ spec:
 
     - name: run-restore
       script:
-        image: debian:13
+        # proxmox-backup-client は pbs-client イメージに焼き込まれている。
+        # 実行時に Proxmox の CDN へ取りに行くと、疎通しない CDN ノードを掴んだ
+        # ときにジョブごと落ちるため (詳細は docker-images/pbs-client/Dockerfile)。
+        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
         command: ["/bin/sh", "-c"]
         source: |
           set -e
-
-          echo "Updating package lists..."
-          apt update
-
-          echo "Installing packages..."
-          apt install -y curl
-
-          echo "Adding Proxmox restore Client repository..."
-          echo "deb http://download.proxmox.com/debian/pbs-client trixie main" > /etc/apt/sources.list.d/pbs-client.list
-          curl -fsSL https://enterprise.proxmox.com/debian/proxmox-release-trixie.gpg -o /etc/apt/trusted.gpg.d/proxmox-release-trixie.gpg
-
-          echo "Updating package lists..."
-          apt update
-
-          echo "Installing proxmox-backup-client version 4.0.14-1..."
-          apt install -y proxmox-backup-client=4.0.14-1
 
           echo "Deleting RESTORE_TARGET_DIR before restore..."
           rm -vrf ${RESTORE_TARGET_DIR}/*

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/argo-workflows-restore.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/argo-workflows-restore.yaml
@@ -72,7 +72,7 @@ spec:
         # proxmox-backup-client は pbs-client イメージに焼き込まれている。
         # 実行時に Proxmox の CDN へ取りに行くと、疎通しない CDN ノードを掴んだ
         # ときにジョブごと落ちるため (詳細は docker-images/pbs-client/Dockerfile)。
-        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
+        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:054a8803d9d9a9ba855ee232128490432d5979c707b28155135de3a9000f1a4f
         command: ["/bin/sh", "-c"]
         source: |
           set -e

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/argo-workflows-restore.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mcserver--s7/argo-workflows-restore.yaml
@@ -69,26 +69,13 @@ spec:
 
     - name: run-restore
       script:
-        image: debian:13
+        # proxmox-backup-client は pbs-client イメージに焼き込まれている。
+        # 実行時に Proxmox の CDN へ取りに行くと、疎通しない CDN ノードを掴んだ
+        # ときにジョブごと落ちるため (詳細は docker-images/pbs-client/Dockerfile)。
+        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
         command: ["/bin/sh", "-c"]
         source: |
           set -e
-
-          echo "Updating package lists..."
-          apt update
-
-          echo "Installing packages..."
-          apt install -y curl
-
-          echo "Adding Proxmox restore Client repository..."
-          echo "deb http://download.proxmox.com/debian/pbs-client trixie main" > /etc/apt/sources.list.d/pbs-client.list
-          curl -fsSL https://enterprise.proxmox.com/debian/proxmox-release-trixie.gpg -o /etc/apt/trusted.gpg.d/proxmox-release-trixie.gpg
-
-          echo "Updating package lists..."
-          apt update
-
-          echo "Installing proxmox-backup-client version 4.0.14-1..."
-          apt install -y proxmox-backup-client=4.0.14-1
 
           echo "Deleting RESTORE_TARGET_DIR before restore..."
           rm -vrf ${RESTORE_TARGET_DIR}/*

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/workflow-template.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/workflow-template.yaml
@@ -209,7 +209,7 @@ spec:
         # proxmox-backup-client は pbs-client イメージに焼き込まれている。
         # 実行時に Proxmox の CDN へ取りに行くと、疎通しない CDN ノードを掴んだ
         # ときにジョブごと落ちるため (詳細は docker-images/pbs-client/Dockerfile)。
-        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
+        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:054a8803d9d9a9ba855ee232128490432d5979c707b28155135de3a9000f1a4f
         command: ["/bin/sh", "-c"]
         source: |
           set -e

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/workflow-template.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/workflows/mcserver-backup/workflow-template.yaml
@@ -206,27 +206,14 @@ spec:
         - name: pbs-tmpfs
           emptyDir: {}
       script:
-        image: mirror.gcr.io/debian:13
+        # proxmox-backup-client は pbs-client イメージに焼き込まれている。
+        # 実行時に Proxmox の CDN へ取りに行くと、疎通しない CDN ノードを掴んだ
+        # ときにジョブごと落ちるため (詳細は docker-images/pbs-client/Dockerfile)。
+        image: ghcr.io/giganticminecraft/pbs-client:1.0.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
         command: ["/bin/sh", "-c"]
         source: |
           set -e
-          
-          echo "Updating package lists..."
-          apt update
-          
-          echo "Installing packages..."
-          apt install -y curl
-          
-          echo "Adding Proxmox restore Client repository..."
-          echo "deb http://download.proxmox.com/debian/pbs-client trixie main" > /etc/apt/sources.list.d/pbs-client.list
-          curl -fsSL https://enterprise.proxmox.com/debian/proxmox-release-trixie.gpg -o /etc/apt/trusted.gpg.d/proxmox-release-trixie.gpg
-          
-          echo "Updating package lists..."
-          apt update
-          
-          echo "Installing proxmox-backup-client version 4.0.14-1..."
-          apt install -y proxmox-backup-client=4.0.14-1
-          
+
           echo "Running backup..."
           proxmox-backup-client backup "${BACKUP_NAME}" \
             --repository "${PBS_USER}@${PBS_HOST}:${PBS_DATASTORE}" \


### PR DESCRIPTION
## 概要

#5923 で追加した pbs-client イメージへ、11 個のワークフローを移行します。

実行時に Proxmox の CDN から `proxmox-backup-client` を apt install するのをやめ、依存を焼き込んだイメージを参照します。これにより **バックアップ実行時に Proxmox の CDN へ一切触れなくなり**、疎通しない CDN ノードを掴んで落ちる失敗モードが構造的に消えます。

背景と原因分析は #5923 に記載しています。

## 移行対象 (11 ファイル)

| ファイル | 焼き込みで不要になったもの |
|---|---|
| `cluster-wide-apps/garage-backup-to-pbs/argo-workflows-backup.yaml` | PBC + AWS CLI |
| `cluster-wide-apps/garage-backup-to-pbs/argo-workflows-restore.yaml` | PBC + AWS CLI |
| `seichi-debug-minecraft/upload-world-to-garage/workflow-template.yaml` | PBC + AWS CLI + zstd + python3 |
| `seichi-minecraft/mcserver--lobby/argo-workflows-backup.yaml` | PBC |
| `seichi-minecraft/mcserver--lobby/argo-workflows-restore.yaml` | PBC |
| `seichi-minecraft/mcserver--{s1,s2,s3,s5,s7}/argo-workflows-restore.yaml` | PBC |
| `seichi-minecraft/workflows/mcserver-backup/workflow-template.yaml` | PBC |

ロジック本体は変更していません。削除したのはインストール手順のみです (`-190 / +45` 行)。

## 副次的な効果

- 同一のインストール手順が **11 箇所に複製**されていたのが解消されます
- `proxmox-backup-client=4.0.14-1` のバージョン固定が 11 箇所に散っていたのが Dockerfile 1 箇所に集約され、Renovate の追従対象になります (移行前は upstream 4.2.5-1 に対して **18 バージョン塩漬け**でした)

## 検証

- **digest ピン留め**: `sha256:054a8803...` は CI で cosign が署名し、Kyverno と同条件の `cosign verify` が通った index digest と一致します。Kyverno が探すレガシー形式の署名タグ `sha256-054a8803....sig` が GHCR 上に存在することも確認済みです
- **イメージ**: pin した参照で GHCR から pull し、`--network none` で `proxmox-backup-client 4.2.5` / `aws-cli 2.36.34` / `zstd` / `python3` がすべて起動することを確認済み
- **マニフェスト**: 11 ファイルすべて実クラスタに対する `kubectl apply --dry-run=server` が通ることを確認済み (Argo の CRD スキーマ検証込み)
- **残存参照**: `seichi-onp-k8s/manifests/` 配下に `download.proxmox.com` / `enterprise.proxmox.com` / `awscli-exe-linux` の参照が **0 件**であることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017awcQ8pfQ98AJ6L4z3xbLy