### PR TITLE
chore(deps): ポータルのイメージを最新化

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: seichi-portal-backend
-          image: ghcr.io/giganticminecraft/seichi-portal-backend:0.2.11@sha256:798977ce7be77c19b93f28c37e0bc92a5c6dada85acde003eca155909a93828b
+          image: ghcr.io/giganticminecraft/seichi-portal-backend:0.2.12@sha256:ddd84cb7dbb88a0eecbb387fbaa15123b06f34a407eb572bed33fdc94b0be1f3
           ports:
             - name: http
               containerPort: 9000

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-frontend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-frontend/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: seichi-portal-frontend
-          image: ghcr.io/giganticminecraft/seichi-portal-frontend:0.3.12@sha256:2d3f41acd0522671c65ffd07c8eecde43442f308406f5fe5ed96b762fac4fbd8
+          image: ghcr.io/giganticminecraft/seichi-portal-frontend:0.3.13@sha256:87d9335c46b076e27e6b3ae7d6ba0b85a2533f15fdc373bf3fe055ac2b8918b1
           ports:
             - name: http
               containerPort: 3000


### PR DESCRIPTION
## 概要
- seichi-portal-backend を v0.2.12 に更新
- seichi-portal-frontend を v0.3.13 に更新
- 両イメージを GHCR の immutable digest で固定

## 確認事項
- GitHub API で両リポジトリの最新公開リリースを確認
- GHCR の image index digest を確認
- git diff --check を実行し、問題がないことを確認

## 補足
- 作業ツリーにあった未追跡 SQL ファイルは今回の変更に含めていません

🤖 Generated with Codex