### PR TITLE
fix(alertmanager): Discord 通知が content の YAML 再解釈で全滅していたのを修正

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/prometheus-operator.yaml
@@ -407,6 +407,20 @@ spec:
               # 暫定使用)。resolved と noncritical は投稿のみで ping しない。
               # チャンネル専用ロールに変える場合は critical receiver の content と
               # allowed_mentions の両方の ID を差し替える (#5601)。
+              #
+              # 【重要】payload 内の各文字列は、テンプレート描画後の結果が YAML として
+              # 再解釈される。パースに成功して非文字列型になると、その型のまま JSON 化されて
+              # Discord に送られ 400 で拒否される。
+              # 実例: content が "[FIRING:1] Alert (ns)" に描画されると Go の yaml.v3 は
+              # 先頭をフローシーケンスとして解釈し ["FIRING:1"] だけを残す(以降は捨てる)。
+              # Discord は content を文字列として期待するため
+              #   {"content": ["Could not interpret \"['FIRING:1']\" as string."]}
+              # を返し、通知が丸ごと失われる。2026-08-13〜09-07 の約 1 か月間、
+              # webhook 通知 2625 件中 2613 件がこれで失われていた (critical の firing だけは
+              # 先頭が <@&...> のロールメンションだったため偶然成功していた)。
+              # そのため content は必ず絵文字などの安全な文字で始める。
+              # 逆に description が "**Alert**" 始まりなのは問題ない。YAML のエイリアス参照
+              # として解釈に失敗し、生文字列にフォールバックするため。
               - name: "discord-portal-critical"
                 webhook_configs:
                   - url_file: /etc/alertmanager/secrets/portal-alert-discord/webhook-url
@@ -418,7 +432,7 @@ spec:
                       # デフォルトの __subject は末尾に CommonLabels - GroupLabels を
                       # 括弧で列挙する (condition/container/endpoint/... のダンプに
                       # なって読めない) ため、alertname と namespace だけの自作にする
-                      content: '{{ if eq .Status "firing" }}<@&532704116799963168> {{ end }}{{ if eq .Status "firing" }}[FIRING:{{ .Alerts.Firing | len }}]{{ else }}[RESOLVED]{{ end }} {{ .GroupLabels.alertname }}{{ with .GroupLabels.namespace }} ({{ . }}){{ end }}'
+                      content: '{{ if eq .Status "firing" }}<@&532704116799963168> 🔥 [FIRING:{{ .Alerts.Firing | len }}]{{ else }}✅ [RESOLVED]{{ end }} {{ .GroupLabels.alertname }}{{ with .GroupLabels.namespace }} ({{ . }}){{ end }}'
                       allowed_mentions:
                         roles: ["532704116799963168"]
                       embeds:
@@ -432,7 +446,7 @@ spec:
                   - url_file: /etc/alertmanager/secrets/portal-alert-discord/webhook-url
                     max_alerts: 5
                     payload:
-                      content: '{{ if eq .Status "firing" }}[FIRING:{{ .Alerts.Firing | len }}]{{ else }}[RESOLVED]{{ end }} {{ .GroupLabels.alertname }}{{ with .GroupLabels.namespace }} ({{ . }}){{ end }}'
+                      content: '{{ if eq .Status "firing" }}⚠️ [FIRING:{{ .Alerts.Firing | len }}]{{ else }}✅ [RESOLVED]{{ end }} {{ .GroupLabels.alertname }}{{ with .GroupLabels.namespace }} ({{ . }}){{ end }}'
                       allowed_mentions:
                         parse: []
                       embeds:
@@ -449,7 +463,7 @@ spec:
                       # デフォルトの __subject は末尾に CommonLabels - GroupLabels を
                       # 括弧で列挙する (condition/container/endpoint/... のダンプに
                       # なって読めない) ため、alertname と namespace だけの自作にする
-                      content: '{{ if eq .Status "firing" }}<@&532704116799963168> {{ end }}{{ if eq .Status "firing" }}[FIRING:{{ .Alerts.Firing | len }}]{{ else }}[RESOLVED]{{ end }} {{ .GroupLabels.alertname }}{{ with .GroupLabels.namespace }} ({{ . }}){{ end }}'
+                      content: '{{ if eq .Status "firing" }}<@&532704116799963168> 🔥 [FIRING:{{ .Alerts.Firing | len }}]{{ else }}✅ [RESOLVED]{{ end }} {{ .GroupLabels.alertname }}{{ with .GroupLabels.namespace }} ({{ . }}){{ end }}'
                       allowed_mentions:
                         roles: ["532704116799963168"]
                       embeds:
@@ -463,7 +477,7 @@ spec:
                   - url_file: /etc/alertmanager/secrets/infra-alert-discord/webhook-url
                     max_alerts: 5
                     payload:
