### PR TITLE
feat(loki): retention を設定してチャンクの無期限保持をやめる

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/loki.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/cluster-wide-apps/app-of-other-apps/loki.yaml
@@ -57,6 +57,17 @@ spec:
             # Loki ruler の rule group 上限 (#5603)。ルール肥大とラベル爆発の安全弁
             ruler_max_rules_per_rule_group: 20
             ruler_max_rule_groups_per_tenant: 20
+            # 全ストリーム共通の保持期間。未設定 (Loki のデフォルト) だと
+            # チャンクが永久に残り、garage の loki バケットが際限なく増える
+            # (2026-09-07 時点で 1.1 TB / 126 万オブジェクト)。
+            retention_period: 720h # 30d
+            # hubble-observer のフローログだけは短くする。#6006 で AUDIT のみに
+            # 絞った後も Loki 全体の約半分を占める見込みで、かつ AUDIT は
+            # 「今すぐ許可ルールを書くための TODO」であって長期保存の価値が薄いため。
+            retention_stream:
+              - selector: '{service_name="hubble-observer"}'
+                priority: 1
+                period: 168h # 7d
           # NOTE: chart のテンプレートが読むのは loki.rulerConfig であり、
           # loki.ruler キーはどこからも参照されない (以前の ruler.enable_api は no-op だった)
           rulerConfig:
@@ -87,6 +98,14 @@ spec:
               compactor_ring:
                 kvstore:
                   store: memberlist
+              # retention は compactor が実行する。SingleBinary では compactor は
+              # in-process で動くため追加コンポーネントは不要
+              # (values の compactor.replicas: 0 は microservices 用の Deployment を
+              # 潰しているだけで、in-process の compactor とは別物)。
+              retention_enabled: true
+              # Loki 3.x では retention_enabled: true のとき delete_request_store が
+              # 必須で、未設定だと Loki が起動に失敗する
+              delete_request_store: s3
             common:
               ring:
                 kvstore:


### PR DESCRIPTION
## 背景

**Loki に retention が一度も設定されていませんでした**（`git log -S "retention_period"` で該当コミットなし）。チャンクが永久に残り、garage の `loki` バケットは **1.1 TB / 126 万オブジェクト**まで肥大化しています。

同じ構造の問題が thanos 側にもあり、そちらは garage→PBS バックアップの dump 用 PVC を溢れさせて `backup--garage-to-pbs` を ENOSPC で失敗させました（2026-09-06）。`loki` バケットは #5295 でバックアップ対象から除外済みのため同じ形では影響しませんが、**garage の容量を無制限に消費し続ける点は同じ**です。

## 設定内容

```yaml
limits_config:
  retention_period: 720h          # 30d、全ストリーム共通
  retention_stream:
    - selector: '{service_name="hubble-observer"}'
      priority: 1
      period: 168h                # 7d
structuredConfig:
  compactor:
    retention_enabled: true
    delete_request_store: s3
```

- **`delete_request_store` は Loki 3.x で `retention_enabled: true` のとき必須**で、未設定だと Loki が起動に失敗します。ここが一番の落とし穴です
- SingleBinary では compactor は in-process で動くため追加コンポーネントは不要です（values の `compactor.replicas: 0` は microservices 用の Deployment を潰しているだけで、in-process の compactor とは別物）
- hubble-observer だけ 7d にしているのは、#6006 で AUDIT のみに絞った後も Loki 全体の約半分を占める見込みで、かつ AUDIT は「今すぐ許可ルールを書くための TODO」であって長期保存の価値が薄いためです

## ⚠️ マージ順序

**#6006（hubble を AUDIT のみに絞る）を先にマージしてください。**

本 PR を適用すると、1.1 TB / 126 万オブジェクトのうち保持期間外のものが一斉に削除対象になり、**garage へ大量の DELETE が飛びます**。2026-09-07 に garage の quorum 障害を経験したばかりなので、先に #6006 で流量を 1/20 に落としてから適用するのが安全です。

## 検証

- [x] チャート 18.12.1 を `helm template` でレンダリングし、ConfigMap の `config.yaml` に設定が正しく出ることを確認

  ```yaml
  compactor:
    compactor_ring: {kvstore: {store: memberlist}}
    delete_request_store: s3
    retention_enabled: true
  limits_config:
    retention_period: 720h
    retention_stream:
      - period: 168h
        priority: 1
        selector: '{service_name="hubble-observer"}'
  ```

- [ ] マージ後: Loki pod が正常起動すること（`delete_request_store` 未設定なら起動失敗するので即分かる）
- [ ] マージ後: compactor ログに retention の適用が出ること
- [ ] 適用後: garage の `loki` バケットが縮小に転じること
- [ ] 適用中: garage の 503 / `block_resync_errored_blocks` が増えないこと（削除負荷の監視）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKpnMJuaHaCGeKFBALCi3q
