### PR TITLE
seichi-portal-backend のメモリ上限を一時的に 3Gi へ増やす

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
@@ -54,13 +54,14 @@ spec:
             failureThreshold: 3
           resources:
             # 起動・復旧時のメモリ増加と CPU throttling を吸収する。
+            # 実際に必要なメモリ量を観測できるよう、memory limit は一時的に 3Gi とする。
             # 平常時の CPU 使用量は小さいため、CPU request は据え置く。
             requests:
               cpu: 50m
               memory: 256Mi
             limits:
               cpu: 600m
-              memory: 512Mi
+              memory: 3Gi
           env:
             - name: MYSQL_DATABASE
               value: seichi-portal


### PR DESCRIPTION
## 概要

- PR #5974 でメモリ上限を 512Mi に増やした後も、seichi-portal-backend が起動から 36 秒で OOMKilled になった
- 実際に必要なメモリ量を観測できる余裕を設けるため、memory limit を一時的に 512Mi から 3Gi へ増やす
- memory request は 256Mi のまま維持する

## 確認事項

- ArgoCD で 512Mi の設定が反映された新しい Pod も OOMKilled となり、CrashLoopBackOff に入っていることを確認
- 終了理由が OOMKilled、exit code が 137、コンテナの稼働時間が 36 秒だったことを確認
- `git diff --check` が成功し、空白エラーがないことを確認
- Kubernetes の設定値だけを変更しているため、テストコードは追加していない
- ローカルの kubectl には接続先クラスタが設定されていないため、dry-run による Kubernetes API の検証は未実施

## 補足

- 反映後に Grafana でピークと定常時のメモリ使用量を確認し、適切な request / limit に改めて調整する

🤖 Generated with Codex