-                      content: '{{ if eq .Status "firing" }}[FIRING:{{ .Alerts.Firing | len }}]{{ else }}[RESOLVED]{{ end }} {{ .GroupLabels.alertname }}{{ with .GroupLabels.namespace }} ({{ . }}){{ end }}'
+                      content: '{{ if eq .Status "firing" }}⚠️ [FIRING:{{ .Alerts.Firing | len }}]{{ else }}✅ [RESOLVED]{{ end }} {{ .GroupLabels.alertname }}{{ with .GroupLabels.namespace }} ({{ . }}){{ end }}'
                       allowed_mentions:
                         parse: []
                       embeds:


### PR DESCRIPTION
## 症状

Alertmanager から Discord への webhook 通知が 400 で拒否され続けていました。

```
discord-infra-noncritical/webhook[0]: unexpected status code 400:
{"content": ["Could not interpret \"['FIRING:1']\" as string."]}

discord-infra-critical/webhook[0]: unexpected status code 400:
{"content": ["Could not interpret \"['RESOLVED']\" as string."]}
```

**webhook 送信 2625 件のうち 2613 件（99.5%）が失われていました。**

| 時点 | `alertmanager_notifications_failed_total{reason="clientError"}` |
|---|---|
| 〜2026-08-22 | 0 |
| 2026-08-22 | 2（初発） |
| 2026-08-24 | 736 |
| 2026-09-07 | **2497** |

ルーティング・mute time interval・`notify` ラベルの付与はいずれも正常で、Alertmanager は送信を試みたうえで Discord 側に拒否されていました。

## 原因

payload 内の各文字列は、**テンプレート描画後の結果が YAML として再解釈されます**。パースに成功して非文字列型になると、その型のまま JSON 化されて送られます。

`content` は `[FIRING:1] Alert (ns)` に描画されますが、Go の `yaml.v3` はこれをフローシーケンスとして解釈し `["FIRING:1"]` だけを残します（以降は捨てられます）。Discord は `content` に文字列を要求するため 400 になり、通知が丸ごと失われていました。

同じパーサ（`yq`）での確認結果:

| 描画結果 | パース結果 |
|---|---|
| `[FIRING:1] ThanosCompactHalted (monitoring)` | **`["FIRING:1"]`（配列）** |
| `[RESOLVED] KubePersistentVolumeFillingUp (garage)` | **`["RESOLVED"]`（配列）** |
| `<@&532704116799963168> [FIRING:1] ...` | 文字列 |
| `⚠️ [FIRING:1] ...` | 文字列 |

critical の firing だけは `content` が `<@&...>` のロールメンションで始まるため偶然パースに成功して文字列になっており、**これが唯一成功していた 12 件**にあたります。

embed の `title` は絵文字始まり、`description` は `**Alert**` 始まりで YAML のエイリアス参照として解釈に失敗し生文字列にフォールバックするため、いずれも影響を受けていません。

混入したのは `0f840b3dc`（2026-08-13, #5811）で、critical の firing 以外の `content` が `[` 始まりになりました。実際の失敗は最初の該当アラートが飛んだ 2026-08-22 から観測されています。

## 修正

`content` を embed の `title` と同じ絵文字プレフィクス（🔥 / ⚠️ / ✅）で始めます。これにより描画結果が必ず YAML のプレーンスカラーとして解釈されます。

```diff
- content: '{{ if eq .Status "firing" }}[FIRING:{{ .Alerts.Firing | len }}]{{ else }}[RESOLVED]{{ end }} ...'
+ content: '{{ if eq .Status "firing" }}⚠️ [FIRING:{{ .Alerts.Firing | len }}]{{ else }}✅ [RESOLVED]{{ end }} ...'
```

同じバグの再導入を防ぐため、この制約を receivers の直前にコメントとして残しました。

## 検証

- [x] YAML パース（Helm values 内のネストを含む）
- [x] 修正後に描画される 4 パターンすべてを `yq`（Alertmanager と同じ Go `yaml.v3`）で確認 → **すべて文字列**
  - `<@&...> 🔥 [FIRING:1] ThanosCompactHalted (monitoring)`
  - `✅ [RESOLVED] ThanosCompactHalted (monitoring)`
  - `⚠️ [FIRING:1] GarageBlockResyncErrors (garage)`
  - `✅ [RESOLVED] KubePersistentVolumeFillingUp (garage)`
- [ ] マージ後: `alertmanager_notifications_failed_total{reason="clientError"}` の増加が止まること
- [ ] マージ後: Discord に実際に投稿されること

**検証は容易です。** `ThanosCompactHalted` が現在 firing 中で `group_interval: 5m` で再送されるため、マージ後 5 分程度で結果が出ます。

## 補足

このバグにより、`notify: discord` の opt-in リストに入っている critical アラート（`KubePersistentVolumeFillingUp` など）の **resolved 通知も約 1 か月間届いていませんでした**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKpnMJuaHaCGeKFBALCi3q
