### PR TITLE
feat(prometheus): thanos-compact の halt と Garage の異常を検知するアラートを追加

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
@@ -287,6 +287,24 @@ spec:
                     annotations:
                       summary: Thanos object storage operation failures
                       description: Thanos object storage operation {{ "{{ $labels.operation }}" }} is failing for {{ "{{ $labels.job }}" }}.
+                  - alert: ThanosCompactHalted
+                    # compactor は critical error を踏むと halt して自動復帰しない。
+                    # halt 後もブロックメタデータの同期だけは回り続けるため Pod は Running/Ready のままで、
+                    # 「動いているように見えて compaction もブロック削除も止まっている」状態になる。
+                    # 実績: 2026-09-01 10:37Z に compact 作業ディレクトリ枯渇 (preallocate: no space left on device)
+                    # で halt し、6 日間気付かれなかった。その間 thanos バケットの増加が
+                    # 2.3 GiB/日 -> 17 GiB/日 に加速し、garage-backup-dump PVC (400Gi) を溢れさせて
+                    # backup--garage-to-pbs を ENOSPC で失敗させた。
+                    # この指標は halt 中ずっと 1 で安定するため == 1 を見るだけでよい
+                    # (for: 15m は Pod 再作成直後の一過性を吸収するため)。
+                    expr: thanos_compact_halted == 1
+                    for: 15m
+                    labels:
+                      severity: error
+                      notify: discord
+                    annotations:
+                      summary: Thanos compactor が halt しています
+                      description: compaction とブロック削除が停止しています。放置するとオブジェクトストレージが増え続けるため、thanos-compact のログから halt 理由を確認し、解消後に Pod を再作成してください。
           resource-usage:
             groups:
               - name: resource-usage

--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-alerts/prometheusrule.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/garage-alerts/prometheusrule.yaml
@@ -1,0 +1,51 @@
+# Garage の異常を既存の Alertmanager -> Discord 経路へ通知する。
+#
+# 重要: Garage 自身が公開するクラスタ健全性メトリクス
+# (cluster_healthy / cluster_available / cluster_storage_nodes_ok /
+#  cluster_partitions_quorum / cluster_partitions_all_ok) は
+# ノード間のネットワーク疎通ベースで、ストレージ障害には反応しない。
+# 2026-09-06〜09-07 に garage-2 の iSCSI LUN が offline 化して
+# 全 PUT が 503 になった障害でも、これらは最後まで正常値
+# (cluster_healthy=1, storage_nodes_ok=3/3, partitions_quorum=256/256) のままだった。
+# そのため「Garage が健全か」は下記 2 つで判断する。
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: garage-alerts
+  namespace: garage
+  labels:
+    release: prometheus
+spec:
+  groups:
+    - name: garage-alerts
+      rules:
+        - alert: GarageS3ServerErrors
+          # 症状側の一次シグナル。書き込みが quorum 不足で 503 になると
+          # Loki / Thanos / ワールドアップロード / バックアップが軒並み失敗する。
+          # 実測: 2026-08-15〜09-06 の日次 503 増分はほぼ全日 0 で、
+          # 障害中のみ約 8/秒。閾値 0.1/秒 は障害時実測の約 1/80 で十分な余裕がある。
+          expr: sum(rate(api_s3_error_counter{status_code="503"}[5m])) > 0.1
+          for: 10m
+          labels:
+            severity: critical
+            notify: discord
+          annotations:
+            summary: "Garage が S3 リクエストを 503 で拒否しています"
+            description: "Garage の 503 応答が 10 分以上継続しています。いずれかのノードのブロックストアが応答していない可能性が高いです。garage status はネットワーク疎通しか見ないため healthy に見える点に注意してください。各ノードで /sys/block/<dev>/device/state が offline になっていないか確認してください。"
+
+        - alert: GarageBlockResyncErrors
+          # 原因側のシグナル。ディスク I/O エラーなどでブロックの再同期に
+          # 失敗し続けている状態を捉える。
+          # 実測: 平常時は garage-0=20 / garage-1=13 / garage-2=29 前後で
+          # 23 日間ほぼ不動。障害時のみ garage-2 が 2199 まで上昇した。
+          # 閾値 100 は平常最大値の約 3 倍かつ障害時実測の約 1/20。
+          # 障害からの復旧中(resync キュー消化中)も一時的に上がるため、
+          # resync が終わるまで鳴り続けるのは期待どおりの挙動。
+          expr: max by (pod) (block_resync_errored_blocks) > 100
+          for: 30m
+          labels:
+            severity: warning
+            notify: discord
+          annotations:
+            summary: "Garage {{ $labels.pod }} で再同期に失敗しているブロックが増えています"
+            description: "{{ $labels.pod }} の block_resync_errored_blocks が 30 分以上 100 を超えています。ノードのカーネルログで I/O エラーを、garage block list-errors で参照が残るブロック(RC>0)を確認してください。"


