### PR TITLE
seichi-portal-backend の OOM を防ぐためリソース上限を増やす

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
@@ -53,14 +53,14 @@ spec:
             timeoutSeconds: 3
             failureThreshold: 3
           resources:
-            # OTel exporter のオーバーヘッド吸収のため limit を 100m から 300m へ増強
-            # (seichi-game-data-publisher が exporter 導入時に 50m→300m へ増強した実績に倣う)
+            # 起動・復旧時のメモリ増加と CPU throttling を吸収する。
+            # 平常時の CPU 使用量は小さいため、CPU request は据え置く。
             requests:
               cpu: 50m
-              memory: 128Mi
-            limits:
-              cpu: 300m
               memory: 256Mi
+            limits:
+              cpu: 600m
+              memory: 512Mi
           env:
             - name: MYSQL_DATABASE
               value: seichi-portal


### PR DESCRIPTION
## 概要

- seichi-portal-backend が 256Mi のメモリ上限に達して OOMKilled を繰り返していたため、memory request を 128Mi から 256Mi、limit を 256Mi から 512Mi に増やす
- 復旧中の CPU 使用量が 300m の上限付近に達し、CFS throttling も確認されたため、CPU limit を 300m から 600m に増やす
- 平常時の CPU 使用量は小さいため、CPU request は 50m のまま維持する

## 確認事項

- ArgoCD で対象 Pod の終了理由が OOMKilled、exit code が 137、再起動回数が 6 回に増えていることを確認
- Grafana でメモリ使用量が最大 255.7Mi、CPU 使用量が最大 298m、CFS throttling が最大 100% に達していることを確認
- `git diff --check` が成功し、空白エラーがないことを確認
- ローカルの kubectl には接続先クラスタが設定されていないため、dry-run による Kubernetes API の検証は未実施

## 補足

- 反映後はメモリ使用量を継続して確認し、512Mi の上限でも余裕が不足する場合はアプリケーション側のメモリ使用原因を調査する

🤖 Generated with Codex