### PR TITLE
chore: seichi-portal-backend を 0.2.11 に更新

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: seichi-portal-backend
-          image: ghcr.io/giganticminecraft/seichi-portal-backend:0.2.10@sha256:8d474417f16f36e39d0a701c4302b6b77b1ea39484983f9d9a9ebbf8097a5ffe
+          image: ghcr.io/giganticminecraft/seichi-portal-backend:0.2.11@sha256:798977ce7be77c19b93f28c37e0bc92a5c6dada85acde003eca155909a93828b
           ports:
             - name: http
               containerPort: 9000


### PR DESCRIPTION
## 概要
- seichi-portal-backend の本番イメージを 0.2.10 から 0.2.11 に更新
- 既存の digest 固定方式を維持し、0.2.11 の multi-arch index digest を設定

## 確認事項
- git diff --check を実行し、空白エラーがないことを確認
- 公開 GHCR の 0.2.11 マニフェストを取得し、設定した digest が index digest と一致することを確認
- Kubernetes API に接続できないため、クラスタ上の apply 検証は未実施

🤖 Generated with Codex