### PR TITLE
feat: Redmine 移行用の一回限り Job を追加

### DIFF
--- a/docs/runbooks/seichi-portal-redmine-importer.md
+++ b/docs/runbooks/seichi-portal-redmine-importer.md
@@ -1,0 +1,271 @@
+# SeichiPortal への Redmine 移行手順
+
+## 目的と前提
+
+Redmine の issue、journal comment、issue relation を SeichiPortal のフォーム回答へ移行するための、
+一回限りの Kubernetes Job の運用手順。Importer は次の固定 image を使用する。
+
+```text
+ghcr.io/giganticminecraft/seichi-portal-redmine-importer:163de71799135a2445b99707cde02bf5621eea18@sha256:5406a8b58d56020bb6256711a73ca25a5bacb99fe8452ec3b557a50e5dede9cf
+```
+
+この Job は Redmine API から GET するだけで、Redmine へ書き込まない。Portal DB への保存は image 内の
+backend の Domain / Usecase / Repository 経由で行い、backend HTTP API、Redis、RabbitMQ、Meilisearch には
+接続しない。
+
+SQL dump は、このリポジトリの Git、ConfigMap、Secret、image のいずれにも保存しない。バックアップと
+復元は、運用者が承認済みの DB 運用経路で行う。
+
+## Secret の事前準備
+
+既存の seichi_infra は、sensitive な Terraform variable を GitHub Actions の Secret から渡し、
+Terraform の `kubernetes_secret_v1` resource で Kubernetes Secret を作成している。この移行でも同じ方式を
+使う。
+
+1. この PR を merge する前に、GitHub Actions の repository secret として
+   `TF_VAR_SEICHI_PORTAL_REDMINE_IMPORTER__API_KEY` を out-of-band で登録する。値は GitHub の Secret
+   設定画面または標準入力を使う CLI から登録し、コマンドライン引数、シェル履歴、ログへ出さない。
+2. この PR の merge 後、既存の Terraform apply workflow が成功することを確認する。workflow は Secret の
+   値を Terraform variable `seichi_portal_redmine_importer__api_key` に渡し、namespace
+   `seichi-minecraft` の `seichi-portal-redmine-importer-credentials` Secret に
+   `REDMINE_API_KEY` として保存する。
+3. Kubernetes Secret の存在と `REDMINE_API_KEY` key の存在だけを確認する。Secret の値は表示しない。
+
+API key と DB password の値は、Git、YAML、Job の args、ログ、README に書かない。移行完了後、Job と
+NetworkPolicy を prune したことを確認してから、Terraform の Secret resource／variable を削除する cleanup
+PR を作成し、その merge 後に GitHub Actions の repository secret も削除する。
+
+## ArgoCD の実行 gate
+
+`seichi-minecraft-seichi-portal-redmine-importer` は ApplicationSet が生成する Application である。base の
+Job と CiliumNetworkPolicy には `argocd.argoproj.io/sync-options: Skip` が付いているため、この PR を merge
+しただけでは live resource は作成されない。
+
+DB 復元と `plan` の確認後、運用者が Job と NetworkPolicy の `Skip` annotation だけを削除する有効化 PR を
+作成して merge する。base Job の `args` は常に `["import"]` のままにする。ArgoCD が Job を作成した後は、
+desired manifest を変更しない限り、完了した Job が自動的に再実行されることはない。
+
+移行完了後は one-off directory 全体を Git から削除する cleanup change を merge する。ApplicationSet が
+generated Application を削除し、ArgoCD の Application finalizer による prune で live resource も削除される。
+base resource を先に手動削除して再作成を誘発しない。
+
+## 実行手順
+
+### 1. 本番 DB の現行バックアップを取得する
+
+現行の Portal DB を復元できるバックアップを取得し、バックアップの取得時刻と保存先を記録する。既存の
+MariaDB backup workflow を使う場合も、workflow の成功だけでなく、復元に使う backup object が存在することを
+確認する。
+
+### 2. Portal backend の書き込みを停止する
+
+Portal backend を maintenance 状態にする既存の運用手順を使い、書き込みリクエストが届かないことを確認
+する。Portal 側に maintenance 機能がない場合は、運用者が ArgoCD の self-heal と競合しないよう backend の
+Application を一時的に同期停止したうえで Deployment を停止し、backend Pod が残っていないことを確認する。
+
+この Job 自体から backend Deployment を scale down、再起動、変更してはいけない。frontend や外部の書き込み
+経路も停止または遮断し、移行と DB 復元が終わるまで維持する。
+
+### 3. test user を除外した Portal DB backup を復元する
+
+手順 1 のバックアップ、またはそれを復元元とする承認済みの DB restore 手順を使う。復元元の backup から
+次の test user と、それらに紐づくデバッグ用 BAN を除外する。
+
+- `test_user`
+- `test_std_user`
+
+除外処理と SQL dump は運用環境の外部作業領域だけで行い、Git、ConfigMap、Secret、image に入れない。
+
+### 4. DB の復元完了を確認する
+
+MariaDB の restore resource、restore Job、対象 database の接続状態をそれぞれ確認する。restore が完了する
+前に次の手順へ進まない。Importer が使用する接続先は `mariadb:3306`、database/user は
+`seichi-portal` である。
+
+### 5. 必要なフォーム、質問、ラベルを確認する
+
+Importer image 内の `/etc/seichi-portal/redmine-import.json` と、復元した Portal DB の値が一致することを
+確認する。少なくとも tracker に対応するフォーム、各 form の全 question、choice、label が存在し、必須 question
+に mapping があることを確認する。特に次を確認する。
+
+- アイデア投稿フォーム
+- 公共建築フォーム
+- 修繕依頼フォーム
+- 不要保護報告フォーム
+- `移行元トラッカー: ...` の answer label と、status 用 label
+- 公共建築の終了条件、修繕依頼の server／world／coordinate／修繕内容、不要保護報告の対象 ID／場所／理由を
+  保存する質問
+
+件数確認やフォーム確認の SQL は、承認済み DB tooling から既存の `seichi-portal` DB user で read-only に
+実行する。password は対話入力または tooling の Secret 参照を使い、コマンドへ値を埋め込まない。DB root password
+は importer の接続にも確認作業にも使わない。
+
+### 6. 同じ image で plan を実行する
+
+base Job はまだ `Skip` のままにしておき、次の overlay だけを apply する。overlay は base と同じ image、
+Secret、resources、securityContext、egress policy を使い、Job 名に `-plan` を付けた一時 resource を作る。
+
+```bash
+plan_dir=seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/plan
+
+kubectl apply -k "${plan_dir}"
+kubectl -n seichi-minecraft wait \
+  --for=condition=complete \
+  job/seichi-portal-redmine-importer-plan \
+  --timeout=12h
+kubectl -n seichi-minecraft logs job/seichi-portal-redmine-importer-plan
+kubectl delete -k "${plan_dir}" --ignore-not-found
+```
+
+`plan` は Redmine の対象 issue と詳細、フォーム、question、status、label、既存回答を照合する。ログに
+`report: 0 error(s), 0 warning(s)` が出ることを確認し、エラーがあれば import を有効化しない。警告は内容を
+確認してから進める。
+
+plan の出力で、アイデア投稿が専用フォームへ分類されること、公共建築・修繕依頼・不要保護報告が専用フォーム
+と custom field question へ割り当てられることを確認する。Portal 側の公開範囲は、現在の image の設定では
+アイデア投稿だけが `PUBLIC`、それ以外が `PRIVATE` になる。これは後述の import 後の DB 確認でも検証する。
+
+plan が成功し、DB restore とフォーム確認にも問題がなければ、Job と NetworkPolicy の `Skip` annotation を
+削除するだけの有効化 PR を merge する。ArgoCD Application が作成され、live の Job がまだ存在しないことを
+確認してから sync を待つ。
+
+### 7. 問題がなければ import Job を実行する
+
+有効化 PR の merge 後、ApplicationSet が生成した
+`seichi-minecraft-seichi-portal-redmine-importer` の sync を待つ。Job を手動で別名作成したり、base Job の
+args を書き換えたりしない。
+
+### 8. Job のログと完了状態を確認する
+
+`backoffLimit: 0` のため自動再実行は発生しない。Job の完了と Pod の終了コードを確認し、ログを保存する。
+
+```bash
+kubectl -n seichi-minecraft get job seichi-portal-redmine-importer
+kubectl -n seichi-minecraft wait \
+  --for=condition=complete \
+  job/seichi-portal-redmine-importer \
+  --timeout=12h
+kubectl -n seichi-minecraft logs job/seichi-portal-redmine-importer
+```
+
+`IMPORT ... result=Imported` または再実行時の `AlreadyImported`、および
+`IMPORT answer_relations inserted=... already_exists=...` を確認する。失敗時は Job を削除して再作成せず、
+ログと DB の状態を保存して復元元・エラー原因を調査する。
+
+### 9. 同じ image で verify を実行する
+
+import Job が完了し、ログを確認した後、`verify` overlay で一時 Job を作る。verify でも DB への read-only
+照合と Redmine API の GET が行われる。
+
+```bash
+verify_dir=seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/verify
+
+kubectl apply -k "${verify_dir}"
+kubectl -n seichi-minecraft wait \
+  --for=condition=complete \
+  job/seichi-portal-redmine-importer-verify \
+  --timeout=12h
+kubectl -n seichi-minecraft logs job/seichi-portal-redmine-importer-verify
+kubectl delete -k "${verify_dir}" --ignore-not-found
+```
+
+全対象 issue の `VERIFY ... result=AlreadyImported` を確認する。`ImportRequired`、エラー、または件数の
+不一致がある場合は通常運用へ戻さず、DB とログを調査する。
+
+### 10. 件数と公開範囲を確認する
+
+次の SQL を、既存の `seichi-portal` DB user で read-only に実行する。テーブル名は importer の保存先に
+合わせている。復元 DB に移行済みデータが既にある場合は、移行前の件数との差分も記録する。
+
+```sql
+SELECT COUNT(*) AS imported_issues
+FROM redmine_imported_answer_references;
+
+SELECT COUNT(*) AS imported_journal_comments
+FROM redmine_imported_comments;
+
+SELECT COUNT(*) AS imported_answer_relations
+FROM answer_relations AS relation
+JOIN redmine_imported_answer_references AS first_issue
+  ON first_issue.answer_id = relation.first_answer_id
+JOIN redmine_imported_answer_references AS second_issue
+  ON second_issue.answer_id = relation.second_answer_id;
+
+SELECT answer.publication, COUNT(*) AS count
+FROM answers AS answer
+JOIN redmine_imported_answer_references AS imported
+  ON imported.answer_id = answer.id
+GROUP BY answer.publication
+ORDER BY answer.publication;
+
+SELECT answer.form_id, form.title, answer.publication, COUNT(*) AS count
+FROM answers AS answer
+JOIN redmine_imported_answer_references AS imported
+  ON imported.answer_id = answer.id
+JOIN form_meta_data AS form
+  ON form.id = answer.form_id
+GROUP BY answer.form_id, form.title, answer.publication
+ORDER BY form.title, answer.publication;
+```
+
+今回のローカル確認値は目安として次のとおり。Redmine 側の issue、journal、relation が更新されていれば値は
+変わり得るため、Job や SQL の期待値として hard-code しない。
+
+- 移行対象 issue: 約 12,491
+- Redmine journal comment: 約 14,530
+- answer relation: 約 2,186
+- verify: 全件 `AlreadyImported`
+
+件数だけでなく、アイデア投稿だけが `PUBLIC`、その他が `PRIVATE` であることを確認する。フォーム別集計では、
+公共建築・修繕依頼・不要保護報告の回答がそれぞれ専用フォームに入り、対応する custom field が専用 question
+へ移っていることも確認する。
+
+### 11. Job と一時 NetworkPolicy の manifest を削除する
+
+plan／verify の overlay resource が残っていないことを確認した後、次の one-off directory 全体を Git から
+削除する cleanup change を作成して merge する。
+
+```text
+seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/
+```
+
+cleanup change を merge する前に、生成された Application の `metadata.finalizers` に
+`resources-finalizer.argocd.argoproj.io` が付いていることと、ApplicationSet の
+`preserveResourcesOnDeletion` が有効になっていないことを確認する。これらを確認できない場合は directory を
+削除せず、ArgoCD の Application 削除時に resource prune が行われる状態を先に復旧する。
+
+```bash
+kubectl -n argocd get application seichi-minecraft-seichi-portal-redmine-importer \
+  -o jsonpath='{.metadata.finalizers}{"\n"}'
+kubectl -n argocd get applicationset seichi-minecraft-apps \
+  -o jsonpath='{.spec.preserveResourcesOnDeletion}{"\n"}'
+```
+
+ApplicationSet が `seichi-portal-redmine-importer` Application を削除し、ArgoCD の Application finalizer による
+prune が完了して、次が存在しなくなったことを確認する。
+
+- `seichi-portal-redmine-importer` Job
+- `allow--from-seichi-portal-redmine-importer--to-import-dependencies` CiliumNetworkPolicy
+
+確認例:
+
+```bash
+kubectl -n seichi-minecraft get job seichi-portal-redmine-importer
+kubectl -n seichi-minecraft get ciliumnetworkpolicy \
+  allow--from-seichi-portal-redmine-importer--to-import-dependencies
+```
+
+`NotFound` になったことを確認してから、Terraform の importer Secret resource と variable、GitHub Actions
+repository secret の削除も cleanup PR として行う。Job のログと DB 確認が終わるまで、base resource を
+`kubectl delete` してはいけない。
+
+### 12. backend の通常運用を再開する
+
+Portal backend の書き込み停止または maintenance 状態を解除し、Deployment を通常の replica 数へ戻す。backend
+Pod が Ready になり、Portal から通常の read/write ができることを確認する。
+
+### 13. backend 側の Redmine importer PR を revert する
+
+移行結果と通常運用を確認した後、`seichi-portal-backend` repository の Redmine importer merge PR（merge
+commit `163de71799135a2445b99707cde02bf5621eea18`、PR #1383）を revert する。revert は backend repository
+側で別途行い、この repository の backend source は変更しない。

--- a/docs/runbooks/seichi-portal-redmine-importer.md
+++ b/docs/runbooks/seichi-portal-redmine-importer.md
@@ -3,7 +3,7 @@
 ## 目的と前提
 
 Redmine の issue、journal comment、issue relation を SeichiPortal のフォーム回答へ移行するための、
-一回限りの Kubernetes Job の運用手順。Importer は次の固定 image を使用する。
+一回限りの data migration／import Kubernetes Job の運用手順。Importer は次の固定 image を使用する。
 
 ```text
 ghcr.io/giganticminecraft/seichi-portal-redmine-importer:163de71799135a2445b99707cde02bf5621eea18@sha256:5406a8b58d56020bb6256711a73ca25a5bacb99fe8452ec3b557a50e5dede9cf
@@ -13,8 +13,13 @@ ghcr.io/giganticminecraft/seichi-portal-redmine-importer:163de71799135a2445b9970
 backend の Domain / Usecase / Repository 経由で行い、backend HTTP API、Redis、RabbitMQ、Meilisearch には
 接続しない。
 
-SQL dump は、このリポジトリの Git、ConfigMap、Secret、image のいずれにも保存しない。バックアップと
-復元は、運用者が承認済みの DB 運用経路で行う。
+SQL dump (`seichi-portal-pre-redmine-import-without-debug-users.sql`) 自体は、このリポジトリの Git、
+ConfigMap、Secret、image のいずれにも保存しない。dump に含まれる importer 実行前の Portal 初期データは、
+schema と `_sqlx_migrations` を除いた data-only migration として
+`seichi-portal-redmine-importer/database-migration/001-pre-redmine-seed.sql` に反映している。この migration は
+GitOps で一度だけ適用する ConfigMap と MariaDB client Job から構成し、完了後に directory ごと削除する。
+schema と SQLx migration の管理は backend 側に任せる。バックアップと復元は、運用者が承認済みの DB 運用経路で
+行う。
 
 ## Secret の事前準備
 
@@ -22,14 +27,17 @@ SQL dump は、このリポジトリの Git、ConfigMap、Secret、image のい�
 Terraform の `kubernetes_secret_v1` resource で Kubernetes Secret を作成している。この移行でも同じ方式を
 使う。
 
-1. この PR を merge する前に、GitHub Actions の repository secret として
-   `TF_VAR_SEICHI_PORTAL_REDMINE_IMPORTER__API_KEY` を out-of-band で登録する。値は GitHub の Secret
-   設定画面または標準入力を使う CLI から登録し、コマンドライン引数、シェル履歴、ログへ出さない。
-2. この PR の merge 後、既存の Terraform apply workflow が成功することを確認する。workflow は Secret の
-   値を Terraform variable `seichi_portal_redmine_importer__api_key` に渡し、namespace
-   `seichi-minecraft` の `seichi-portal-redmine-importer-credentials` Secret に
+1. この PR の Terraform plan が実行される前に、GitHub Actions の repository secret として
+   `TF_VAR_SEICHI_PORTAL_REDMINE_IMPORTER__API_KEY` を out-of-band で登録する。値は GitHub の Secret 設定画面
+   または標準入力を使う CLI から登録し、コマンドライン引数、シェル履歴、ログへ出さない。この Secret がない
+   状態では、必須 Terraform variable に値が入らず plan が失敗する。
+2. Secret 登録後、PR の `tf plan` が成功することを確認する。既存 workflow の
+   `expose-all-tf-vars-to-github-env.sh` が Secret 名の `TF_VAR_` 以降を小文字化し、Terraform variable
+   `seichi_portal_redmine_importer__api_key` へ渡す。
+3. PR merge 後、既存の Terraform apply workflow が成功することを確認する。workflow は Secret の値を
+   namespace `seichi-minecraft` の `seichi-portal-redmine-importer-credentials` Secret に
    `REDMINE_API_KEY` として保存する。
-3. Kubernetes Secret の存在と `REDMINE_API_KEY` key の存在だけを確認する。Secret の値は表示しない。
+4. Kubernetes Secret の存在と `REDMINE_API_KEY` key の存在だけを確認する。Secret の値は表示しない。
 
 API key と DB password の値は、Git、YAML、Job の args、ログ、README に書かない。移行完了後、Job と
 NetworkPolicy を prune したことを確認してから、Terraform の Secret resource／variable を削除する cleanup
@@ -37,13 +45,20 @@ PR を作成し、その merge 後に GitHub Actions の repository secret も�
 
 ## ArgoCD の実行 gate
 
-`seichi-minecraft-seichi-portal-redmine-importer` は ApplicationSet が生成する Application である。base の
-Job と CiliumNetworkPolicy には `argocd.argoproj.io/sync-options: Skip` が付いているため、この PR を merge
-しただけでは live resource は作成されない。
+`seichi-minecraft-seichi-portal-redmine-importer` は ApplicationSet が生成する Application である。importer の
+Job／CiliumNetworkPolicy と、data migration の ConfigMap／Job／CiliumNetworkPolicy には
+`argocd.argoproj.io/sync-options: Skip` が付いているため、この PR を merge しただけでは live resource は
+作成されない。
 
-DB 復元と `plan` の確認後、運用者が Job と NetworkPolicy の `Skip` annotation だけを削除する有効化 PR を
-作成して merge する。base Job の `args` は常に `["import"]` のままにする。ArgoCD が Job を作成した後は、
-desired manifest を変更しない限り、完了した Job が自動的に再実行されることはない。
+DB 復元後、まず data migration だけを有効化する Git change を作成して merge する。具体的には
+`database-migration/kustomization.yaml` の ConfigMap、`database-migration/job.yaml` の Job、
+`database-migration/network-policy.yaml` の CiliumNetworkPolicy から `Skip` annotation を削除し、base の
+importer Job／NetworkPolicy は `Skip` のままにする。ConfigMap／NetworkPolicy は sync wave `-1`、migration Job は
+wave `0`、importer Job は wave `1` なので、同じ Application の sync になっても data migration が先に適用される。
+data migration の resource は直接 `kubectl apply` せず、この Git change の merge と ArgoCD sync だけで作成する。
+最初の migration Job が完了したことを確認してから `plan` を実行し、その後 importer Job／NetworkPolicy の
+`Skip` だけを削除する別の enable change を merge する。base Job の `args` は常に `["import"]` のままにする。
+ArgoCD が Job を作成した後は、desired manifest を変更しない限り、完了した Job が自動的に再実行されることはない。
 
 移行完了後は one-off directory 全体を Git から削除する cleanup change を merge する。ApplicationSet が
 generated Application を削除し、ArgoCD の Application finalizer による prune で live resource も削除される。
@@ -82,11 +97,28 @@ MariaDB の restore resource、restore Job、対象 database の接続状態を�
 前に次の手順へ進まない。Importer が使用する接続先は `mariadb:3306`、database/user は
 `seichi-portal` である。
 
-### 5. 必要なフォーム、質問、ラベルを確認する
+### 5. data migration を適用し、必要なフォーム、質問、ラベルを確認する
 
-Importer image 内の `/etc/seichi-portal/redmine-import.json` と、復元した Portal DB の値が一致することを
-確認する。少なくとも tracker に対応するフォーム、各 form の全 question、choice、label が存在し、必須 question
-に mapping があることを確認する。特に次を確認する。
+まず、schema migration が完了し、`seichi-portal` DB user が対象 database に接続できることを確認する。次に
+data migration だけを有効化する change を作成して merge し、ApplicationSet が生成した Application の sync と
+次の Job の完了を待つ。
+
+```bash
+kubectl -n seichi-minecraft wait \
+  --for=condition=complete \
+  job/seichi-portal-pre-redmine-migration \
+  --timeout=1h
+kubectl -n seichi-minecraft logs job/seichi-portal-pre-redmine-migration
+```
+
+Job のログに SQL 実行エラーがなく、`seichi-portal-pre-redmine-migration` が `Complete` になっていることを
+確認する。この Job は dump 全体を restore するものではなく、Git 管理の data-only migration を既存 schema へ
+適用するものである。今回の migration が投入する行数の確認目安は users 1、forms 18、questions 46、choices 47、
+labels 18、form_discord_webhooks 18、global_discord_webhook_settings 1 である。
+
+data migration 完了後、Importer image 内の `/etc/seichi-portal/redmine-import.json` と Portal DB の値が一致する
+ことを確認する。少なくとも tracker に対応するフォーム、各 form の全 question、choice、label が存在し、必須
+question に mapping があることを確認する。特に次を確認する。
 
 - アイデア投稿フォーム
 - 公共建築フォーム
@@ -102,7 +134,8 @@ Importer image 内の `/etc/seichi-portal/redmine-import.json` と、復元し�
 
 ### 6. 同じ image で plan を実行する
 
-base Job はまだ `Skip` のままにしておき、次の overlay だけを apply する。overlay は base と同じ image、
+data migration Job が成功し、フォーム、question、choice、label の確認が終わるまで base importer Job は
+`Skip` のままにする。その後、次の overlay だけを apply する。overlay は base と同じ image、
 Secret、resources、securityContext、egress policy を使い、Job 名に `-plan` を付けた一時 resource を作る。
 
 ```bash