### PR DESCRIPTION
## 背景

2026-09-06 の `backup--garage-to-pbs` 失敗を調査したところ、通知されたバックアップ失敗は最下流の症状にすぎず、**検知できていなかった障害が 2 つ**あることが分かりました。

| 時刻 (JST) | 事象 |
|---|---|
| 09-01 19:37 | **thanos-compact が halt**（compact 作業ディレクトリ枯渇）。以後 6 日間気付かれず |
| 09-01〜09-05 | compaction とブロック削除が止まり、thanos バケットが **2.3 GiB/日 → 17 GiB/日** に加速 |
| 09-06 10:00 | `garage-backup-dump` PVC (400Gi) が溢れ、**バックアップが ENOSPC で失敗**（通知されたのはここだけ） |
| 09-07 01:19 | 別件で **garage-2 の iSCSI LUN が offline 化**し、Garage の全 PUT が 503 に |

どちらも Discord には何も飛んでいませんでした。

## 変更内容

### 1. `ThanosCompactHalted`（既存 `thanos` グループに追加）

compactor は halt しても**ブロックメタデータの同期だけは回り続けるため Pod は Running/Ready のまま**で、外から見て正常に見えます。これが 6 日間の見逃しの直接原因でした。

```yaml
expr: thanos_compact_halted == 1
for: 15m
```

この指標は halt 中ずっと安定して 1 なので、`== 1` を見るだけで確実に検知できます。

### 2. `garage-alerts`（新規 PrometheusRule）

**設計上の要点**: Garage 自身のクラスタ健全性メトリクスは**ネットワーク疎通ベースで、ストレージ障害に完全に盲目**です。今回の障害中、全 PUT が 503 を返している最中も以下はすべて正常値のままでした。

| メトリクス | 障害中の値 |
|---|---|
| `cluster_healthy` | 1 |
| `cluster_storage_nodes_ok` | 3 / 3 |
| `cluster_partitions_quorum` | 256 / 256 |
| `cluster_partitions_all_ok` | 256 / 256 |

そのため、**実データで反応が確認できた 2 指標**でアラートを組んでいます。

```yaml
- GarageS3ServerErrors:    sum(rate(api_s3_error_counter{status_code="503"}[5m])) > 0.1   for 10m
- GarageBlockResyncErrors: max by (pod) (block_resync_errored_blocks) > 100               for 30m
```

閾値はすべて実測に基づきます。

| 指標 | 平常時（23日間） | 障害時 | 閾値の余裕 |
|---|---|---|---|
| 503 レート | 日次増分がほぼ全日 **0** | 約 **8/秒** | 障害時の約 1/80 |
| `block_resync_errored_blocks` | garage-0=20 / garage-1=13 / garage-2=29 で**ほぼ不動** | garage-2 が **2199** | 平常最大値の約 3 倍かつ障害時の約 1/20 |

## 意図的にやらなかったこと

**既存の Thanos アラート 3 本は変更していません**（差分の削除行は 0 です）。

- `ThanosSidecarUploadStale` — 偽発火実績あり（コメントに記録済み。2026-07-20 に約 2.5 時間誤 firing し、wk-2 の再起動を約 40 分ブロック）
- `ThanosSidecarUploadFailures` / `ThanosObjectStorageOperationFailures` — 障害との因果関係が認められた前例がなく、短時間の通知が積み重なると通知自体を見なくなるため

通知ノイズを増やさない方針を優先しました。

## 検証

- [x] YAML パース確認（Helm values 内にネストした `additionalPrometheusRulesMap` を含む）
- [x] 3 つの式すべてを本番 Prometheus で実行
  - `thanos_compact_halted == 1` → **1 を返す**（現在 halt 中のため、マージ後に実際に発火して Discord 経路まで通しで検証できます）
  - Garage 側 2 本 → いずれも空（garage-0=28 / garage-1=16 / garage-2=40 で閾値 100 を大きく下回る）＝ 誤発火なし
- [ ] マージ後: ArgoCD で `cluster-wide-apps-garage-alerts` が Synced/Healthy になること
- [ ] マージ後: Prometheus の `/api/v1/rules` に 3 ルールがロードされること

## 補足（本 PR の対象外）

- thanos-compact は **現在も halt したまま**です。同じ 7 ブロックのグループが 50Gi に収まらないことが 9/1 と 9/7 の 2 回の実測で確定しており、再起動だけでは同じ地点で止まります。`data-thanos-compact-0` の拡張が別途必要です。
- 根本的には Thanos の retention が `0d`（無期限）かつ downsampling 無効なため、compaction グループは今後も増え続けます（設定は外部リポジトリ `GiganticMinecraft/thanos-config`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKpnMJuaHaCGeKFBALCi3q
