### PR TITLE
fix(hubble-observer): AUDIT のみを記録して Loki の取り込み量を約95%削減する

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/hubble-observer.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/hubble-observer.yaml
@@ -12,7 +12,25 @@ spec:
     helm:
       releaseName: hubble-observer
       values: |
-        verdictFilter: "none"
+        # AUDIT のみを記録する。none (全 verdict) だと FORWARDED が
+        # フロー件数の 94.8% を占め、Loki の取り込み量 約130 GiB/日 の
+        # ほぼ全量がこれになる (2026-09-07 実測: 5分間 234,552 フロー中
+        # FORWARDED 222,305 / AUDIT 12,056 / TRACED 191)。
+        #
+        # policyAuditMode: true (cilium.yaml) の下では、ポリシー上は拒否
+        # されるはずの通信が DROPPED ではなく AUDIT として記録される。
+        # つまり AUDIT が「audit モードを切ったら遮断される通信」＝
+        # まだ書けていない許可ルールの一覧であり、NetworkPolicy 導入
+        # 作業に必要な信号はこれだけで足りる。FORWARDED (許可済みの通信)
+        # は作業上の価値がないため落とす。
+        #
+        # 将来 policyAuditMode を false にすると、遮断された通信は AUDIT
+        # ではなく DROPPED として出るようになる。そのときはこの値を
+        # DROPPED に変更すること (変更しないと何も記録されなくなる)。
+        # なお両方を同時に指定することはできない。チャートは値を
+        # `--verdict <値>` にそのまま埋め込むが、hubble CLI はカンマ区切りを
+        # 受け付けない (実測: invalid argument "DROPPED,AUDIT")。
+        verdictFilter: "AUDIT"
         hubbleRelay:
           serviceName: hubble-relay
           port: "80"


### PR DESCRIPTION
## 背景

Loki の取り込み量が **約 130 GiB/日** あり、その **94.8% が hubble-observer の FORWARDED フロー**でした。

2026-09-07 の実測（5 分間、234,552 フロー）:

| verdict | 件数 | 割合 |
|---|---|---|
| **FORWARDED** | 222,305 | **94.8%** |
| AUDIT | 12,056 | 5.1% |
| TRACED | 191 | 0.1% |

`verdictFilter` は 2026-04-04 の導入時から `"none"`（全 verdict を記録）のままで、この状態が約 5 か月続いていました。結果として garage の `loki` バケットは **1.1 TB / 126 万オブジェクト**まで肥大化しています。

（なお 8/20 時点の実測でもフロー数・FORWARDED 比率は今日とほぼ同一でした。最近増えたのではなく、当初からこの量です。）

## なぜ AUDIT だけで足りるか

`cilium.yaml` で **`policyAuditMode: true`** が有効なため、ポリシー上は拒否されるはずの通信は `DROPPED` ではなく **`AUDIT`** として記録され、通信自体は通ります。

つまり **AUDIT は「audit モードを切ったら遮断される通信」＝まだ書けていない許可ルールの一覧そのもの**で、NetworkPolicy 導入作業に必要な信号はこれで足ります。FORWARDED（既に許可されている通信）には作業上の価値がありません。

実際、AUDIT の上位はこうなっています。

| src | → dst | port | 件数/10分 |
|---|---|---|---|
| monitoring | → monitoring | 3100 (Loki) | 11,102 |
| monitoring | → kube-system | (DNS) | 3,275 |
| seichi-minecraft | → kube-system | (DNS) | 1,217 |
| seichi-minecraft | → seichi-minecraft | 3306 (MariaDB) | 1,132 |
| monitoring | → garage | 3900 (S3) | 484 |

`default-deny` を入れたものの許可ルールが未整備な通信が並んでおり、これは残すべき信号です。

## ⚠️ 将来の注意点

`policyAuditMode` を `false` にすると、遮断された通信は `AUDIT` ではなく **`DROPPED`** として出ます。**そのタイミングでこの値を `DROPPED` に変更しないと、何も記録されなくなります。** コメントにも明記しました。

両方を同時に指定することはできません。チャートは値を `--verdict <値>` にそのまま埋め込みますが、hubble CLI はカンマ区切りを受け付けません（実測: `invalid argument "DROPPED,AUDIT" for "--verdict" flag`）。フラグを 2 回書く文字列補間のハックは可能ですが、チャートが値を `| quote` するようになると壊れるため採用していません。

## 検証

- [x] チャート 2.5.0 をローカルに展開し `helm template` で args を確認
  ```
  hubble observe flows --verdict AUDIT --not --drop-reason-desc 'UNSUPPORTED_L3_PROTOCOL'
    --follow --ip-translation --server ... -o json
  ```
  （`--verdict AUDIT` が入り、既存の他の引数は維持されている）
- [x] 実機で `hubble observe --verdict AUDIT` が動作することを確認
- [ ] マージ後: `loki_distributor_bytes_received_total` が 約130 → 約7 GiB/日 に落ちること
- [ ] マージ後: Hubble NetworkPolicy Planning ダッシュボードの audit クエリが従来どおり結果を返すこと

## 関連

この後、Loki 側に retention を入れる PR を別途出します（本 PR で流量を落としてから適用する順序）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKpnMJuaHaCGeKFBALCi3q
