### PR TITLE
fix: Redmine 移行用 DB ユーザーの接続数上限を設定

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/seichi-portal-db.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/seichi-portal-db.yaml
@@ -23,6 +23,7 @@ spec:
   passwordSecretKeyRef:
     name: seichi-portal-db-credentials
     key: password
+  maxUserConnections: 50
 
 ---
 apiVersion: k8s.mariadb.com/v1alpha1


### PR DESCRIPTION
## 概要
- Redmine importer の実行時に Portal DB ユーザーの接続数上限へ達するため、MariaDB Operator の `User` に `maxUserConnections: 50` を設定します。
- `seichi-portal` の `User` を再作成する際に適用される設定です。
- Importer、Secret、SQL dump には変更を加えていません。

## 確認事項
- `origin/main` 起点で今回の設定1行だけの差分であることを確認しました。
- `git diff --check` を実行し、問題ありませんでした。
- 本番クラスタへの apply や DB 操作は実施していません。
- `User` は接続数設定が immutable のため、適用時は `seichi-portal` の User 再作成が必要です。

🤖 Generated with Codex