### PR TITLE
chore(deps): ポータルのイメージを最新版へ更新

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-backend/deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: seichi-portal-backend
-          image: ghcr.io/giganticminecraft/seichi-portal-backend:0.2.12@sha256:ddd84cb7dbb88a0eecbb387fbaa15123b06f34a407eb572bed33fdc94b0be1f3
+          image: ghcr.io/giganticminecraft/seichi-portal-backend:0.2.13@sha256:07bf719b833f8b2641294653da3dd9145e02bfc317b7546692d99f99b41d9a92
           ports:
             - name: http
               containerPort: 9000

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-frontend/deployment.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/seichi-portal-frontend/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: seichi-portal-frontend
-          image: ghcr.io/giganticminecraft/seichi-portal-frontend:0.3.13@sha256:87d9335c46b076e27e6b3ae7d6ba0b85a2533f15fdc373bf3fe055ac2b8918b1
+          image: ghcr.io/giganticminecraft/seichi-portal-frontend:0.3.14@sha256:a8863c9de9324ae53de325330a860ba668a40ff5960b125974f5c36aca005159
           ports:
             - name: http
               containerPort: 3000


### PR DESCRIPTION
## 概要
- seichi-portal-backend を v0.2.13 に更新
- seichi-portal-frontend を v0.3.14 に更新
- 両イメージを GHCR の immutable digest で固定

## 確認事項
- GitHub API で両リポジトリの最新公開リリースを再確認
- GHCR の image index digest を確認
- git diff --check を実行し、問題がないことを確認

## 補足
- 作業ツリーにあった未追跡 SQL ファイルは今回の変更に含めていません

🤖 Generated with Codex