### PR TITLE
Portal の Email Address Obfuscation を無効化する

### DIFF
--- a/terraform/cloudflare_configuration_rules.tf
+++ b/terraform/cloudflare_configuration_rules.tf
@@ -1,0 +1,20 @@
+resource "cloudflare_ruleset" "configuration_rules" {
+  zone_id     = local.cloudflare_zone_id
+  name        = "default"
+  description = "Cloudflare configuration rules"
+  kind        = "zone"
+  phase       = "http_config_settings"
+
+  rules = [
+    {
+      ref         = "disable_email_obfuscation_for_seichi_portal"
+      action      = "set_config"
+      expression  = "(http.host eq \"portal.${local.root_domain}\")"
+      description = "seichi-portal の React hydration 前にメールアドレスが書き換わるのを防ぐ"
+      action_parameters = {
+        email_obfuscation = false
+      }
+      enabled = true
+    },
+  ]
+}


### PR DESCRIPTION
## 概要
- Cloudflare が `portal.seichi.click` のメールアドレスを React の hydration 前にリンクへ書き換えないようにする
- `http_config_settings` の Configuration Rule を追加し、対象ホストだけ `email_obfuscation = false` にする
- ほかのサブドメインに対する Email Address Obfuscation の設定は変更しない

## 確認事項
- `terraform fmt -check -diff` が成功し、Terraform の書式に問題がないことを確認した
- Cloudflare Provider v5.24.0 で `terraform validate -no-color` が成功した
- Terraform Cloud の plan が成功し、`cloudflare_ruleset.configuration_rules` 1件が追加されることを確認した
- plan には既存の GitHub Pages 用 DNS レコード名の大文字・小文字差による更新も1件含まれるが、今回の差分とは無関係な既存ドリフト

🤖 Generated with Codex