### PR TITLE
backend と Meilisearch の同期処理用リソースを増やす

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/meilisearch/meilisearch.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/meilisearch/meilisearch.yaml
@@ -24,12 +24,13 @@ spec:
           enabled: true
           size: 10Gi
         resources:
+          # Redmine 移行後の大量同期を処理できるよう、一時的に余裕を持たせる。
           requests:
-            cpu: "15m"
-            memory: "512Mi"
-          limits:
-            cpu: "50m"
+            cpu: "500m"
             memory: "1Gi"
+          limits:
+            cpu: "2"
+            memory: "2Gi"
   destination:
     server: https://kubernetes.default.svc
     namespace: seichi-minecraft

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
@@ -53,14 +53,13 @@ spec:
             timeoutSeconds: 3
             failureThreshold: 3
           resources:
-            # 起動・復旧時のメモリ増加と CPU throttling を吸収する。
+            # 大量同期時のメモリ増加と CPU throttling を吸収する。
             # 実際に必要なメモリ量を観測できるよう、memory limit は一時的に 3Gi とする。
-            # 平常時の CPU 使用量は小さいため、CPU request は据え置く。
             requests:
-              cpu: 50m
-              memory: 256Mi
+              cpu: 500m
+              memory: 1Gi
             limits:
-              cpu: 600m
+              cpu: "2"
               memory: 3Gi
           env:
             - name: MYSQL_DATABASE


### PR DESCRIPTION
## 概要

- Redmine 移行後の大量同期により、seichi-portal-backend と Meilisearch の双方で CPU throttling とファイル記述子不足が発生している
- backend の request を CPU 500m / memory 1Gi、limit を CPU 2 / memory 3Gi に増やす
- Meilisearch の request を CPU 500m / memory 1Gi、limit を CPU 2 / memory 2Gi に増やす

## 確認事項

- ArgoCD で backend が再起動せず動作している一方、readiness probe が失敗して 0/1 Ready になっていることを確認
- Grafana で backend の CPU 使用量が 600m の上限付近、CPU throttling が最大約 93% に達していることを確認
- Meilisearch の CPU throttling が最大 100% に達し、liveness probe の失敗で再起動したことを確認
- 両サービスのログで `Too many open files` / `No file descriptors available` が発生していることを確認
- `git diff --check` が成功し、空白エラーがないことを確認
- Kubernetes の設定値だけを変更しているため、テストコードは追加していない
- ローカル kubectl に接続先クラスタが設定されていないため、dry-run による Kubernetes API 検証は未実施

## 補足

- 今回の増量は大量同期を完了させるための暫定対応
- 同期完了後に Grafana の実測値を確認し、request / limit を再調整する
- ファイル記述子不足が続く場合は、同期処理の並列数制限が必要

🤖 Generated with Codex