@@ -125,15 +158,16 @@ plan の出力で、アイデア投稿が専用フォームへ分類されるこ
 と custom field question へ割り当てられることを確認する。Portal 側の公開範囲は、現在の image の設定では
 アイデア投稿だけが `PUBLIC`、それ以外が `PRIVATE` になる。これは後述の import 後の DB 確認でも検証する。
 
-plan が成功し、DB restore とフォーム確認にも問題がなければ、Job と NetworkPolicy の `Skip` annotation を
-削除するだけの有効化 PR を merge する。ArgoCD Application が作成され、live の Job がまだ存在しないことを
-確認してから sync を待つ。
+plan が成功し、DB restore と data migration、フォーム確認にも問題がなければ、base importer Job と importer
+NetworkPolicy の `Skip` annotation だけを削除する有効化 PR を merge する。data migration の resource は既に
+完了済みなので、再度作成・実行しない。ArgoCD Application が importer Job を作成してから sync を待つ。
 
 ### 7. 問題がなければ import Job を実行する
 
 有効化 PR の merge 後、ApplicationSet が生成した
-`seichi-minecraft-seichi-portal-redmine-importer` の sync を待つ。Job を手動で別名作成したり、base Job の
-args を書き換えたりしない。
+`seichi-minecraft-seichi-portal-redmine-importer` の sync を待つ。data migration Job が Complete の状態で
+残っていることと、importer Job が sync wave `1` で作成されたことを確認する。Job を手動で別名作成したり、base
+Job の args を書き換えたりしない。
 
 ### 8. Job のログと完了状態を確認する
 
@@ -242,17 +276,24 @@ kubectl -n argocd get applicationset seichi-minecraft-apps \
 ```
 
 ApplicationSet が `seichi-portal-redmine-importer` Application を削除し、ArgoCD の Application finalizer による
-prune が完了して、次が存在しなくなったことを確認する。
+prune が完了して、次の Job、ConfigMap、CiliumNetworkPolicy がすべて存在しなくなったことを確認する。
 
 - `seichi-portal-redmine-importer` Job
+- `seichi-portal-pre-redmine-migration` Job
+- `seichi-portal-pre-redmine-migration-sql` ConfigMap
 - `allow--from-seichi-portal-redmine-importer--to-import-dependencies` CiliumNetworkPolicy
+- `allow--from-seichi-portal-pre-redmine-migration--to-mariadb` CiliumNetworkPolicy
 
 確認例:
 
 ```bash
 kubectl -n seichi-minecraft get job seichi-portal-redmine-importer
+kubectl -n seichi-minecraft get job seichi-portal-pre-redmine-migration
+kubectl -n seichi-minecraft get configmap seichi-portal-pre-redmine-migration-sql
 kubectl -n seichi-minecraft get ciliumnetworkpolicy \
   allow--from-seichi-portal-redmine-importer--to-import-dependencies
