### PR TITLE
ops: Redmine 移行前の DB migration を有効化

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/database-migration/job.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/database-migration/job.yaml
@@ -10,7 +10,6 @@ metadata:
   labels:
     app: seichi-portal-pre-redmine-migration
   annotations:
-    argocd.argoproj.io/sync-options: Skip
     argocd.argoproj.io/sync-wave: "0"
 spec:
   backoffLimit: 0

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/database-migration/kustomization.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/database-migration/kustomization.yaml
@@ -14,5 +14,4 @@ configMapGenerator:
 generatorOptions:
   disableNameSuffixHash: true
   annotations:
-    argocd.argoproj.io/sync-options: Skip
     argocd.argoproj.io/sync-wave: "-1"

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/database-migration/network-policy.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-redmine-importer/database-migration/network-policy.yaml
@@ -8,7 +8,6 @@ metadata:
   name: allow--from-seichi-portal-pre-redmine-migration--to-mariadb
   namespace: seichi-minecraft
   annotations:
-    argocd.argoproj.io/sync-options: Skip
     argocd.argoproj.io/sync-wave: "-1"
 spec:
   endpointSelector:


### PR DESCRIPTION
## 概要

Redmine importer を実行する前段として、Portal DB の data-only migration を ArgoCD で有効化します。
この PR は merge すると `seichi-minecraft` namespace に次の resource が作成され、migration Job が発火します。

- `seichi-portal-pre-redmine-migration` Job
- migration 用 CiliumNetworkPolicy
- `seichi-portal-pre-redmine-migration-sql` ConfigMap

削除するのは上記3リソースの `argocd.argoproj.io/sync-options: Skip` だけです。importer、plan、verify は引き続き
Skip のままです。

## Merge 前の確認

- 本番 DB の現行 backup を取得済みであること
- Portal backend の書き込みを停止または maintenance 状態にしていること
- `test_user`、`test_std_user` と紐づくデバッグ用 BAN を除外した DB backup を復元済みであること
- DB schema migration と `seichi-portal` DB user による接続を確認済みであること
- Terraform apply が成功し、既存 DB credentials Secret が利用可能であること

SQL dump 自体や DB password は Git、ConfigMap、Secret、Job args、ログに含めません。Redmine API key は repository
secret `TF_VAR_SEICHI_PORTAL_REDMINE_IMPORTER__API_KEY` から Terraform 経由で provision します。

## Merge 後の確認

ArgoCD の自動同期で migration Job が作成され、sync wave `0` で一度だけ実行されます。Job が `Complete` になり、
SQL 実行エラーがないこと、users 1／forms 18／questions 46／choices 47／labels 18 などの投入結果を確認します。
確認が終わるまで importer／plan／verify を有効化する別 PR は merge しません。

Job の作成・削除に `kubectl apply/delete` は使用しません。状態とログの確認は ArgoCD UI、または read-only の操作で
行います。移行完了後は one-off directory 全体を Git から削除し、ArgoCD に prune させます。

## 確認事項

- Kustomize render 成功
- kubeconform: `Valid: 9, Invalid: 0, Errors: 0, Skipped: 0`
- yamllint 成功
- `git diff --check` 成功
- production cluster への apply、DB restore、Job 実行、削除はこの PR 作成時点では行っていません

🤖 Generated with Codex
