### PR TITLE
feat(prometheus): CP ノードの haproxy (:8405) スクレイプジョブを追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
@@ -243,6 +243,14 @@ spec:
                 - 192.168.32.11:2381
                 - 192.168.32.12:2381
                 - 192.168.32.13:2381
+            # CP ノード上の K8s API 用 haproxy (systemd 管理、frontend prometheus :8405)
+            - job_name: 'haproxy'
+              scheme: http
+              static_configs:
+              - targets:
+                - 192.168.32.11:8405
+                - 192.168.32.12:8405
+                - 192.168.32.13:8405
         additionalPrometheusRulesMap:
           thanos:
             groups:


### PR DESCRIPTION
## 概要

CP 3台の K8s API 用 haproxy (systemd 管理) は `frontend prometheus` (:8405) で prometheus-exporter を公開しているが、これをスクレイプする job が存在せずメトリクスが未収集だった。kube-etcd と同じ static_configs パターンで `additionalScrapeConfigs` に job を追加する。

## 背景

- 2026-09-01 の haproxy 3.4.4 更新作業中に、cp-1 だけ `frontend prometheus` が無い設定ドリフトを発見 → cp-1 にも追加済み(ノード側作業)で 3台とも :8405 応答を確認済み
- その際、Prometheus 側に haproxy の scrape job 自体が無いことも判明したため本 PR で追加

## 反映後の確認

`{job="haproxy"}` で `haproxy_*` メトリクス(フロントエンド/バックエンドの状態、K8s API バックエンド 3台の UP/DOWN 等)が収集される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018g9TUZqxNxco5SKSabbDn3