+kubectl -n seichi-minecraft get ciliumnetworkpolicy \
+  allow--from-seichi-portal-pre-redmine-migration--to-mariadb
 ```
 
 `NotFound` になったことを確認してから、Terraform の importer Secret resource と variable、GitHub Actions

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/base/job.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/base/job.yaml
@@ -1,6 +1,6 @@
 # Redmine の issue を SeichiPortal へ移行する一回限りの Job。
 #
-# 初回 merge では ArgoCD の Skip により作成されない。DB 復元と plan の確認後、
+# 初回 merge では ArgoCD の Skip により作成されない。DB 復元、事前 data migration、plan の確認後、
 # この annotation を削除する変更を merge して初めて import Job を作成すること。
 apiVersion: batch/v1
 kind: Job
@@ -11,6 +11,7 @@ metadata:
     app: seichi-portal-redmine-importer
   annotations:
     argocd.argoproj.io/sync-options: Skip
+    argocd.argoproj.io/sync-wave: "1"
 spec:
   backoffLimit: 0
   activeDeadlineSeconds: 43200

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/base/job.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/base/job.yaml
@@ -1,0 +1,73 @@
+# Redmine の issue を SeichiPortal へ移行する一回限りの Job。
+#
+# 初回 merge では ArgoCD の Skip により作成されない。DB 復元と plan の確認後、
+# この annotation を削除する変更を merge して初めて import Job を作成すること。
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: seichi-portal-redmine-importer
+  namespace: seichi-minecraft
+  labels:
+    app: seichi-portal-redmine-importer
+  annotations:
+    argocd.argoproj.io/sync-options: Skip
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: 43200
+  template:
+    metadata:
+      labels:
+        app: seichi-portal-redmine-importer
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: redmine-importer
+          image: ghcr.io/giganticminecraft/seichi-portal-redmine-importer:163de71799135a2445b99707cde02bf5621eea18@sha256:5406a8b58d56020bb6256711a73ca25a5bacb99fe8452ec3b557a50e5dede9cf
+          args: ["import"]
+          env:
+            - name: MYSQL_DATABASE
+              value: seichi-portal
+            - name: MYSQL_USER
+              value: seichi-portal
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: seichi-portal-db-credentials
+                  key: password
+            - name: MYSQL_HOST
+              value: mariadb
+            - name: MYSQL_PORT
+              value: "3306"
+            - name: REDMINE_BASE_URL
+              value: https://redmine.seichi.click
+            - name: REDMINE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: seichi-portal-redmine-importer-credentials
+                  key: REDMINE_API_KEY
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/base/kustomization.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: seichi-minecraft
+
+resources:
+  - job.yaml
+  - network-policy.yaml

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/base/network-policy.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/base/network-policy.yaml
@@ -1,0 +1,42 @@
+# Importer が移行中に使う宛先だけを許可する一時 CiliumNetworkPolicy。
+#
+# 初回 merge では ArgoCD の Skip により作成されない。DB 復元後に Job と同時に
+# 有効化し、移行完了後は kustomization から外して ArgoCD に prune させること。
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow--from-seichi-portal-redmine-importer--to-import-dependencies
+  namespace: seichi-minecraft
+  annotations:
+    argocd.argoproj.io/sync-options: Skip
+spec:
+  endpointSelector:
+    matchLabels:
+      app: seichi-portal-redmine-importer
+  egress:
+    - toServices:
+        - k8sService:
+            serviceName: mariadb
+            namespace: seichi-minecraft
+      toPorts:
+        - ports:
+            - port: "3306"
+              protocol: TCP
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: ANY
+          rules:
+            dns:
+              - matchName: redmine.seichi.click
+              - matchName: mariadb.seichi-minecraft.svc.cluster.local
+    - toFQDNs:
+        - matchName: redmine.seichi.click
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/database-migration/001-pre-redmine-seed.sql
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/database-migration/001-pre-redmine-seed.sql
@@ -1,0 +1,179 @@
+-- Data-only seed migration for the Portal database before the Redmine import.
+-- The source SQL dump is intentionally not tracked; this file contains only the
+-- data rows from form_choices, form_discord_webhooks, form_meta_data,
+-- form_questions, global_discord_webhook_settings, label_for_form_answers,
+-- and users. Schema and _sqlx_migrations are owned by backend migrations.
+-- Keep this migration one-shot and remove this directory after the import.
+START TRANSACTION;
+
+-- Seed users.
+INSERT INTO `users` (`id`, `name`, `role`) VALUES
+('e1ee55bb-c993-4896-88e9-9893a11df27a','rito_5289','ADMINISTRATOR') ON DUPLICATE KEY UPDATE `name` = VALUES(`name`), `role` = VALUES(`role`);
+
+-- Seed form_meta_data.
+INSERT INTO `form_meta_data` (`id`, `title`, `description`, `visibility`, `allow_temporary_answers`, `answer_visibility`, `answer_response_visibility`, `hide_author`, `acceptance_period_start_at`, `acceptance_period_end_at`, `default_answer_title`, `created_at`, `created_by`, `updated_at`, `updated_by`) VALUES
+('01a04c05-2cd2-74b0-bf0c-eab63b3f2213','不具合報告フォーム','ここはギガンティック⭐︎整地鯖をプレイ中に発見した不具合を報告するフォームです。\nこちらにご報告いただいた不具合は、運営チームが確認後適切な対応を行います。\n\nなお、報告をいただいてから内容を確認するまでに時間を要することを予めご了承ください。\n\n【不具合報告ルール】\n・虚偽の報告は処罰対象となります。\n・原則、頂いた報告に対する個別の返信はしておりません。\n\n【ゲーム内の特定場所・特定時間を報告する時の注意】\n以下の事項を全て明記してください。\n・サーバー名（アルカディア？エデン？…）\n・ワールド名（メインワールド？第1整地ワールド？第2整地ワールド？…）\n・座標（X座標、Y座標、Z座標）\n・時間（何月何日？何時何分頃？）\n\n【不具合報告ガイドライン】\n・報告の際はテンプレートを使用してください。\n・運営チームへのお問い合わせはここでは行えません。\n・サーバーへログインできない場合は、公式Discordなどでメンテナンス情報・障害情報をご確認ください。\n・投稿の詳細を簡潔に記載してください。\n・調査に必要な情報（サーバー名・ワールド名など）を全て含めてください。\n・複数の不具合を報告する際は、不具合ごとに新しい投稿を作成してください。\n・不具合の不正利用を促す内容、不具合とは関係ない内容、不具合の調査・進捗状況についての質問は投稿しないでください。\n\n【不具合報告時のテンプレート】\n概要:\n＜どのような問題が起きているのか、簡単な概要＞\n\n発生日時:\n＜不具合が発生した日時＞\n\nサーバー名:\n＜不具合が発生したサーバー名＞\n\nワールド名:\n＜不具合が発生したワールド名＞\n\n座標:\n＜ワールド関連の不具合を報告する際は記載してください。わからない場合はそのまま記載してください＞\n\n再現手順:\n＜不具合発生に至った手順を詳しく記載してください＞\n1.\n2.\n3.','PUBLIC',0,'PRIVATE','FULL',0,NULL,NULL,NULL,'2026-08-29 05:36:42','e1ee55bb-c993-4896-88e9-9893a11df27a','2026-08-30 03:56:04','e1ee55bb-c993-4896-88e9-9893a11df27a'),
+('01a04c0c-7d3c-7973-bbde-dadbfd9abc0b','通報フォーム','ルール違反を発見したら当フォームから通報ください。ご協力ありがとうございます。\n\n【通報ルール】\n・虚偽の通報は処罰対象となります。\n・原則、頂いた通報に対する個別の返信はしておりません。\n\n【ゲーム内の特定場所・特定時間を報告する時の注意】\n以下の事項が全て明記されていないと、運営チームが場所や時間を特定できません。\n・サーバー名（アルカディア？エデン？…）\n・ワールド名（メインワールド？第1整地ワールド？第2整地ワールド？…）\n・座標（X座標、Y座標、Z座標）\n・時間（何月何日？何時何分頃？）\n\n【証拠について】\nDiscordに貼った画像や動画のリンクは証拠になりません。DiscordのCDN URL（cdn.discordapp.com や cdn.discord.com）はアクセス期限が設定されるため、画像や動画の証拠には使用しないでください。画像や動画を提出する場合は、GyazoやYouTubeの限定公開などを利用してください。\n\n動画による証拠が必要な例：チート行為。\n画像による証拠が必要な例：ゲーム内チャットでの違反行為、他プレイヤーへの迷惑行為、整地の心得違反。\n\n動画は対象者のIDが鮮明に映るように撮影してください。画像はMinecraftのウィンドウ全体を撮影し、対象者のIDが鮮明に分かるものを使用してください。Discordのログは改ざんできるため、チャット違反の証拠には使用できません。Discordのメッセージリンクは使用できます。\n\n上の説明や注意事項をよく読んだ上で、以下に回答してください。','PUBLIC',0,'PRIVATE','FULL',0,NULL,NULL,NULL,'2026-08-29 05:44:42','e1ee55bb-c993-4896-88e9-9893a11df27a','2026-08-30 03:56:13','e1ee55bb-c993-4896-88e9-9893a11df27a'),
+('01a04c15-4c82-7b81-a6b5-99350312fa71','ご意見ご感想フォーム','以下のような事項を送信できるフォームです。\n・運営チームへのエール\n・整地鯖を遊んでみての感想や意見\n\n頂いた投稿内容は全て目を通し、今後の運営の参考にさせていただきます。\n個別の返信はしておりませんのでご了承ください。\n\nご意見ご感想フォームです。不具合報告やお問い合わせには別のフォームをご利用ください。\n\n頂いたご意見は、内容によってはプレイヤーに公開されることがありますので、あらかじめご了承ください。','PUBLIC',0,'PRIVATE','FULL',0,NULL,NULL,NULL,'2026-08-29 05:54:19','e1ee55bb-c993-4896-88e9-9893a11df27a','2026-08-30 03:56:21','e1ee55bb-c993-4896-88e9-9893a11df27a'),
+('01a04c19-06d1-78e1-82a1-b437f1c81ede','アイデア投稿フォーム','こちらからアイデアを投稿できます。\n投稿されたアイデアは公式DiscordグループやRedmine等にて一般公開されます。\n現時点で考えつく限りで構いませんので、なぜそのアイデアを提案するのかといった根拠も併せて記入してください。明確で具体的な根拠があることにより、議論の助けとなります。\nギガンティック☆整地鯖のみならず、春などの他のseichi.click networkのゲームサーバー、公式Discordグループなど他サービスに関するアイデアも募集しています。\n\n【投稿前の確認】\nhttps://redmine.seichi.click/projects/idea で同じアイデアがないか確認してください。','PUBLIC',0,'PUBLIC','FULL',1,NULL,NULL,NULL,'2026-08-29 05:58:23','e1ee55bb-c993-4896-88e9-9893a11df27a','2026-08-30 03:56:37','e1ee55bb-c993-4896-88e9-9893a11df27a'),
+('01a04c1f-4c5d-7ab2-baf4-753b65eef361','サーバーにログインできない方へ','サーバーにログインできない場合のお問い合わせフォームです。\n\nProxyやVPNからの接続を検知したメッセージが表示された場合、環境を変えて再度お試しください。どうしても解決しない場合は、グローバルIPアドレス（IPv4）を記入してください。10から始まるものや192.168から始まるものはローカルIPアドレスのため使用できません。\n\nゲーム内の問題の場合は、サーバー名、ワールド名、座標（X座標、Y座標、Z座標の順）、時間（何月何日、何時何分頃）を記入してください。','PUBLIC',0,'PRIVATE','FULL',0,NULL,NULL,NULL,'2026-08-29 06:05:14','e1ee55bb-c993-4896-88e9-9893a11df27a','2026-08-30 03:56:51','e1ee55bb-c993-4896-88e9-9893a11df27a'),
+('01a04c1f-4c7d-7e42-96bf-856e78f482a4','MOD使用可否のお問い合わせ','MODの使用可否についてお問い合わせするフォームです。内容を正しく記入してください。正しく記入されていない場合は回答できないことがあります。ダウンロード先への直リンクは記入しないでください。','PUBLIC',0,'PRIVATE','FULL',0,NULL,NULL,NULL,'2026-08-29 06:05:14','e1ee55bb-c993-4896-88e9-9893a11df27a','2026-08-30 03:57:02','e1ee55bb-c993-4896-88e9-9893a11df27a'),
+('01a04c1f-4c98-74e0-b92b-c400d4e1fbb1','経験値がオーバーフローしてしまった方へ','経験値のオーバーフローについてのお問い合わせフォームです。内容を正しく記入してください。正しく記入されていない場合は対応できないことがあります。修復にはゲーム内にログインしておいていただく必要があります。','PUBLIC',0,'PRIVATE','FULL',0,NULL,NULL,NULL,'2026-08-29 06:05:14','e1ee55bb-c993-4896-88e9-9893a11df27a','2026-08-30 03:57:13','e1ee55bb-c993-4896-88e9-9893a11df27a'),
+('01a04c1f-4cb3-7f91-b64b-e2057b56f55f','処罰への異議申し立て','処罰への異議申し立てフォームです。運営チームが当該処罰を不当と認める場合を除き、BANの解除は行われません。次のいずれかに該当する場合、原則として異議申し立てを受理しません。\n・被処罰者本人以外から投稿されたもの\n・お問い合わせフォーム以外に投稿されたもの\n・処罰執行から60日以上経過した処罰に関するもの\n\n投稿前に以下をご確認ください。\nBANについて：https://www.seichi.network/ban\nルール（第二節 処罰の執行及び異議申し立て）：https://www.seichi.network/rule','PUBLIC',0,'PRIVATE','FULL',0,NULL,NULL,NULL,'2026-08-29 06:05:14','e1ee55bb-c993-4896-88e9-9893a11df27a','2026-08-30 03:57:36','e1ee55bb-c993-4896-88e9-9893a11df27a'),
+('01a04c1f-4cce-7391-b10b-6e3fb1d2af6c','整地ワールドの再生成希望','整地ワールドの再生成希望フォームです。第1整地ワールドは毎週金曜日に自動的に再生成されるため、こちらでは受け付けていません。その他の整地ワールドは、すべてブロックが掘り尽くされたと思われる場合にご連絡ください。なお、このお問い合わせへの個別の返信は行っていません。','PUBLIC',0,'PRIVATE','FULL',0,NULL,NULL,NULL,'2026-08-29 06:05:14','e1ee55bb-c993-4896-88e9-9893a11df27a','2026-08-30 03:57:25','e1ee55bb-c993-4896-88e9-9893a11df27a'),
+('01a04c1f-4ce6-7761-bde2-d59b8542f30e','お問い合わせフォーム','お問い合わせフォームです。投稿前に、よくある質問（https://www.seichi.network/qanda）をお読みください。\n\n不具合報告や迷惑プレイヤーの通報には専用フォームをご利用ください。返答には最大2週間程度かかる場合があります。内容によっては返答を差し控えることや、返信しないことがあります。内容に不備がある場合は返答や対応ができません。\n\nメールでの返信は seichi.click.saiyo@gmail.com から行っています。\n\n画像や動画を証拠として提出する場合は、DiscordのCDN URLではなく、GyazoやYouTubeの限定公開などをご利用ください。','PUBLIC',1,'PRIVATE','FULL',0,NULL,NULL,NULL,'2026-08-29 06:05:14','e1ee55bb-c993-4896-88e9-9893a11df27a','2026-08-29 06:18:49','e1ee55bb-c993-4896-88e9-9893a11df27a'),
+('01a050c7-7c1a-7f01-bfd0-5c1841f81001','運営課題フォーム','運営上のアイデアや不具合を登録し、対応状況を管理するフォームです。課題の種類を選択し、内容や発生状況、期待する対応などを具体的に記入してください。','PRIVATE',0,'PRIVATE','FULL',0,NULL,NULL,NULL,'2026-08-30 03:47:25','e1ee55bb-c993-4896-88e9-9893a11df27a','2026-08-30 04:03:27','e1ee55bb-c993-4896-88e9-9893a11df27a'),
+('01a050c7-e4ee-7cd0-ac7f-81d804679e0f','建築・ワールド整備フォーム','建築やワールドの整備に関する案件を登録し、対応状況を管理するフォームです。案件の種類を選択し、場所や対象、希望する対応などを具体的に記入してください。','PRIVATE',0,'PRIVATE','FULL',0,NULL,NULL,NULL,'2026-08-30 03:47:52','e1ee55bb-c993-4896-88e9-9893a11df27a','2026-08-30 04:03:27','e1ee55bb-c993-4896-88e9-9893a11df27a'),
+('01a050c7-e518-7fc2-af67-ba2df61aa4ff','企画・制作フォーム','イベントやデザインに関する企画・制作案件を登録し、進行状況を管理するフォームです。案件の種類を選択し、目的や必要な成果物、希望時期などを具体的に記入してください。','PRIVATE',0,'PRIVATE','FULL',0,NULL,NULL,NULL,'2026-08-30 03:47:52','e1ee55bb-c993-4896-88e9-9893a11df27a','2026-08-30 04:03:27','e1ee55bb-c993-4896-88e9-9893a11df27a'),
+('01a050c7-e547-7e62-8efe-0ccc3209c06a','会議記録フォーム','運営に関する会議の記録を登録し、決定事項や継続課題を確認するフォームです。会議の種類を選択し、議題・議論の内容・決定事項・次回までの対応などを記入してください。','PRIVATE',0,'PRIVATE','FULL',0,NULL,NULL,NULL,'2026-08-30 03:47:52','e1ee55bb-c993-4896-88e9-9893a11df27a','2026-08-30 04:03:27','e1ee55bb-c993-4896-88e9-9893a11df27a'),
+('01a050c7-e56e-7010-8425-c7201cef8032','処罰エビデンスフォーム','ルール違反に関する証拠を登録し、確認・対応のために管理するフォームです。証拠の発生場所を選択し、対象者・発生日時・状況・証拠へのリンクなどを具体的に記入してください。','PRIVATE',0,'PRIVATE','FULL',0,NULL,NULL,NULL,'2026-08-30 03:47:52','e1ee55bb-c993-4896-88e9-9893a11df27a','2026-08-30 04:03:27','e1ee55bb-c993-4896-88e9-9893a11df27a'),
+('01a052fd-44a5-72b3-aff7-6035df6d6772','公共建築フォーム','公共建築に関する案件を記録し、対応状況を管理するフォームです。案件の内容と、必要に応じて終了条件を記入してください。','PRIVATE',0,'PRIVATE','FULL',0,NULL,NULL,NULL,'2026-08-30 14:05:25','e1ee55bb-c993-4896-88e9-9893a11df27a','2026-08-30 14:06:59','e1ee55bb-c993-4896-88e9-9893a11df27a'),
+('01a052fd-8ae3-7a73-8856-d101b56d47b8','修繕依頼フォーム','サーバーやワールドの修繕を依頼するフォームです。対象の場所と、必要な対応内容を記入してください。','PRIVATE',0,'PRIVATE','FULL',0,NULL,NULL,NULL,'2026-08-30 14:05:43','e1ee55bb-c993-4896-88e9-9893a11df27a','2026-08-30 14:06:59','e1ee55bb-c993-4896-88e9-9893a11df27a'),
+('01a052fd-da04-7951-acd8-ad28963480a9','不要保護報告フォーム','不要になった保護を報告するフォームです。対象のサーバー・ワールド・座標と、不要と判断した理由を記入してください。','PRIVATE',0,'PRIVATE','FULL',0,NULL,NULL,NULL,'2026-08-30 14:06:03','e1ee55bb-c993-4896-88e9-9893a11df27a','2026-08-30 14:06:59','e1ee55bb-c993-4896-88e9-9893a11df27a') ON DUPLICATE KEY UPDATE `title` = VALUES(`title`), `description` = VALUES(`description`), `visibility` = VALUES(`visibility`), `allow_temporary_answers` = VALUES(`allow_temporary_answers`), `answer_visibility` = VALUES(`answer_visibility`), `answer_response_visibility` = VALUES(`answer_response_visibility`), `hide_author` = VALUES(`hide_author`), `acceptance_period_start_at` = VALUES(`acceptance_period_start_at`), `acceptance_period_end_at` = VALUES(`acceptance_period_end_at`), `default_answer_title` = VALUES(`default_answer_title`), `created_at` = VALUES(`created_at`), `created_by` = VALUES(`created_by`), `updated_at` = VALUES(`updated_at`), `updated_by` = VALUES(`updated_by`);
+
+-- Seed form_questions.
+INSERT INTO `form_questions` (`question_id`, `form_id`, `template_key`, `position`, `title`, `description`, `question_type`, `is_required`) VALUES
+('01a04c05-2cd2-74b0-bf0c-ea777979c48f','01a04c05-2cd2-74b0-bf0c-eab63b3f2213','bug_type',0,'不具合の種類',NULL,'SingleChoice',1),
+('01a04c05-2cd2-74b0-bf0c-eaabd232c118','01a04c05-2cd2-74b0-bf0c-eab63b3f2213','bug_content',1,'不具合の内容','発見した不具合について、時間と場所、不具合の内容、その前後にあったことなどをできるだけ具体的に記入してください。画像や動画を証拠として提出する場合は、GyazoやYouTubeの限定公開など、期限切れにならないサービスを利用してください。DiscordのCDN URLは証拠として使用しないでください。','Text',1),
+('01a04c0c-7d3c-7973-bbde-da77f2844a35','01a04c0c-7d3c-7973-bbde-dadbfd9abc0b','summary',0,'要約','当サーバールールのうち、どのルールに違反する行為なのかを入力してください。複数回答可です。当てはまるものがない場合は「その他」と入力してください。','Text',1),
+('01a04c0c-7d3c-7973-bbde-da874aef3dec','01a04c0c-7d3c-7973-bbde-dadbfd9abc0b','report_content',1,'通報内容','通報内容をできるだけ詳しく入力してください。ゲーム内の特定場所・特定時間を報告する場合は、説明欄の注意事項を確認してください。','Text',1),
+('01a04c0c-7d3c-7973-bbde-da98b09f1997','01a04c0c-7d3c-7973-bbde-dadbfd9abc0b','evidence_url',2,'証拠動画または画像のURL','任意項目です。証拠を提出する場合は、GyazoやYouTubeの限定公開などを利用してください。DiscordのCDN URLは使用しないでください。','Text',0),
+('01a04c0c-7d3c-7973-bbde-daaa894d9100','01a04c0c-7d3c-7973-bbde-dadbfd9abc0b','target_minecraft_id',3,'通報対象Minecraft ID','通報対象者のMinecraft IDが分かる場合は記入してください。','Text',0),
+('01a04c0c-7d3c-7973-bbde-dabd3a9f6565','01a04c0c-7d3c-7973-bbde-dadbfd9abc0b','includes_direct_message',4,'今回の通報内容は個人チャット（ダイレクトメッセージ）の内容を含みますか？',NULL,'SingleChoice',1),
+('01a04c0c-7d3c-7973-bbde-dacef381c1c5','01a04c0c-7d3c-7973-bbde-dadbfd9abc0b','direct_message_consent',5,'個人チャット（ダイレクトメッセージ）に関する同意','通報内容に個人チャット（ダイレクトメッセージ）の内容を含む場合のみ、以下にチェックしてください。これは、あなたが通信当事者本人であることを確認する目的のみに使用します。','MultipleChoice',0),
+('01a04c15-4c82-7b81-a6b5-9929721e8d75','01a04c15-4c82-7b81-a6b5-99350312fa71','feedback_content',0,'投稿内容','投稿内容をご入力ください。Enterキーで改行可能です。','Text',1),
+('01a04c19-06d1-78e1-82a1-b3ff6219aca5','01a04c19-06d1-78e1-82a1-b437f1c81ede','redmine_checked',0,'確認','投稿前にRedmineを検索し、同じアイデアがないことを確認してください。','MultipleChoice',1),
+('01a04c19-06d1-78e1-82a1-b40a30f66b5b','01a04c19-06d1-78e1-82a1-b437f1c81ede','idea_summary',1,'アイデアの要約',NULL,'Text',1),
+('01a04c19-06d1-78e1-82a1-b419b008fe89','01a04c19-06d1-78e1-82a1-b437f1c81ede','idea_content',2,'アイデアの内容',NULL,'Text',1),
+('01a04c19-06d1-78e1-82a1-b4233cd8fc18','01a04c19-06d1-78e1-82a1-b437f1c81ede','idea_reason',3,'アイデアの理由','それがあることによって便利だと考える理由、それがないことによって不便な理由を記入してください。','Text',1),
+('01a04c1f-4c5d-7ab2-baf4-751e8ea5eda1','01a04c1f-4c5d-7ab2-baf4-753b65eef361','login_message_or_action',0,'表示されているメッセージや直前にしていた行動など','表示されているメッセージや直前にしていた行動などを、分かる範囲で詳細に記入してください。','Text',1),
+('01a04c1f-4c5d-7ab2-baf4-7523318f579a','01a04c1f-4c5d-7ab2-baf4-753b65eef361','global_ip_address',1,'グローバルIPアドレス(v4)','ProxyやVPNの検知メッセージが表示された場合に記入してください。該当しない場合は空欄で構いません。','Text',0),
+('01a04c1f-4c7d-7e42-96bf-8535e9cc72cd','01a04c1f-4c7d-7e42-96bf-856e78f482a4','mod_name',0,'MODの名前',NULL,'Text',1),
+('01a04c1f-4c7d-7e42-96bf-8545552bed11','01a04c1f-4c7d-7e42-96bf-856e78f482a4','mod_content',1,'MODの内容',NULL,'Text',1),
+('01a04c1f-4c7d-7e42-96bf-8553b99f3998','01a04c1f-4c7d-7e42-96bf-856e78f482a4','mod_description_url',2,'MODの説明などが記載されているURL','ダウンロード先への直リンクなどは避けてください。','Text',1),
+('01a04c1f-4c98-74e0-b92b-c3fb8d09893a','01a04c1f-4c98-74e0-b92b-c400d4e1fbb1','login_schedule',0,'ログインする予定がある日時','修復のためにログインする予定の日時を少なくとも3つ記入してください。候補の中から運営チームが対応できる日時を選びます。例：2023/01/01 00:00～12:00','Text',1),
+('01a04c1f-4cb3-7f91-b64b-e1f81b69fc0f','01a04c1f-4cb3-7f91-b64b-e2057b56f55f','appeal_content',0,'異議申し立ての内容','異議申し立ての詳細内容を入力してください。Enterキーで改行できます。','Text',1),
+('01a04c1f-4cce-7391-b10b-6e207eb76132','01a04c1f-4cce-7391-b10b-6e3fb1d2af6c','world_regeneration_target',0,'どのサーバー／整地ワールドについてのご希望でしょうか。','該当するものを複数選択してください。','MultipleChoice',1),
+('01a04c1f-4ce6-7761-bde2-d58a4c93ab38','01a04c1f-4ce6-7761-bde2-d59b8542f30e','inquiry_content',0,'お問い合わせ内容','お問い合わせの詳細内容を自由に入力してください。Enterキーで改行できます。','Text',1),
+('01a050c7-7c1a-7f01-bfd0-5c0a7fde0e8b','01a050c7-7c1a-7f01-bfd0-5c1841f81001','content',1,'内容','アイデアの提案内容や、不具合の発生状況・再現手順など、対応に必要な情報を具体的に記入してください。','Text',1),
+('01a050c7-e4ee-7cd0-ac7f-81c68d692c7f','01a050c7-e4ee-7cd0-ac7f-81d804679e0f','content',1,'内容','対象となる場所・保護・建築物、現状、希望する対応などを具体的に記入してください。','Text',1),
+('01a050c7-e518-7fc2-af67-ba1859ec9ca3','01a050c7-e518-7fc2-af67-ba2df61aa4ff','content',1,'内容','企画の目的、対象、必要な成果物、希望時期などを具体的に記入してください。','Text',1),
+('01a050c7-e547-7e62-8efe-0cb0f00d7ba4','01a050c7-e547-7e62-8efe-0ccc3209c06a','content',1,'内容','議題、出席者、議論の要点、決定事項、担当者、期限などを記録してください。','Text',1),
+('01a050c7-e56e-7010-8425-c71842b8fb10','01a050c7-e56e-7010-8425-c7201cef8032','content',1,'内容','対象者、発生日時、行為の内容、確認に必要な情報、証拠へのリンクなどを具体的に記入してください。','Text',1),
+('01a050d5-68e7-7633-838e-c34f4de13c18','01a050c7-7c1a-7f01-bfd0-5c1841f81001','issue_type',0,'課題の種類','登録する課題の種類を選択してください。','SingleChoice',1),
+('01a050d5-df4e-7dc0-a7eb-656516cffd64','01a050c7-e4ee-7cd0-ac7f-81d804679e0f','request_type',0,'案件の種類','登録する案件の種類を選択してください。','SingleChoice',1),
+('01a050d5-df87-71b0-a42c-930959f3a86a','01a050c7-e518-7fc2-af67-ba2df61aa4ff','request_type',0,'案件の種類','登録する案件の種類を選択してください。','SingleChoice',1),
+('01a050d5-dfbc-7543-bcb4-97f74f50fa99','01a050c7-e547-7e62-8efe-0ccc3209c06a','meeting_type',0,'会議の種類','記録する会議の種類を選択してください。','SingleChoice',1),
+('01a050d5-dff7-72b3-a6a6-8beff000a7c7','01a050c7-e56e-7010-8425-c7201cef8032','evidence_type',0,'証拠の発生場所','証拠の対象となる行為が発生した場所を選択してください。','SingleChoice',1),
+('01a052fd-44a5-72b3-aff7-601574f93efe','01a052fd-44a5-72b3-aff7-6035df6d6772','content',0,'案件の内容','公共建築に関する内容を記入してください。','Text',1),
+('01a052fd-44a5-72b3-aff7-6022fefd3648','01a052fd-44a5-72b3-aff7-6035df6d6772','completion_condition',1,'終了条件','案件を完了とする条件を記入してください。','Text',0),
+('01a052fd-da04-7951-acd8-acc89182c0dc','01a052fd-da04-7951-acd8-ad28963480a9','content',0,'報告内容','不要な保護に関する内容を記入してください。','Text',1),
+('01a052fd-da04-7951-acd8-acd15af55f97','01a052fd-da04-7951-acd8-ad28963480a9','minecraft_id',1,'Minecraft ID','対象となる土地の所有者など、分かる場合は Minecraft ID を記入してください。','Text',0),
+('01a052fd-da04-7951-acd8-ace103918d06','01a052fd-da04-7951-acd8-ad28963480a9','server',2,'サーバー','対象のサーバーを記入してください。','Text',0),
+('01a052fd-da04-7951-acd8-acf25eba1987','01a052fd-da04-7951-acd8-ad28963480a9','world',3,'ワールド','対象のワールドを記入してください。','Text',0),
+('01a052fd-da04-7951-acd8-ad086a82bf66','01a052fd-da04-7951-acd8-ad28963480a9','coordinate',4,'座標','対象地点の座標を記入してください。','Text',0),
+('01a052fd-da04-7951-acd8-ad150d4503ea','01a052fd-da04-7951-acd8-ad28963480a9','reason',5,'不要と判断した理由','該当する理由を選択してください。','MultipleChoice',0),
+('01a052fe-258f-7a83-81c3-7e81396fed83','01a052fd-8ae3-7a73-8856-d101b56d47b8','content',0,'依頼内容','修繕してほしい内容を記入してください。','Text',1),
+('01a052fe-258f-7a83-81c3-7e9f3b1b69ce','01a052fd-8ae3-7a73-8856-d101b56d47b8','server',1,'サーバー','対象のサーバーを記入してください。','Text',0),
+('01a052fe-258f-7a83-81c3-7ea7d7ebba27','01a052fd-8ae3-7a73-8856-d101b56d47b8','world',2,'ワールド','対象のワールドを記入してください。','Text',0),
+('01a052fe-258f-7a83-81c3-7eb880c8789a','01a052fd-8ae3-7a73-8856-d101b56d47b8','coordinate',3,'座標','対象地点の座標を記入してください。','Text',0),
+('01a052fe-258f-7a83-81c3-7ec77e067d07','01a052fd-8ae3-7a73-8856-d101b56d47b8','coordinate_2',4,'座標2','範囲のある依頼など、追加の座標があれば記入してください。','Text',0),
+('01a052fe-258f-7a83-81c3-7eddb455f045','01a052fd-8ae3-7a73-8856-d101b56d47b8','repair_types',5,'修繕依頼の内容','該当する内容を選択してください。','MultipleChoice',0) ON DUPLICATE KEY UPDATE `form_id` = VALUES(`form_id`), `template_key` = VALUES(`template_key`), `position` = VALUES(`position`), `title` = VALUES(`title`), `description` = VALUES(`description`), `question_type` = VALUES(`question_type`), `is_required` = VALUES(`is_required`);
+
+-- Seed form_choices.
+INSERT INTO `form_choices` (`id`, `question_id`, `position`, `label`) VALUES
+(1,'01a04c05-2cd2-74b0-bf0c-ea777979c48f',0,'ゲーム内'),
+(2,'01a04c05-2cd2-74b0-bf0c-ea777979c48f',1,'Discord'),
+(3,'01a04c05-2cd2-74b0-bf0c-ea777979c48f',2,'Redmine'),
+(4,'01a04c05-2cd2-74b0-bf0c-ea777979c48f',3,'公式HP'),
+(5,'01a04c05-2cd2-74b0-bf0c-ea777979c48f',4,'その他'),
+(6,'01a04c0c-7d3c-7973-bbde-dabd3a9f6565',0,'はい'),
+(7,'01a04c0c-7d3c-7973-bbde-dabd3a9f6565',1,'いいえ'),
+(8,'01a04c0c-7d3c-7973-bbde-dacef381c1c5',0,'この通報は個人チャット（ダイレクトメッセージ）に関する内容を含みます。私は運営チームが個人間チャットの内容を確認することに同意します。'),
+(34,'01a04c19-06d1-78e1-82a1-b3ff6219aca5',0,'私はRedmineを検索し、同じアイデアがないことを確認しました'),
+(35,'01a04c1f-4cce-7391-b10b-6e207eb76132',0,'アルカディア／第2整地'),
+(36,'01a04c1f-4cce-7391-b10b-6e207eb76132',1,'アルカディア／第3整地'),
+(37,'01a04c1f-4cce-7391-b10b-6e207eb76132',2,'アルカディア／第4整地'),
+(38,'01a04c1f-4cce-7391-b10b-6e207eb76132',3,'アルカディア／ネザー整地'),
+(39,'01a04c1f-4cce-7391-b10b-6e207eb76132',4,'アルカディア／エンド整地'),
+(40,'01a04c1f-4cce-7391-b10b-6e207eb76132',5,'エデン／第2整地'),
+(41,'01a04c1f-4cce-7391-b10b-6e207eb76132',6,'エデン／第3整地'),
+(42,'01a04c1f-4cce-7391-b10b-6e207eb76132',7,'エデン／ネザー整地'),
+(43,'01a04c1f-4cce-7391-b10b-6e207eb76132',8,'エデン／エンド整地'),
+(44,'01a04c1f-4cce-7391-b10b-6e207eb76132',9,'ヴァルハラ／第2整地'),
+(45,'01a04c1f-4cce-7391-b10b-6e207eb76132',10,'ヴァルハラ／第3整地'),
+(46,'01a04c1f-4cce-7391-b10b-6e207eb76132',11,'ヴァルハラ／第4整地'),
+(47,'01a04c1f-4cce-7391-b10b-6e207eb76132',12,'ヴァルハラ／ネザー整地'),
+(48,'01a04c1f-4cce-7391-b10b-6e207eb76132',13,'ヴァルハラ／エンド整地'),
+(49,'01a04c1f-4cce-7391-b10b-6e207eb76132',14,'整地専用／Earth整地'),
+(50,'01a04c1f-4cce-7391-b10b-6e207eb76132',15,'整地専用／第4整地'),
+(51,'01a050d5-68e7-7633-838e-c34f4de13c18',0,'アイデア'),
+(52,'01a050d5-68e7-7633-838e-c34f4de13c18',1,'不具合'),
+(53,'01a050d5-df4e-7dc0-a7eb-656516cffd64',0,'公共建築'),
+(54,'01a050d5-df4e-7dc0-a7eb-656516cffd64',1,'修繕依頼'),
+(55,'01a050d5-df4e-7dc0-a7eb-656516cffd64',2,'不要保護報告'),
+(56,'01a050d5-df87-71b0-a42c-930959f3a86a',0,'イベント'),
+(57,'01a050d5-df87-71b0-a42c-930959f3a86a',1,'デザイン'),
+(58,'01a050d5-dfbc-7543-bcb4-97f74f50fa99',0,'運営会議'),
+(59,'01a050d5-dfbc-7543-bcb4-97f74f50fa99',1,'アイデア会議'),
+(60,'01a050d5-dff7-72b3-a6a6-8beff000a7c7',0,'ゲーム内'),
+(61,'01a050d5-dff7-72b3-a6a6-8beff000a7c7',1,'Discord'),
+(66,'01a052fd-da04-7951-acd8-ad150d4503ea',0,'1マスのみである'),
+(67,'01a052fd-da04-7951-acd8-ad150d4503ea',1,'その他'),
+(68,'01a052fd-da04-7951-acd8-ad150d4503ea',2,'全Ownerが永久BANを受けている'),
+(69,'01a052fd-da04-7951-acd8-ad150d4503ea',3,'同一箇所に異常なほど重なっている'),
+(70,'01a052fd-da04-7951-acd8-ad150d4503ea',4,'未建築または建築途中で、全Ownerのlastquitが7日以上前'),
+(71,'01a052fd-da04-7951-acd8-ad150d4503ea',5,'極端に長方形である'),
+(72,'01a052fd-da04-7951-acd8-ad150d4503ea',6,'活用済みの土地が著しく少ない'),
+(73,'01a052fe-258f-7a83-81c3-7eddb455f045',0,'空中ブロック'),
+(74,'01a052fe-258f-7a83-81c3-7eddb455f045',1,'トンネル状'),
+(75,'01a052fe-258f-7a83-81c3-7eddb455f045',2,'水放置'),
+(76,'01a052fe-258f-7a83-81c3-7eddb455f045',3,'マグマ放置') ON DUPLICATE KEY UPDATE `question_id` = VALUES(`question_id`), `position` = VALUES(`position`), `label` = VALUES(`label`);
+
+-- Seed label_for_form_answers.
+INSERT INTO `label_for_form_answers` (`id`, `name`) VALUES
+('01a04c43-e914-7db3-a1ee-7e997089e14e','優先度: 今すぐ'),
+('01a04c43-e92e-7ae3-80a2-9384a4eb1f88','優先度: 低め'),
+('01a04c43-ea10-7ed3-88a3-627d4e52be43','優先度: 急いで'),
+('01a04c43-eb28-71a2-8f1c-b33b764da184','優先度: 通常'),
+('01a04c43-ebd6-7c60-8bba-a96e535c9e86','優先度: 高め'),
+('01a050c6-a353-7f32-8e02-f41e6cb6cf2c','移行元トラッカー: アイデア'),
+('01a050c6-a377-7583-86fa-dd4bffb84404','移行元トラッカー: 不具合'),
+('01a050c6-a398-7621-a48b-1e8ed8159dfb','移行元トラッカー: 公共建築'),
+('01a050c6-a3bb-7922-a3f2-afe4a1dde60e','移行元トラッカー: 修繕依頼'),
+('01a050c6-a3dc-7881-b540-9e2105988d74','移行元トラッカー: 不要保護報告'),
+('01a050c6-a3fc-7bf1-8bda-4d36521b3854','移行元トラッカー: イベント'),
+('01a050c6-a41c-7b20-b1b2-1753c13a19b9','移行元トラッカー: デザイン'),
+('01a050c6-a43c-70f3-8750-5ab80798ecf1','移行元トラッカー: 運営会議'),
+('01a050c6-a45c-72c1-b194-55bedc3fac75','移行元トラッカー: アイデア会議'),
+('01a050c6-a480-7802-a234-cbab77ea2271','移行元トラッカー: ゲーム内処罰エビデンス'),
+('01a050c6-a4a1-7602-a5d6-bc82dd41e3b0','移行元トラッカー: Discord処罰エビデンス'),
+('01a05219-7683-7a11-8136-4bcb3c1004a6','移行元ステータス: 承認'),
+('01a05219-980d-7c50-8c05-fbf50dab0139','移行元ステータス: 却下') ON DUPLICATE KEY UPDATE `name` = VALUES(`name`);
+
+-- Seed form_discord_webhooks.
+INSERT INTO `form_discord_webhooks` (`id`, `form_id`, `url`) VALUES
+(1,'01a04c05-2cd2-74b0-bf0c-eab63b3f2213',NULL),
+(3,'01a04c0c-7d3c-7973-bbde-dadbfd9abc0b',NULL),
+(4,'01a04c15-4c82-7b81-a6b5-99350312fa71',NULL),
+(6,'01a04c19-06d1-78e1-82a1-b437f1c81ede',NULL),
+(7,'01a04c1f-4c5d-7ab2-baf4-753b65eef361',NULL),
+(8,'01a04c1f-4c7d-7e42-96bf-856e78f482a4',NULL),
+(9,'01a04c1f-4c98-74e0-b92b-c400d4e1fbb1',NULL),
+(10,'01a04c1f-4cb3-7f91-b64b-e2057b56f55f',NULL),
+(11,'01a04c1f-4cce-7391-b10b-6e3fb1d2af6c',NULL),
+(12,'01a04c1f-4ce6-7761-bde2-d59b8542f30e',NULL),
+(14,'01a050c7-7c1a-7f01-bfd0-5c1841f81001',NULL),
+(15,'01a050c7-e4ee-7cd0-ac7f-81d804679e0f',NULL),
+(16,'01a050c7-e518-7fc2-af67-ba2df61aa4ff',NULL),
+(17,'01a050c7-e547-7e62-8efe-0ccc3209c06a',NULL),
+(18,'01a050c7-e56e-7010-8425-c7201cef8032',NULL),
+(33,'01a052fd-44a5-72b3-aff7-6035df6d6772',NULL),
+(34,'01a052fd-8ae3-7a73-8856-d101b56d47b8',NULL),
+(35,'01a052fd-da04-7951-acd8-ad28963480a9',NULL) ON DUPLICATE KEY UPDATE `form_id` = VALUES(`form_id`), `url` = VALUES(`url`);
+
+-- Seed global_discord_webhook_settings.
+INSERT INTO `global_discord_webhook_settings` (`singleton_key`, `url`) VALUES
+(1,NULL) ON DUPLICATE KEY UPDATE `url` = VALUES(`url`);
+
+COMMIT;

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/database-migration/job.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/database-migration/job.yaml
@@ -1,0 +1,119 @@
+# Portal DB の schema migration 後に、Redmine importer が参照する初期データを一度だけ投入する Job。
+#
+# 初回 merge では ArgoCD の Skip により実行されない。DB の schema と Secret を確認した後、
+# この Job／NetworkPolicy／ConfigMap の Skip を削除する変更を merge して実行すること。
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: seichi-portal-pre-redmine-migration
+  namespace: seichi-minecraft
+  labels:
+    app: seichi-portal-pre-redmine-migration
+  annotations:
+    argocd.argoproj.io/sync-options: Skip
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: 3600
+  template:
+    metadata:
+      labels:
+        app: seichi-portal-pre-redmine-migration
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: mariadb-client
+          image: docker-registry1.mariadb.com/library/mariadb:11.8@sha256:2439dcd7d14010ecd1ff7a4e1c5abe8e208c34fe35290744deeeaac3569043c3
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+
+              export MYSQL_PWD="${MYSQL_PASSWORD}"
+              mariadb_args="
+                --protocol=TCP
+                --host=${MYSQL_HOST}
+                --port=${MYSQL_PORT}
+                --user=${MYSQL_USER}
+                --database=${MYSQL_DATABASE}
+              "
+
+              schema_is_ready() {
+                schema_table_count="$(
+                  mariadb ${mariadb_args} \
+                    --batch \
+                    --skip-column-names \
+                    -e "
+                      SELECT COUNT(*)
+                      FROM information_schema.tables
+                      WHERE table_schema = DATABASE()
+                        AND table_name IN (
+                          'users',
+                          'form_meta_data',
+                          'form_questions',
+                          'form_choices',
+                          'label_for_form_answers',
+                          'form_discord_webhooks',
+                          'global_discord_webhook_settings'
+                        );
+                    " 2>/dev/null
+                )"
+                [ "${schema_table_count}" = "7" ]
+              }
+
+              until schema_is_ready; do
+                sleep 5
+              done
+
+              mariadb ${mariadb_args} \
+                --batch \
+                --skip-column-names \
+                < /migration/001-pre-redmine-seed.sql
+              unset MYSQL_PWD
+          env:
+            - name: MYSQL_DATABASE
+              value: seichi-portal
+            - name: MYSQL_USER
+              value: seichi-portal
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: seichi-portal-db-credentials
+                  key: password
+            - name: MYSQL_HOST
+              value: mariadb
+            - name: MYSQL_PORT
+              value: "3306"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: migration
+              mountPath: /migration
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: migration
+          configMap:
+            name: seichi-portal-pre-redmine-migration-sql
+            defaultMode: 0444
+        - name: tmp
+          emptyDir: {}

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/database-migration/kustomization.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/database-migration/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: seichi-minecraft
+
+resources:
+  - job.yaml
+  - network-policy.yaml
+
+configMapGenerator:
+  - name: seichi-portal-pre-redmine-migration-sql
+    files:
+      - 001-pre-redmine-seed.sql
+
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    argocd.argoproj.io/sync-options: Skip
+    argocd.argoproj.io/sync-wave: "-1"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/database-migration/network-policy.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/database-migration/network-policy.yaml
@@ -1,11 +1,11 @@
-# Importer が移行中に使う宛先だけを許可する一時 CiliumNetworkPolicy。
+# Portal DB の初期データ migration Job が使う宛先だけを許可する一時 CiliumNetworkPolicy。
 #
-# 初回 merge では ArgoCD の Skip により作成されない。DB 復元、事前 data migration、plan の確認後に Job と
-# 同時に有効化し、移行完了後は kustomization から外して ArgoCD に prune させること。
+# 初回 merge では ArgoCD の Skip により作成されない。migration Job と同時に有効化し、
+# 移行完了後は Job／ConfigMap と一緒に prune させること。
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: allow--from-seichi-portal-redmine-importer--to-import-dependencies
+  name: allow--from-seichi-portal-pre-redmine-migration--to-mariadb
   namespace: seichi-minecraft
   annotations:
     argocd.argoproj.io/sync-options: Skip
@@ -13,7 +13,7 @@ metadata:
 spec:
   endpointSelector:
     matchLabels:
-      app: seichi-portal-redmine-importer
+      app: seichi-portal-pre-redmine-migration
   egress:
     - toServices:
         - k8sService:
@@ -33,11 +33,4 @@ spec:
               protocol: ANY
           rules:
             dns:
-              - matchName: redmine.seichi.click
               - matchName: mariadb.seichi-minecraft.svc.cluster.local
-    - toFQDNs:
-        - matchName: redmine.seichi.click
-      toPorts:
-        - ports:
-            - port: "443"
-              protocol: TCP

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/kustomization.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: seichi-minecraft
+
+resources:
+  - base

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/kustomization.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/kustomization.yaml
@@ -4,3 +4,4 @@ namespace: seichi-minecraft
 
 resources:
   - base
+  - database-migration

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/plan/kustomization.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/plan/kustomization.yaml
@@ -1,0 +1,29 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: seichi-minecraft
+
+nameSuffix: -plan
+
+resources:
+  - ../base
+
+patches:
+  - target:
+      group: batch
+      version: v1
+      kind: Job
+      name: seichi-portal-redmine-importer
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/argocd.argoproj.io~1sync-options
+      - op: replace
+        path: /spec/template/spec/containers/0/args
+        value: ["plan"]
+  - target:
+      group: cilium.io
+      version: v2
+      kind: CiliumNetworkPolicy
+      name: allow--from-seichi-portal-redmine-importer--to-import-dependencies
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/argocd.argoproj.io~1sync-options

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/verify/kustomization.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/verify/kustomization.yaml
@@ -1,0 +1,29 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: seichi-minecraft
+
+nameSuffix: -verify
+
+resources:
+  - ../base
+
+patches:
+  - target:
+      group: batch
+      version: v1
+      kind: Job
+      name: seichi-portal-redmine-importer
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/argocd.argoproj.io~1sync-options
+      - op: replace
+        path: /spec/template/spec/containers/0/args
+        value: ["verify"]
+  - target:
+      group: cilium.io
+      version: v2
+      kind: CiliumNetworkPolicy
+      name: allow--from-seichi-portal-redmine-importer--to-import-dependencies
+    patch: |-
+      - op: remove
+        path: /metadata/annotations/argocd.argoproj.io~1sync-options

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -610,6 +610,16 @@ variable "seichi_portal_backend__discord_bot_token" {
 
 #endregion
 
+#region seichi-portal-redmine-importer secrets
+
+variable "seichi_portal_redmine_importer__api_key" {
+  description = "Redmine API key for the one-off seichi-portal importer"
+  type        = string
+  sensitive   = true
+}
+
+#endregion
+
 #region seichi-portal-frontend secrets
 
 variable "seichi_portal_frontend__ms_app_client_id" {

--- a/terraform/onp_cluster_minecraft_secrets.tf
+++ b/terraform/onp_cluster_minecraft_secrets.tf
@@ -291,6 +291,21 @@ resource "kubernetes_secret_v1" "seichi_portal_backend_secrets" {
   type = "Opaque"
 }
 
+resource "kubernetes_secret_v1" "seichi_portal_redmine_importer_credentials" {
+  depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
+
+  metadata {
+    name      = "seichi-portal-redmine-importer-credentials"
+    namespace = "seichi-minecraft"
+  }
+
+  data = {
+    REDMINE_API_KEY = var.seichi_portal_redmine_importer__api_key
+  }
+
+  type = "Opaque"
+}
+
 resource "kubernetes_secret_v1" "seichi_portal_frontend_secrets" {
   depends_on = [kubernetes_namespace_v1.onp_seichi_minecraft]
 


### PR DESCRIPTION
## 概要

- Redmine から SeichiPortal へ issue、journal comment、issue relation を移行する `batch/v1 Job` と、移行中だけ必要な CiliumNetworkPolicy を追加しました。
- Importer image は次の tag と GHCR OCI index digest に固定しています。
  `ghcr.io/giganticminecraft/seichi-portal-redmine-importer:163de71799135a2445b99707cde02bf5621eea18@sha256:5406a8b58d56020bb6256711a73ca25a5bacb99fe8452ec3b557a50e5dede9cf`
- Job は `seichi-minecraft` namespace の `seichi-portal-redmine-importer` とし、`args: ["import"]`、`restartPolicy: Never`、`backoffLimit: 0`、12 時間の deadline、非 root／read-only root filesystem／capabilities 全 drop／RuntimeDefault seccomp を設定しました。`ttlSecondsAfterFinished` は設定していません。
- egress は `mariadb:3306`、kube-dns の DNS、`redmine.seichi.click:443` のみに限定しています。backend HTTP API、Redis、RabbitMQ、Meilisearch には接続しません。
- dump 自体は Git／ConfigMap／Secret／image に含めず、dump のうち importer 実行前に必要な Portal 初期データだけを data-only migration `001-pre-redmine-seed.sql` として Git 管理し、MariaDB client の一回限り Job で既存 schema に適用します。ConfigMap／migration Job／migration NetworkPolicy は importer より先の sync wave で適用し、完了後に one-off directory ごと prune します。
- `plan`／`verify` は常設 Application に含めず、同じ base を使う一時 Kustomize overlay として runbook に記載しました。
- 既存の Terraform Secret 管理方式に合わせ、sensitive variable から `seichi-portal-redmine-importer-credentials` Secret を provision します。

## Secret の事前準備

この PR の Terraform plan が実行される前に、GitHub Actions repository secret `TF_VAR_SEICHI_PORTAL_REDMINE_IMPORTER__API_KEY` を out-of-band で登録してください。この Secret がない状態では必須 Terraform variable に値が入らず plan が失敗します。既存 workflow の `expose-all-tf-vars-to-github-env.sh` が Secret 名の `TF_VAR_` 以降を小文字化して Terraform variable へ渡し、merge 後の Terraform apply が `seichi-portal-redmine-importer-credentials` Secret に `REDMINE_API_KEY` を provision します。値は Git、YAML、Job の args、ログ、README に書かず、Kubernetes Secret は存在と key 名だけを確認します。移行完了後に全 Job／ConfigMap／NetworkPolicy を ArgoCD が prune したことを確認してから、Terraform の Secret resource／variable と repository secret を cleanup します。

## 実行手順と後片付け

1. 本番 DB の現行 backup を取得する。
2. Portal backend の書き込みを停止または maintenance 状態にする。
3. `test_user`、`test_std_user` と紐づくデバッグ用 BAN を除外した Portal DB backup を復元する。SQL dump は Git、ConfigMap、Secret、image に含めません。
4. DB restore 完了と対象 DB の接続を確認する。
5. DB schema migration 完了後、data migration の ConfigMap／Job／NetworkPolicy の `Skip` だけを削除する enable change を merge し、migration Job の完了と SQL 実行結果を確認する。続けて必要なフォーム、question、choice、label を確認する。
6. `plan` overlay を apply し、`report: 0 error(s), 0 warning(s)`、フォーム分類、custom field mapping、公開範囲を確認して overlay を削除する。
7. plan と data migration に問題がなければ、importer Job／NetworkPolicy の `argocd.argoproj.io/sync-options: Skip` だけを削除する別の enable change を merge し、ArgoCD に import Job を作成させる。migration Job は再実行しない。
8. Job の完了状態とログを確認する。
9. `verify` overlay を apply し、全件 `AlreadyImported` を確認して overlay を削除する。
10. issue 約 12,491 件、journal comment 約 14,530 件、answer relation 約 2,186 件を目安に、フォーム別件数と公開範囲を確認する。Redmine 更新により件数は変わり得ます。
11. one-off directory 全体を削除する cleanup change を merge し、生成 Application の finalizer と prune 完了、および importer／migration の Job、ConfigMap、NetworkPolicy の消失を確認する。
12. backend の通常運用を再開する。
13. 移行完了後に `seichi-portal-backend` 側の Redmine importer PR #1383（merge commit `163de71799135a2445b99707cde02bf5621eea18`）を revert する。

詳細なコマンド、SQL、ArgoCD の削除確認は `docs/runbooks/seichi-portal-redmine-importer.md` を参照してください。

## 確認事項

- `docker buildx imagetools inspect`、amd64 image pull、image metadata で digest、`USER ubuntu`、entrypoint `/redmine-importer`、組み込み config path を確認しました。
- importer base／plan／verify と data migration の `kubectl kustomize` 展開に成功しました。
- kubeconform（既存 pin の CRD schema catalog を含む）で 11 resources／4 files を `Valid: 11, Invalid: 0, Errors: 0, Skipped: 0` と確認しました。
- 一時 MariaDB で source dump を schema と data に分け、data-only migration を空の同一 schema へ適用し、2 回目も成功することと forms 18／questions 46／choices 47／labels 18 などの行数を確認しました。
- `terraform fmt -check -diff -recursive`、`terraform init -backend=false` 後の `terraform validate`、`git diff --check` を実行しました。
- production cluster への `kubectl apply`、DB restore、Job 実行、Job／NetworkPolicy の削除は行っていません。

🤖 Generated with Codex
