### PR TITLE
fix(garage): add required pod anti-affinity to spread replicas across nodes

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/garage.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/garage.yaml
@@ -56,6 +56,18 @@ spec:
             cpu: 1000m
             memory: 2Gi
 
+        # replica が同一ノードに同居すると、そのノードの障害だけで
+        # replicationFactor=2 のクォーラムが割れる (2026-09-01 に wk-3 の
+        # フェンシングで garage-1/garage-2 が同時喪失し S3 が読み書き不能になった)
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: garage
+                    app.kubernetes.io/instance: garage
+                topologyKey: kubernetes.io/hostname
+
         environment:
           - name: GARAGE_ADMIN_TOKEN
             valueFrom:


### PR DESCRIPTION
## 背景

2026-09-01、wk-3 が SNR にフェンシング(強制リブート)された際、garage StatefulSet の 3 replica のうち **garage-1 と garage-2 の 2 つが wk-3 に同居**していたため、単一ノードの障害で S3 のクォーラム(replicationFactor=2)が割れ、Minecraft サーバー群のプラグイン/ワールドダウンロードが全滅した。

## 変更内容

garage の Helm values に `requiredDuringSchedulingIgnoredDuringExecution` の podAntiAffinity (topologyKey: `kubernetes.io/hostname`) を追加し、replica が同一ノードに同居しないことを保証する。

## 影響・ロールアウト

- 現在の配置は偶然 3 worker に分散済み (garage-0=wk-2, garage-1=wk-1, garage-2=wk-3) のため、制約は既に充足されており即時の再配置は起きない
- pod template 変更により RollingUpdate (逆序: garage-2 → 1 → 0) で 1 台ずつ再起動される。各ステップで 2/3 が稼働しクォーラムは維持される
- worker ノードの drain 中はその replica が Pending になる(他 2 ノードは占有済みのため)が、これは同居を許すより安全側の挙動

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014EL6SRhY6vZwy34r6ShvbK