### PR TITLE
fix(kubechecks): disable repository cache for tag revisions

### DIFF
--- a/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/apps.yaml
+++ b/seichi-onp-k8s/manifests/seichi-kubernetes/apps/root/apps.yaml
@@ -268,6 +268,10 @@ spec:
             KUBECHECKS_TIDY_OUTDATED_COMMENTS_MODE: "delete"
             KUBECHECKS_LOG_LEVEL: "info"
             KUBECHECKS_MONITOR_ALL_APPLICATIONS: "true"
+            # v3.4.0 の永続 Git キャッシュはタグの clone 後にも refs/heads/<tag> を
+            # fetch するため、Garage などタグを targetRevision に使うアプリで失敗する。
+            # タグ対応済みの通常 clone を使う。upstream の Update 修正後に再有効化する。
+            KUBECHECKS_REPO_CACHE_ENABLED: "false"
 
         secrets:
           create: false


### PR DESCRIPTION
kubechecks v3.4.0 fails to validate Applications whose Git `targetRevision` is a tag. On #6002, Garage's `v2.4.1` clones successfully as a tag, but `PersistentRepoManager.Clone` immediately calls `UpdateBaseBranch` → `Repo.Update`, which fetches only `refs/heads/v2.4.1`. This produces an ERROR before Garage manifests can be generated.

Set `KUBECHECKS_REPO_CACHE_ENABLED=false` to use the existing ephemeral clone implementation, which supports tags. This is a deployment workaround for the upstream cache bug; the comment records when to re-enable caching. All checks remain enabled, and the separate PR archive cache remains enabled. External Git sources will be cloned per check instead of reused across checks, increasing download work.

Validation:
- Against the unmodified v3.4.0 Git implementation, a local regression test reproduced the exact error with caching enabled, then verified the correct commit for a tag, a branch that advanced beyond the tag, and a repeated tag request with caching disabled.
- `helm lint --strict` and `helm template` passed with kubechecks chart 3.0.0 and these values; the rendered ConfigMap contains the string `false`.
- An isolated Kubernetes Job ran `kubechecks process --repo-cache-enabled=false GiganticMinecraft/seichi_infra#6002` with the current image and credentials. It completed in 25 seconds; Garage manifest generation, diff, kubeconform and pre-upgrade checks completed. GitHub received a success status (Warning because of the existing ImageUpdater schema warnings) for head `81b1ea605f736217a9e088b256f255cea208e696`.

The long-running controller has not been changed. Applying this PR is necessary to prevent subsequent webhook runs from hitting the same cache bug. Garage has not been upgraded or merged.

Upstream implementation: [manager.go](https://github.com/zapier/kubechecks/blob/v3.4.0/pkg/git/manager.go#L109), [repo.go](https://github.com/zapier/kubechecks/blob/v3.4.0/pkg/git/repo.go#L351).
