### PR TITLE
chore: seichi-portal-backend を 0.2.10 に更新

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: seichi-portal-backend
-          image: ghcr.io/giganticminecraft/seichi-portal-backend:0.2.8@sha256:33fc739aa75859fcef029210f208f598f8e536d69c7afce2dd65773320c1d5b2
+          image: ghcr.io/giganticminecraft/seichi-portal-backend:0.2.10@sha256:8d474417f16f36e39d0a701c4302b6b77b1ea39484983f9d9a9ebbf8097a5ffe
           ports:
             - name: http
               containerPort: 9000


### PR DESCRIPTION
## 概要
- seichi-portal-backend の本番イメージを 0.2.8 から 0.2.10 に更新
- 既存の digest 固定方式を維持し、0.2.10 の multi-arch index digest を設定

## 確認事項
- git diff --check を実行し、空白エラーがないことを確認
- 公開 GHCR の 0.2.10 マニフェストを取得し、設定した digest が index digest と一致することを確認
- Kubernetes API に接続できないため、クラスタ上の apply 検証は未実施

🤖 Generated with Codex